### PR TITLE
Remove OMEMO session when untrusting a fingerprint

### DIFF
--- a/src/omemo/store.c
+++ b/src/omemo/store.c
@@ -148,7 +148,14 @@ delete_session(const signal_protocol_address *address, void *user_data)
         return SG_SUCCESS;
     }
 
-    return g_hash_table_remove(device_store, GINT_TO_POINTER(address->device_id));
+    g_hash_table_remove(device_store, GINT_TO_POINTER(address->device_id));
+
+    char *device_id_str = g_strdup_printf("%d", address->device_id);
+    g_key_file_remove_key(omemo_sessions_keyfile(), address->name, device_id_str, NULL);
+    g_free(device_id_str);
+    omemo_sessions_keyfile_save();
+
+    return SG_SUCCESS;
 }
 
 int


### PR DESCRIPTION
We have to store known_devices in a long term fashion otherwise we might
not be able to delete session if it is remove from device list server
side.

Also ensure that OMEMO is removed from trusted storage.