### PR TITLE
Fix unit tests on 32-bit architectures

### DIFF
--- a/tests/unittests/config/stub_accounts.c
+++ b/tests/unittests/config/stub_accounts.c
@@ -48,13 +48,13 @@ ProfAccount* accounts_get_account(const char * const name)
 gboolean accounts_enable(const char * const name)
 {
     check_expected(name);
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 gboolean accounts_disable(const char * const name)
 {
     check_expected(name);
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 gboolean accounts_rename(const char * const account_name,
@@ -62,13 +62,13 @@ gboolean accounts_rename(const char * const account_name,
 {
     check_expected(account_name);
     check_expected(new_name);
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 gboolean accounts_account_exists(const char * const account_name)
 {
     check_expected(account_name);
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 void accounts_set_jid(const char * const account_name, const char * const value)
@@ -148,7 +148,7 @@ char * accounts_get_last_status(const char * const account_name)
 resource_presence_t accounts_get_last_presence(const char * const account_name)
 {
     check_expected(account_name);
-    return (resource_presence_t)mock();
+    return mock_type(resource_presence_t);
 }
 
 void accounts_set_priority_online(const char * const account_name, const gint value)

--- a/tests/unittests/config/stub_accounts.c
+++ b/tests/unittests/config/stub_accounts.c
@@ -36,13 +36,13 @@ int  accounts_remove(const char *jid)
 
 gchar** accounts_get_list(void)
 {
-    return (gchar **)mock();
+    return mock_ptr_type(gchar **);
 }
 
 ProfAccount* accounts_get_account(const char * const name)
 {
     check_expected(name);
-    return (ProfAccount*)mock();
+    return mock_ptr_type(ProfAccount*);
 }
 
 gboolean accounts_enable(const char * const name)

--- a/tests/unittests/log/stub_log.c
+++ b/tests/unittests/log/stub_log.c
@@ -29,7 +29,7 @@
 void log_init(log_level_t filter) {}
 log_level_t log_get_filter(void)
 {
-    return (log_level_t)mock();
+    return mock_type(log_level_t);
 }
 void log_reinit(void) {}
 void log_close(void) {}
@@ -46,7 +46,7 @@ char * get_log_file_location(void)
 
 log_level_t log_level_from_string(char *log_level)
 {
-    return (log_level_t)mock();
+    return mock_type(log_level_t);
 }
 
 void log_stderr_init(log_level_t level) {}

--- a/tests/unittests/otr/stub_otr.c
+++ b/tests/unittests/otr/stub_otr.c
@@ -31,12 +31,12 @@ void otr_shutdown(void) {}
 
 char* otr_libotr_version(void)
 {
-    return (char*)mock();
+    return mock_ptr_type(char*);
 }
 
 char* otr_start_query(void)
 {
-    return (char*)mock();
+    return mock_ptr_type(char*);
 }
 
 void otr_poll(void) {}
@@ -86,13 +86,13 @@ void otr_end_session(const char * const recipient) {}
 
 char * otr_get_my_fingerprint(void)
 {
-    return (char *)mock();
+    return mock_ptr_type(char *);
 }
 
 char * otr_get_their_fingerprint(const char * const recipient)
 {
     check_expected(recipient);
-    return (char *)mock();
+    return mock_ptr_type(char *);
 }
 
 char * otr_encrypt_message(const char * const to, const char * const message)

--- a/tests/unittests/otr/stub_otr.c
+++ b/tests/unittests/otr/stub_otr.c
@@ -57,7 +57,7 @@ void otr_keygen(ProfAccount *account)
 
 gboolean otr_key_loaded(void)
 {
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 char* otr_tag_message(const char * const msg)

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -483,7 +483,7 @@ void occupantswin_occupants_all(void) {}
 // window interface
 ProfWin* win_create_console(void)
 {
-    return (ProfWin*)mock();
+    return mock_ptr_type(ProfWin*);
 }
 ProfWin* win_create_xmlconsole(void)
 {
@@ -491,7 +491,7 @@ ProfWin* win_create_xmlconsole(void)
 }
 ProfWin* win_create_chat(const char * const barejid)
 {
-    return (ProfWin*)mock();
+    return mock_ptr_type(ProfWin*);
 }
 ProfWin* win_create_muc(const char * const roomjid)
 {

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -31,7 +31,7 @@ void session_shutdown(void) {}
 void session_process_events(void) {}
 const char * connection_get_fulljid(void)
 {
-    return (char *)mock();
+    return mock_ptr_type(char *);
 }
 
 const char * connection_get_domain(void)
@@ -65,12 +65,12 @@ jabber_conn_status_t connection_get_status(void)
 
 char* connection_get_presence_msg(void)
 {
-    return (char*)mock();
+    return mock_ptr_type(char*);
 }
 
 char* session_get_account_name(void)
 {
-    return (char*)mock();
+    return mock_ptr_type(char*);
 }
 
 GList * session_get_available_resources(void)
@@ -254,7 +254,7 @@ gboolean bookmark_join(const char *jid)
 
 GList * bookmark_get_list(void)
 {
-    return (GList *)mock();
+    return mock_ptr_type(GList *);
 }
 
 char * bookmark_find(const char * const search_str, gboolean previous)

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -17,13 +17,13 @@ jabber_conn_status_t session_connect_with_details(const char * const jid,
     check_expected(passwd);
     check_expected(altdomain);
     check_expected(port);
-    return (jabber_conn_status_t)mock();
+    return mock_type(jabber_conn_status_t);
 }
 
 jabber_conn_status_t session_connect_with_account(const ProfAccount * const account)
 {
     check_expected(account);
-    return (jabber_conn_status_t)mock();
+    return mock_type(jabber_conn_status_t);
 }
 
 void session_disconnect(void) {}
@@ -60,7 +60,7 @@ void connection_free_uuid(char * uuid) {}
 
 jabber_conn_status_t connection_get_status(void)
 {
-    return (jabber_conn_status_t)mock();
+    return mock_type(jabber_conn_status_t);
 }
 
 char* connection_get_presence_msg(void)
@@ -233,7 +233,7 @@ gboolean bookmark_add(const char *jid, const char *nick, const char *password, c
     check_expected(nick);
     check_expected(password);
     check_expected(autojoin_str);
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 gboolean bookmark_update(const char *jid, const char *nick, const char *password, const char *autojoin_str)
@@ -244,7 +244,7 @@ gboolean bookmark_update(const char *jid, const char *nick, const char *password
 gboolean bookmark_remove(const char *jid)
 {
     check_expected(jid);
-    return (gboolean)mock();
+    return mock_type(gboolean);
 }
 
 gboolean bookmark_join(const char *jid)


### PR DESCRIPTION
The first commit should fix the build issues on 32-bit architectures, which debacle mentioned in the MUC.
The macro mock_ptr_type does an intermediate cast to uintptr_t which silences the compiler warnings.

The second commit is not necessary to fix the unit tests on 32-bit architectures but improve the coding style by using a similar macro to mock non-pointer types.