### PR TITLE
Check for res_query, then for __res_query in libresolv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,9 @@ AM_CPPFLAGS="$AM_CPPFLAGS $PARSER_CFLAGS"
 LIBS="$LIBS $PARSER_LIBS"
 
 ### Check for libstrophe dependencies
-AC_CHECK_LIB([resolv], [__res_query], [],
-    [AC_MSG_ERROR([libresolv is required for profanity])])
+AC_CHECK_LIB([resolv], [res_query], [],
+    [AC_CHECK_LIB([resolv], [__res_query], [],
+        [AC_MSG_ERROR([libresolv is required for profanity])])])
 PKG_CHECK_MODULES([openssl], [openssl], [],
     [AC_MSG_ERROR([openssl is required for profanity])])
 AM_CPPFLAGS="$AM_CPPFLAGS $openssl_CFLAGS"


### PR DESCRIPTION
Don't know why there's a check for __res_query, maybe because your version of libresolv doesn't have res_query? Mavericks doesn't have it, but does compile with res_query.

I found a similar commit here:
https://github.com/pasis/libcouplet/pull/2

I notice this check was introduced by commit dcccfacb68caa97131c60f67cc42a30ef8195c31

This commit fixes #254 
