### PR TITLE
Add option to set all window related time formats

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -717,6 +717,7 @@ cmd_ac_init(void)
     autocomplete_add(time_ac, "xml");
     autocomplete_add(time_ac, "statusbar");
     autocomplete_add(time_ac, "lastactivity");
+    autocomplete_add(time_ac, "all");
 
     time_format_ac = autocomplete_new();
     autocomplete_add(time_format_ac, "set");
@@ -2661,6 +2662,11 @@ _time_autocomplete(ProfWin *window, const char *const input, gboolean previous)
     }
 
     found = autocomplete_param_with_ac(input, "/time xml", time_format_ac, TRUE, previous);
+    if (found) {
+        return found;
+    }
+
+    found = autocomplete_param_with_ac(input, "/time all", time_format_ac, TRUE, previous);
     if (found) {
         return found;
     }

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1277,8 +1277,8 @@ static struct cmd_t command_defs[] =
         CMD_TAGS(
             CMD_TAG_UI)
         CMD_SYN(
-            "/time console|chat|muc|config|private|xml set <format>",
-            "/time console|chat|muc|config|private|xml off",
+            "/time all|console|chat|muc|config|private|xml set <format>",
+            "/time all|console|chat|muc|config|private|xml off",
             "/time statusbar set <format>",
             "/time statusbar off",
             "/time lastactivity set <format>")
@@ -1303,13 +1303,16 @@ static struct cmd_t command_defs[] =
             { "xml off",                   "Do not show time in XML console window." },
             { "statusbar set <format>",    "Change time format in statusbar." },
             { "statusbar off",             "Do not show time in status bar." },
-            { "lastactivity set <format>", "Change time format for last activity." })
+            { "lastactivity set <format>", "Change time format for last activity." },
+            { "all set <format>",          "Set time for: console, chat, muc, config, private and xml windows." },
+            { "all off",                   "Do not show time for: console, chat, muc, config, private and xml windows." })
         CMD_EXAMPLES(
             "/time console set %H:%M:%S",
             "/time chat set \"%d-%m-%y %H:%M:%S\"",
             "/time xml off",
             "/time statusbar set %H:%M",
-            "/time lastactivity set \"%d-%m-%y %H:%M:%S\"")
+            "/time lastactivity set \"%d-%m-%y %H:%M:%S\"",
+            "/time all set \"%d-%m-%y %H:%M:%S\"")
     },
 
     { "/inpblock",

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -5359,6 +5359,44 @@ cmd_time(ProfWin *window, const char *const command, gchar **args)
             cons_bad_cmd_usage(command);
             return TRUE;
         }
+    } else if (g_strcmp0(args[0], "all") == 0) {
+        if (args[1] == NULL) {
+            cons_time_setting();
+            return TRUE;
+        } else if (g_strcmp0(args[1], "set") == 0 && args[2] != NULL) {
+            prefs_set_string(PREF_TIME_CONSOLE, args[2]);
+            cons_show("Console time format set to '%s'.", args[2]);
+            prefs_set_string(PREF_TIME_CHAT, args[2]);
+            cons_show("Chat time format set to '%s'.", args[2]);
+            prefs_set_string(PREF_TIME_MUC, args[2]);
+            cons_show("MUC time format set to '%s'.", args[2]);
+            prefs_set_string(PREF_TIME_CONFIG, args[2]);
+            cons_show("config time format set to '%s'.", args[2]);
+            prefs_set_string(PREF_TIME_PRIVATE, args[2]);
+            cons_show("Private chat time format set to '%s'.", args[2]);
+            prefs_set_string(PREF_TIME_XMLCONSOLE, args[2]);
+            cons_show("XML Console time format set to '%s'.", args[2]);
+            wins_resize_all();
+            return TRUE;
+        } else if (g_strcmp0(args[1], "off") == 0) {
+            prefs_set_string(PREF_TIME_CONSOLE, "off");
+            cons_show("Console time display disabled.");
+            prefs_set_string(PREF_TIME_CHAT, "off");
+            cons_show("Chat time display disabled.");
+            prefs_set_string(PREF_TIME_MUC, "off");
+            cons_show("MUC time display disabled.");
+            prefs_set_string(PREF_TIME_CONFIG, "off");
+            cons_show("config time display disabled.");
+            prefs_set_string(PREF_TIME_PRIVATE, "off");
+            cons_show("config time display disabled.");
+            prefs_set_string(PREF_TIME_XMLCONSOLE, "off");
+            cons_show("XML Console time display disabled.");
+            ui_redraw();
+            return TRUE;
+        } else {
+            cons_bad_cmd_usage(command);
+            return TRUE;
+        }
     } else {
         cons_bad_cmd_usage(command);
         return TRUE;


### PR DESCRIPTION
Implements feature requested at: https://github.com/profanity-im/profanity/issues/632

So instead of:

/time console set <format>
/time chat set <format>
/time muc set <format>
/time mucconfig set <format>
/time private set <format>
/time xml set <format>

As a short cut the user can do:

/time all set <format>

Excluding statusbar and lastactivity settings since they are not for main windows, but used slightly differently.