### PR TITLE
libraries order does matter when --as-needed is passed to linker

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,14 +16,22 @@ AC_ARG_WITH([libxml2],
     [AS_HELP_STRING([--with-libxml2], [link with libxml2 instead of expat])])
 
 # Checks for libraries.
-AC_CHECK_LIB([ncurses], [main], [], 
-    [AC_MSG_ERROR([ncurses is required for profanity])])
+if test "x$with_libxml2" = xyes; then
+    AC_CHECK_LIB([xml2], [main], [], 
+        [AC_MSG_ERROR([libxml2 is required for profanity])])
+else
+    AC_CHECK_LIB([expat], [main], [], 
+        [AC_MSG_ERROR([expat is required for profanity])])
+fi
+
 AC_CHECK_LIB([resolv], [main], [], 
     [AC_MSG_ERROR([libresolv is required for profanity])])
 AC_CHECK_LIB([ssl], [main], [], 
     [AC_MSG_ERROR([openssl is required for profanity])])
 AC_CHECK_LIB([strophe], [main], [], 
     [AC_MSG_ERROR([libstrophe is required for profanity])])
+AC_CHECK_LIB([ncurses], [main], [], 
+    [AC_MSG_ERROR([ncurses is required for profanity])])
 AC_CHECK_LIB([glib-2.0], [main], [], 
     [AC_MSG_ERROR([glib-2.0 is required for profanity])])
 AC_CHECK_LIB([curl], [main], [], 
@@ -32,14 +40,6 @@ AC_CHECK_LIB([notify], [main], [],
     [AC_MSG_NOTICE([libnotify not found, desktop notifications no supported])])
 AC_CHECK_LIB([headunit], [main], [], 
     [AC_MSG_NOTICE([headunit not found, will not be able to run tests])])
-
-if test "x$with_libxml2" = xyes; then
-    AC_CHECK_LIB([xml2], [main], [], 
-        [AC_MSG_ERROR([libxml2 is required for profanity])])
-else
-    AC_CHECK_LIB([expat], [main], [], 
-        [AC_MSG_ERROR([expat is required for profanity])])
-fi
 
 # Checks for header files.
 AC_CHECK_HEADERS([stdlib.h string.h])


### PR DESCRIPTION
This fixes linking error when --as-needed option is used. Without this patch building on Gentoo fails.
