### PR TITLE
replace libotr2-dev with libotr5-dev

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -24,7 +24,7 @@ debian_prepare()
     echo
     echo Profanity installer... installing dependencies
     echo
-    sudo apt-get -y install git automake autoconf libssl-dev libexpat1-dev libncursesw5-dev libglib2.0-dev libnotify-dev libcurl3-dev libxss-dev libotr2-dev libgnutls-dev
+    sudo apt-get -y install git automake autoconf libssl-dev libexpat1-dev libncursesw5-dev libglib2.0-dev libnotify-dev libcurl3-dev libxss-dev libotr5-dev libgnutls-dev
 
 }
 


### PR DESCRIPTION
libotr5-dev also exists in sid, wheezy backports and jessie (testing). https://packages.debian.org/search?keywords=libotr5-dev However libotr2-dev no longer exists in Ubuntu.

If you want me to write a separate ubuntu_prepare for Ubuntu users, reject this pr and I'll do it :)
