### PR TITLE
prevent double free of jabber_conn.status

### DIFF
--- a/src/jabber.c
+++ b/src/jabber.c
@@ -313,8 +313,10 @@ jabber_update_presence(jabber_presence_t status, const char * const msg)
             break;
     }
 
-    if (jabber_conn.status != NULL)
+    if (jabber_conn.status != NULL) {
         free(jabber_conn.status);
+        jabber_conn.status = NULL;
+    }
     if (msg != NULL)
         jabber_conn.status = strdup(msg);
 


### PR DESCRIPTION
sequence of the following commands causes crash:
/dnd some string
/dnd
/dnd
where '/dnd' can be any status command
