### PR TITLE
Improve plugin load/install failure message

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6904,12 +6904,14 @@ cmd_plugins_load(ProfWin *window, const char *const command, gchar **args)
         return TRUE;
     }
 
-    gboolean res = plugins_load(args[1]);
+    GString* error_message = g_string_new(NULL);
+    gboolean res = plugins_load(args[1], error_message);
     if (res) {
         cons_show("Loaded plugin: %s", args[1]);
     } else {
-        cons_show("Failed to load plugin: %s", args[1]);
+        cons_show("Failed to load plugin: %s. %s", args[1], error_message->str);
     }
+    g_string_free(error_message, TRUE);
 
     return TRUE;
 }
@@ -6946,12 +6948,14 @@ cmd_plugins_reload(ProfWin *window, const char *const command, gchar **args)
         return TRUE;
     }
 
-    gboolean res = plugins_reload(args[1]);
+    GString* error_message = g_string_new(NULL);
+    gboolean res = plugins_reload(args[1], error_message);
     if (res) {
         cons_show("Reloaded plugin: %s", args[1]);
     } else {
-        cons_show("Failed to reload plugin: %s", args[1]);
+        cons_show("Failed to reload plugin: %s, %s", args[1], error_message);
     }
+    g_string_free(error_message, TRUE);
 
     return TRUE;
 }

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -118,11 +118,11 @@ gboolean plugins_install(const char *const plugin_name, const char *const filena
 gboolean plugins_uninstall(const char *const plugin_name);
 gboolean plugins_update(const char *const plugin_name, const char *const filename, GString * error_message);
 PluginsInstallResult* plugins_install_all(const char *const path);
-gboolean plugins_load(const char *const name);
+gboolean plugins_load(const char *const name, GString *error_message);
 GSList* plugins_load_all(void);
 gboolean plugins_unload(const char *const name);
 gboolean plugins_unload_all(void);
-gboolean plugins_reload(const char *const name);
+gboolean plugins_reload(const char *const name, GString *error_message);
 void plugins_reload_all(void);
 
 void plugins_on_start(void);


### PR DESCRIPTION
In case Python or C plugins are disabled install/load failed silently.
Notify the user that we can't load them because profanity was built
without support for plugins.