### PR TITLE
Cancel autoping timer on disconnect or connection loss

### DIFF
--- a/src/event/common.c
+++ b/src/event/common.c
@@ -53,6 +53,7 @@ ev_disconnect_cleanup(void)
     ui_disconnected();
     session_disconnect();
     roster_destroy();
+    iq_autoping_timer_cancel();
     muc_invites_clear();
     muc_confserver_clear();
     chat_sessions_clear();

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -187,6 +187,7 @@ void iq_room_affiliation_set(const char *const room, const char *const jid, char
 void iq_room_kick_occupant(const char *const room, const char *const nick, const char *const reason);
 void iq_room_role_set(const char *const room, const char *const nick, char *role, const char *const reason);
 void iq_room_role_list(const char * const room, char *role);
+void iq_autoping_timer_cancel(void);
 void iq_autoping_check(void);
 void iq_http_upload_request(HTTPUpload *upload);
 void iq_command_list(const char *const target);

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -206,6 +206,7 @@ void iq_room_role_set(const char * const room, const char * const nick, char *ro
     const char * const reason) {}
 void iq_room_role_list(const char * const room, char *role) {}
 void iq_last_activity_request(gchar *jid) {}
+void iq_autoping_timer_cancel(void) {}
 void iq_autoping_check(void) {}
 void iq_rooms_cache_clear(void) {}
 void iq_command_list(const char *const target) {}


### PR DESCRIPTION
If Profanity is disconnected in any way before ping response is
received, the autoping timer will expire after the next connection
is established. As result, user will be disconnected immediately.

Cancel autoping timer in ev_disconnect_cleanup(), so it is done
for all kind of disconnections.