### PR TITLE
Don't stop plugin installation if given path points to a directory

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6612,12 +6612,6 @@ cmd_plugins_install(ProfWin *window, const char *const command, gchar **args)
         path = strdup(path);
     }
 
-    if (access(path, R_OK) != 0) {
-        cons_show("File not found: %s", path);
-        free(path);
-        return TRUE;
-    }
-
     if (is_regular_file(path)) {
         if (!g_str_has_suffix(path, ".py") && !g_str_has_suffix(path, ".so")) {
             cons_show("Plugins must have one of the following extensions: '.py' '.so'");
@@ -6637,9 +6631,7 @@ cmd_plugins_install(ProfWin *window, const char *const command, gchar **args)
         g_string_free(error_message, TRUE);
         free(path);
         return TRUE;
-    }
-
-    if (is_dir(path)) {
+    } else if (is_dir(path)) {
         PluginsInstallResult* result = plugins_install_all(path);
         if (result->installed || result->failed) {
             if (result->installed) {
@@ -6666,9 +6658,9 @@ cmd_plugins_install(ProfWin *window, const char *const command, gchar **args)
         free(path);
         plugins_free_install_result(result);
         return TRUE;
+    } else {
+        cons_show("Argument must be a file or directory.");
     }
-
-    cons_show("Argument must be a file or directory.");
     return TRUE;
 }
 


### PR DESCRIPTION
The command "/plugins install <path_to_folder> should install all
plugins in the given folder. This commit removes the check if the path
points to a file (which is repeated in the section installing a plugin
from file) and makes the existing code installing multiple plugins accessible

Fixes #1035 