### PR TITLE
"/bookmark add foo" crash - fix

### DIFF
--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -1865,11 +1865,15 @@ cmd_bookmark(gchar **args, struct cmd_help_t help)
         }
 
         if (strcmp(cmd, "add") == 0) {
-            gboolean added = bookmark_add(jid, nick, password, autojoin);
-            if (added) {
-                cons_show("Bookmark added for %s.", jid);
+            if (strchr(jid, '@')==NULL) {
+                cons_show("Can't add bookmark with JID '%s'; should be '%s@domain.tld'", jid, jid);
             } else {
-                cons_show("Bookmark already exists, use /bookmark update to edit.");
+                gboolean added = bookmark_add(jid, nick, password, autojoin);
+                if (added) {
+                    cons_show("Bookmark added for %s.", jid);
+                } else {
+                    cons_show("Bookmark already exists, use /bookmark update to edit.");
+                }
             }
         } else if (strcmp(cmd, "update") == 0) {
             gboolean updated = bookmark_update(jid, nick, password, autojoin);

--- a/src/xmpp/bookmark.c
+++ b/src/xmpp/bookmark.c
@@ -422,7 +422,9 @@ _send_bookmarks(void)
         xmpp_stanza_set_attribute(conference, STANZA_ATTR_JID, bookmark->jid);
 
         Jid *jidp = jid_create(bookmark->jid);
-        xmpp_stanza_set_attribute(conference, STANZA_ATTR_NAME, jidp->localpart);
+        if (jidp->localpart != NULL) {
+            xmpp_stanza_set_attribute(conference, STANZA_ATTR_NAME, jidp->localpart);
+        }
         jid_destroy(jidp);
 
         if (bookmark->autojoin) {


### PR DESCRIPTION
A user providing an invalid JID when creating a new bookmark (like 'foo')
would reproducibly crash/segfault profanity, as it insists on checking
string length behind the @ of the JID. However, it could be NULL
if the user accidentally omitted it.
The patch avoids the crash by NULL-checking and prevents
getting there in the first place by checking the argument to "add".
Backtrace of unpatched profanity with above command:

Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x0000000000000000
0x00007fff85699732 in strlen ()
(gdb) bt
 #0  0x00007fff85699732 in strlen ()
 #1  0x00000001000965d2 in xmpp_strdup ()
 #2  0x0000000100095d6d in xmpp_stanza_set_attribute ()
 #3  0x0000000100011c5c in _send_bookmarks ()
 #4  0x00000001000115a8 in _bookmark_add ()
 #5  0x000000010003320d in cmd_bookmark ()
 #6  0x000000010002a0f2 in cmd_execute ()
 #7  0x0000000100003a1d in process_input ()
 #8  0x00000001000037c7 in prof_run ()
 #9  0x0000000100045032 in main ()
(gdb)
