### PR TITLE
Connect to an account on start-up

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 static gboolean disable_tls = FALSE;
 static gboolean version = FALSE;
 static char *log = "INFO";
+static char *account_name = "";
 
 int
 main(int argc, char **argv)
@@ -40,6 +41,7 @@ main(int argc, char **argv)
     {
         { "version", 'v', 0, G_OPTION_ARG_NONE, &version, "Show version information", NULL },
         { "disable-tls", 'd', 0, G_OPTION_ARG_NONE, &disable_tls, "Disable TLS", NULL },
+        { "account", 'a', 0, G_OPTION_ARG_STRING, &account_name, "Auto connect to an account on start-up" },
         { "log",'l', 0, G_OPTION_ARG_STRING, &log, "Set logging levels, DEBUG, INFO (default), WARN, ERROR", "LEVEL" },
         { NULL }
     };
@@ -77,7 +79,7 @@ main(int argc, char **argv)
         return 0;
     }
 
-    prof_run(disable_tls, log);
+    prof_run(disable_tls, log, account_name);
 
     return 0;
 }

--- a/src/profanity.c
+++ b/src/profanity.c
@@ -58,7 +58,7 @@ static void _create_directories(void);
 static gboolean idle = FALSE;
 
 void
-prof_run(const int disable_tls, char *log_level)
+prof_run(const int disable_tls, char *log_level, char *account_name)
 {
     _init(disable_tls, log_level);
     log_info("Starting main event loop");
@@ -69,6 +69,12 @@ prof_run(const int disable_tls, char *log_level)
 
     char inp[INP_WIN_MAX];
     int size = 0;
+
+    if (strlen(account_name) != 0) {
+      char *cmd = "/connect";
+      snprintf(inp, sizeof(inp), "%s %s", cmd, account_name);
+      cmd_execute(cmd, inp);
+    }
 
     while(cmd_result == TRUE) {
         wint_t ch = ERR;

--- a/src/profanity.h
+++ b/src/profanity.h
@@ -26,7 +26,7 @@
 #include "resource.h"
 #include "xmpp/xmpp.h"
 
-void prof_run(const int disable_tls, char *log_level);
+void prof_run(const int disable_tls, char *log_level, char *account_name);
 
 void prof_handle_login_success(const char *jid, const char *altdomain);
 void prof_handle_login_account_success(char *account_name);


### PR DESCRIPTION
This commit enables connecting to an account on startup which enables
the use case of having different pre-configured scripts which start
different profanity processes for different accounts. This only makes
sense in the light of not supporting many accounts connected per
process.
