### PR TITLE
fix crash when disconnection timeout is reached

### DIFF
--- a/src/jabber.c
+++ b/src/jabber.c
@@ -243,6 +243,14 @@ jabber_get_jid(void)
     return xmpp_conn_get_jid(jabber_conn.conn);
 }
 
+void
+jabber_free_resources(void)
+{
+	xmpp_conn_release(jabber_conn.conn);
+	xmpp_ctx_free(jabber_conn.ctx);
+	xmpp_shutdown();
+}
+
 static int
 _message_handler(xmpp_conn_t * const conn, 
     xmpp_stanza_t * const stanza, void * const userdata)
@@ -306,13 +314,6 @@ _connection_handler(xmpp_conn_t * const conn,
     
         // received close stream response from server after disconnect
         if (jabber_conn.conn_status == JABBER_DISCONNECTING) {
-            // free memory for connection object and context
-            xmpp_conn_release(jabber_conn.conn);
-            xmpp_ctx_free(jabber_conn.ctx);
-
-            // shutdown libstrophe
-            xmpp_shutdown();
-
             jabber_conn.conn_status = JABBER_DISCONNECTED;
             jabber_conn.presence = PRESENCE_OFFLINE;
             

--- a/src/jabber.h
+++ b/src/jabber.h
@@ -50,5 +50,6 @@ void jabber_send(const char * const msg, const char * const recipient);
 void jabber_update_presence(jabber_presence_t status, const char * const msg);
 const char * jabber_get_jid(void);
 jabber_conn_status_t jabber_get_connection_status(void);
+void jabber_free_resources(void);
 
 #endif

--- a/src/profanity.c
+++ b/src/profanity.c
@@ -282,6 +282,7 @@ _shutdown_init(void)
             jabber_process_events();
         }
     }
+    jabber_free_resources();
 
     _shutdown();
 }


### PR DESCRIPTION
This patch fixes one point of issue #42

Steps to reproduce crash:
1. run profanity
2. connect with a jid
3. enter /quit and cause disconnection timeout (for example, set breakpoint to _shutdown_init in gdb)
