### PR TITLE
fix idle calculation if not using LIBXSS

### DIFF
--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -178,7 +178,7 @@ static wint_t
 _ui_get_char(char *input, int *size, int *result)
 {
     wint_t ch = inp_get_char(input, size, result);
-    if (ch != ERR) {
+    if (ch != ERR && *result != ERR) {
         ui_reset_idle_time();
     }
     return ch;


### PR DESCRIPTION
the inp_get_char was never returning ERR even without getting any input
so the idle timeout stuff was wasting CPU and wasn't working if LIBXSS
wasn't used.
