### PR TITLE
Added command /roster full.

### DIFF
--- a/src/command/command.c
+++ b/src/command/command.c
@@ -171,6 +171,7 @@ static struct cmd_t command_defs[] =
           "The 'clearnick' command removes the current nickname, jid is required.",
           "",
           "Example : /roster (show your roster)",
+          "Example : /roster full (show your roster with groups and subscriptions)",
           "Example : /roster add someone@contacts.org (add the contact)",
           "Example : /roster add someone@contacts.org Buddy (add the contact with nickname 'Buddy')",
           "Example : /roster remove someone@contacts.org (remove the contact)",
@@ -1102,6 +1103,7 @@ cmd_init(void)
 
     roster_ac = autocomplete_new();
     autocomplete_add(roster_ac, "add");
+    autocomplete_add(roster_ac, "full");
     autocomplete_add(roster_ac, "nick");
     autocomplete_add(roster_ac, "clearnick");
     autocomplete_add(roster_ac, "remove");
@@ -1718,6 +1720,10 @@ _roster_autocomplete(char *input, int *size)
         return result;
     }
     result = autocomplete_param_with_ac(input, size, "/roster", roster_ac, TRUE);
+    if (result != NULL) {
+        return result;
+    }
+    result = autocomplete_param_with_ac(input, size, "/roster full", roster_ac, TRUE);
     if (result != NULL) {
         return result;
     }

--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -1292,7 +1292,10 @@ cmd_roster(gchar **args, struct cmd_help_t help)
         GSList *list = roster_get_contacts();
         cons_show_roster(list);
         return TRUE;
-
+    } else if (strcmp(args[0], "full") == 0) {
+        GSList *list = roster_get_contacts();
+        cons_show_roster_full(list);
+        return TRUE;
     // add contact
     } else if (strcmp(args[0], "add") == 0) {
         char *jid = args[1];

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -219,6 +219,7 @@ void (*cons_show_word)(const char * const word);
 void (*cons_show_error)(const char * const cmd, ...);
 void (*cons_show_contacts)(GSList * list);
 void (*cons_show_roster)(GSList * list);
+void (*cons_show_roster_full)(GSList * list);
 void (*cons_show_roster_group)(const char * const group, GSList * list);
 void (*cons_show_wins)(void);
 void (*cons_show_status)(const char * const barejid);


### PR DESCRIPTION
Now /roster full command behaves like /roster before. /roster prints just a plain list
of nicks. This is good for smaller screens and convenient.

If you want you can review it and merge. For me this is more convenient way to see contacts in a roster, and I think this can be also better for some people. 

I am not a C programmer, so you probably can expect some silliness in this code. 
