### PR TITLE
Use passwords from the accounts file

### DIFF
--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -133,6 +133,7 @@ accounts_add(const char *account_name, const char *altdomain)
     if (!g_key_file_has_group(accounts, account_name)) {
         g_key_file_set_boolean(accounts, account_name, "enabled", TRUE);
         g_key_file_set_string(accounts, account_name, "jid", barejid);
+        g_key_file_set_string(accounts, account_name, "password", "");
         g_key_file_set_string(accounts, account_name, "resource", resource);
         if (altdomain != NULL) {
             g_key_file_set_string(accounts, account_name, "server", altdomain);
@@ -188,6 +189,16 @@ accounts_get_account(const char * const name)
         } else {
             account->jid = strdup(name);
             g_key_file_set_string(accounts, name, "jid", name);
+            _save_accounts();
+        }
+
+        gchar *password = g_key_file_get_string(accounts, name, "password", NULL);
+        if (password != NULL) {
+            account->password = strdup(password);
+            g_free(password);
+        } else {
+            account->password = strdup("");
+            g_key_file_set_string(accounts, name, "password", account->password);
             _save_accounts();
         }
 
@@ -288,6 +299,7 @@ accounts_free_account(ProfAccount *account)
     if (account != NULL) {
         free(account->name);
         free(account->jid);
+        free(account->password);
         free(account->resource);
         free(account->server);
         free(account->last_presence);

--- a/src/config/accounts.h
+++ b/src/config/accounts.h
@@ -28,6 +28,7 @@
 typedef struct prof_account_t {
     gchar *name;
     gchar *jid;
+    gchar *password;
     gchar *resource;
     gchar *server;
     gchar *last_presence;

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -793,6 +793,7 @@ cons_show_account(ProfAccount *account)
         cons_show   ("enabled        : FALSE");
     }
     cons_show       ("jid            : %s", account->jid);
+    cons_show       ("password       : [redacted]");
     if (account->resource != NULL) {
         cons_show   ("resource       : %s", account->resource);
     }

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -109,21 +109,20 @@ jabber_init(const int disable_tls)
 }
 
 jabber_conn_status_t
-jabber_connect_with_account(const ProfAccount * const account,
-    const char * const passwd)
+jabber_connect_with_account(const ProfAccount * const account)
 {
     assert(account != NULL);
-    assert(passwd != NULL);
 
     log_info("Connecting using account: %s", account->name);
 
     // save account name and password for reconnect
     saved_account.name = strdup(account->name);
-    saved_account.passwd = strdup(passwd);
+    saved_account.passwd = strdup(account->password);
 
     // connect with fulljid
     Jid *jidp = jid_create_from_bare_and_resource(account->jid, account->resource);
-    jabber_conn_status_t result = _jabber_connect(jidp->fulljid, passwd, account->server);
+    jabber_conn_status_t result =
+      _jabber_connect(jidp->fulljid, account->password, account->server);
     jid_destroy(jidp);
 
     return result;

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -78,8 +78,7 @@ typedef struct disco_identity_t {
 void jabber_init(const int disable_tls);
 jabber_conn_status_t jabber_connect_with_details(const char * const jid,
     const char * const passwd, const char * const altdomain);
-jabber_conn_status_t jabber_connect_with_account(const ProfAccount * const account,
-    const char * const passwd);
+jabber_conn_status_t jabber_connect_with_account(const ProfAccount * const account);
 void jabber_disconnect(void);
 void jabber_shutdown(void);
 void jabber_process_events(void);


### PR DESCRIPTION
This commit makes it so that if the password in an account in the
accounts file is present, then use it. Otherwise ask for the password to
the user.
