### PR TITLE
Small spelling fixes in code and comments

### DIFF
--- a/src/muc.c
+++ b/src/muc.c
@@ -514,7 +514,7 @@ muc_get_roster_ac(const char * const room)
 }
 
 /*
- * Set to TRUE when the rooms roster has been fully recieved
+ * Set to TRUE when the rooms roster has been fully received
  */
 void
 muc_set_roster_received(const char * const room)
@@ -527,7 +527,7 @@ muc_set_roster_received(const char * const room)
 }
 
 /*
- * Returns TRUE id the rooms roster has been fully recieved
+ * Returns TRUE id the rooms roster has been fully received
  */
 gboolean
 muc_get_roster_received(const char * const room)

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -272,7 +272,7 @@ _clear_input(void)
 /*
  * Deal with command editing, return 1 if ch was an edit
  * key press: up, down, left, right or backspace
- * return 0 if it wasnt
+ * return 0 if it wasn't
  */
 static int
 _handle_edit(int result, const wint_t ch, char *input, int *size)

--- a/src/ui/notifier.c
+++ b/src/ui/notifier.c
@@ -121,7 +121,7 @@ _notify_subscription(const char * const from)
 {
     GString *message = g_string_new("Subscription request: \n");
     g_string_append(message, from);
-    _notify(message->str, 10000, "Incomming message");
+    _notify(message->str, 10000, "Incoming message");
     g_string_free(message, TRUE);
 }
 

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -478,7 +478,7 @@ _connection_handler(xmpp_conn_t * const conn,
     } else if (status == XMPP_CONN_DISCONNECT) {
         log_debug("Connection handler: XMPP_CONN_DISCONNECT");
 
-        // lost connection for unkown reason
+        // lost connection for unknown reason
         if (jabber_conn.conn_status == JABBER_CONNECTED) {
             log_debug("Connection handler: Lost connection for unknown reason");
             handle_lost_connection();


### PR DESCRIPTION
Just some small spell fixes, so codespell does not bork about it anymore. 

From Debian with love. 
