### PR TITLE
block for a longer time to not waste too much CPU

### DIFF
--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -112,7 +112,7 @@ inp_win_resize(void)
 void
 inp_non_block(void)
 {
-    wtimeout(inp_win, 20);
+    wtimeout(inp_win, 500);
 }
 
 void


### PR DESCRIPTION
On my laptop (Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz) profanity was using something between 0.2 to 1.4% of the cpu's.

I checked that and it is using 15.666ms/s cpu time. That's quiet a lot for a console tool.
I changed the timeout for "waiting for input" from 20ms to 500ms and the cpu time went down to 0.666ms/s .. 
I was not connected in this time .. so no cpu was being used for any xmpp processing.

I'm not sure if this impacts anything except that you could have 0.5s delay in changing your status from "online" to "x/a" or getting a xmpp message 0.480s later than before. If this is the only impact I would really love to see this change being merged :)
