### PR TITLE
Implemented the buffer for windows resizing

### DIFF
--- a/src/ui/buffer.c
+++ b/src/ui/buffer.c
@@ -23,6 +23,15 @@ buffer_create() {
   return new_buff;
 }
 
+int buffer_size(ProfBuff* buffer) {
+  if(buffer->wrap == 1) {
+    return BUFF_SIZE;
+  }
+  else {
+    return buffer->current;
+  }
+}
+
 void
 buffer_free(ProfBuff* buffer) {
   int i = 0;
@@ -33,29 +42,32 @@ buffer_free(ProfBuff* buffer) {
   for(i = 0; i < imax; i++) {
     free(buffer->entry[i].message);
     free(buffer->entry[i].from);
+    free(buffer->entry[i].date_fmt);
   }
   free(buffer);
 }
 
 void
-buffer_push(ProfBuff* buffer, const char show_char, GTimeVal *tstamp, int flags, int attrs, const char * const from, const char * const message) {
+buffer_push(ProfBuff* buffer, const char show_char, const char * const date_fmt, int flags, int attrs, const char * const from, const char * const message) {
   int *current = &(buffer->current);
-  ProfBuffEntry e = buffer->entry[*current];
+  ProfBuffEntry* e = &(buffer->entry[buffer->current]);
 
   if(buffer->wrap == 1) {
-    free(e.message);
-    free(e.from);
+    free(e->message);
+    free(e->from);
   }
-  e.show_char = show_char;
-  e.tstamp = *tstamp;
-  e.flags = flags;
-  e.attrs = attrs;
+  e->show_char = show_char;
+  e->flags = flags;
+  e->attrs = attrs;
 
-  e.from = malloc(strlen(from)+1);
-  strcpy(e.from, from);
+  e->date_fmt = malloc(strlen(date_fmt)+1);
+  strcpy(e->date_fmt, date_fmt);
 
-  e.message = malloc(strlen(message)+1);
-  strcpy(e.message, message);
+  e->from = malloc(strlen(from)+1);
+  strcpy(e->from, from);
+
+  e->message = malloc(strlen(message)+1);
+  strcpy(e->message, message);
 
   *current += 1;
   if(*current >= BUFF_SIZE) {
@@ -64,11 +76,22 @@ buffer_push(ProfBuff* buffer, const char show_char, GTimeVal *tstamp, int flags,
   }
 }
 
+ProfBuffEntry
+buffer_yield_entry(ProfBuff* buffer, int entry) {
+  return (buffer->entry)[entry];
+  if(buffer->wrap == 1) {
+    return buffer->entry[(buffer->current + entry) % BUFF_SIZE];
+  }
+  else {
+    return buffer->entry[entry % (buffer->current)];
+  }
+}
+
 int
 buffer_yield(ProfBuff* buffer, int line, ProfBuffEntry** list) {
-  //Returns the (line+1)-th last line
+  //Returns the size of the (line+1)-th last line, and list contains the line
   //e.g. if line == 0, returns the last line
-  //To correct for splitted lines...
+  //bug if the wrap happens in the middle of a line
   int current = buffer->current;
   int imax = current;
   if(buffer->wrap == 1) {

--- a/src/ui/buffer.h
+++ b/src/ui/buffer.h
@@ -8,7 +8,7 @@
 
 typedef struct prof_buff_entry_t {
   char show_char;
-  GTimeVal tstamp;
+  char *date_fmt;
   int flags;
   int attrs;
   char *from;
@@ -24,6 +24,8 @@ typedef struct prof_buff_t {
 
 ProfBuff* buffer_create();
 void buffer_free(ProfBuff* buffer);
-void buffer_push(ProfBuff* buffer, const char show_char, GTimeVal *tstamp, int flags, int attrs, const char * const from, const char * const message);
+void buffer_push(ProfBuff* buffer, const char show_char, const char * const date_fmt, int flags, int attrs, const char * const from, const char * const message);
+int buffer_size(ProfBuff* buffer);
 int buffer_yield(ProfBuff* buffer, int line, ProfBuffEntry** list);
+ProfBuffEntry buffer_yield_entry(ProfBuff* buffer, int entry);
 #endif

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -80,5 +80,7 @@ void win_print_incoming_message(ProfWin *window, GTimeVal *tv_stamp,
 void win_show_info(ProfWin *window, PContact contact);
 void win_save_vprint(ProfWin *window, const char show_char, GTimeVal *tstamp, int flags, int attrs, const char * const from, const char * const message, ...);
 void win_save_print(ProfWin *window, const char show_char, GTimeVal *tstamp, int flags, int attrs, const char * const from, const char * const message);
+void win_print(ProfWin *window, const char show_char, const char * const date_fmt, int flags, int attrs, const char * const from, const char * const message);
+void win_redraw(ProfWin *window);
 
 #endif

--- a/src/ui/windows.c
+++ b/src/ui/windows.c
@@ -272,20 +272,15 @@ wins_resize_all(void)
     int rows, cols;
     getmaxyx(stdscr, rows, cols);
 
-    // only make the pads bigger, to avoid data loss on cropping
-    if (cols > max_cols) {
-        max_cols = cols;
-
-        GList *values = g_hash_table_get_values(windows);
-        GList *curr = values;
-
-        while (curr != NULL) {
-            ProfWin *window = curr->data;
-            wresize(window->win, PAD_SIZE, cols);
-            curr = g_list_next(curr);
-        }
-        g_list_free(values);
+    GList *values = g_hash_table_get_values(windows);
+    GList *curr = values;
+    while (curr != NULL) {
+      ProfWin *window = curr->data;
+      wresize(window->win, PAD_SIZE, cols);
+      win_redraw(window);
+      curr = g_list_next(curr);
     }
+    g_list_free(values);
 
     ProfWin *current_win = wins_get_current();
 


### PR DESCRIPTION
buffer_yield in buffer.c is not used for the moment and is buggy.

This implements the buffer for windows, used when the terminal is resized to redraw the pad. Some of the top lines might be lost (since the PAD is 1000 lines and the buffer has 1000 entries and there can sometimes be more than one entry per PAD line)
