### PR TITLE
Implement account removal with /account remove

### DIFF
--- a/src/command/command.c
+++ b/src/command/command.c
@@ -889,6 +889,7 @@ static struct cmd_t command_defs[] =
           "enable account               : Enable the account, it will be used for autocomplete.",
           "disable account              : Disable the account.",
           "add account                  : Create a new account.",
+          "remove account               : Remove an account.",
           "rename account newname       : Rename account to newname.",
           "set account property value   : Set 'property' of 'account' to 'value'.",
           "clear account property value : Clear 'property' of 'account'.",
@@ -1211,6 +1212,7 @@ cmd_init(void)
     autocomplete_add(account_ac, "list");
     autocomplete_add(account_ac, "show");
     autocomplete_add(account_ac, "add");
+    autocomplete_add(account_ac, "remove");
     autocomplete_add(account_ac, "enable");
     autocomplete_add(account_ac, "disable");
     autocomplete_add(account_ac, "rename");
@@ -2780,7 +2782,7 @@ _account_autocomplete(char *input, int *size)
 
     int i = 0;
     gchar *account_choice[] = { "/account set", "/account show", "/account enable",
-        "/account disable", "/account rename", "/account clear" };
+        "/account disable", "/account rename", "/account clear", "/account remove"  };
 
     for (i = 0; i < ARRAY_SIZE(account_choice); i++) {
         found = autocomplete_param_with_func(input, size, account_choice[i],

--- a/src/command/commands.c
+++ b/src/command/commands.c
@@ -189,6 +189,19 @@ cmd_account(gchar **args, struct cmd_help_t help)
             cons_show("Account created.");
             cons_show("");
         }
+    } else if (strcmp(command, "remove") == 0) {
+        char *account_name = args[1];
+        if(!account_name) {
+            cons_show("Usage: %s", help.usage);
+        } else {
+            if(accounts_remove(account_name)){
+                cons_show("Account %s removed.", account_name);
+            } else {
+                cons_show("Failed to remove account %s.", account_name);
+                cons_show("Either the account does not exist, or an unknown error occurred.");
+            }
+            cons_show("");
+        }
     } else if (strcmp(command, "enable") == 0) {
         char *account_name = args[1];
         if (account_name == NULL) {

--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -193,6 +193,16 @@ _accounts_add(const char *account_name, const char *altdomain, const int port)
     jid_destroy(jid);
 }
 
+static int
+_accounts_remove(const char *account_name)
+{
+    int r = g_key_file_remove_group(accounts, account_name, NULL);
+    _save_accounts();
+    autocomplete_remove(all_ac, account_name);
+    autocomplete_remove(enabled_ac, account_name);
+    return r;
+}
+
 static gchar**
 _accounts_get_list(void)
 {
@@ -861,6 +871,7 @@ accounts_init_module(void)
     accounts_reset_all_search = _accounts_reset_all_search;
     accounts_reset_enabled_search = _accounts_reset_enabled_search;
     accounts_add = _accounts_add;
+    accounts_remove = _accounts_remove;
     accounts_get_list = _accounts_get_list;
     accounts_get_account = _accounts_get_account;
     accounts_enable = _accounts_enable;

--- a/src/config/accounts.h
+++ b/src/config/accounts.h
@@ -50,6 +50,7 @@ char * (*accounts_find_enabled)(char *prefix);
 void (*accounts_reset_all_search)(void);
 void (*accounts_reset_enabled_search)(void);
 void (*accounts_add)(const char *jid, const char *altdomain, const int port);
+int  (*accounts_remove)(const char *jid);
 gchar** (*accounts_get_list)(void);
 ProfAccount* (*accounts_get_account)(const char * const name);
 gboolean (*accounts_enable)(const char * const name);


### PR DESCRIPTION
A missing feature that I wanted after experimenting with accounts in profanity.

Basically /account remove removes the account group from the keyfile and saves it back to disk as well as the autocomplete list.
