### PR TITLE
[FIX] triggering assert after disconnecting from ethernet

### DIFF
--- a/src/xmpp/roster_list.c
+++ b/src/xmpp/roster_list.c
@@ -120,12 +120,10 @@ roster_destroy(void)
 gboolean
 roster_update_presence(const char *const barejid, Resource *resource, GDateTime *last_activity)
 {
-    assert(roster != NULL);
-
     assert(barejid != NULL);
     assert(resource != NULL);
 
-    if (!roster_received) {
+    if (roster == NULL || !roster_received) {
         ProfPendingPresence *presence = malloc(sizeof(ProfPendingPresence));
         presence->barejid = strdup(barejid);
         presence->resource = resource;


### PR DESCRIPTION
On macOS, everytime a disconnect from the docking station happens and the ethernet connection disappears, **profanity** crashed with the below stack trace.

I am not too familiar with the code. However, it appears that the **assert** is a bit too aggressive in this particular case and we should not **abort** but rather mark the presence update as pending.

```
Application Specific Information:
Assertion failed: (roster != NULL), function roster_get_contact, file src/xmpp/roster_list.c, line 135.

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff6cd352c6 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff6cdf0bf1 pthread_kill + 284
2   libsystem_c.dylib             	0x00007fff6cc9f6a6 abort + 127
3   libsystem_c.dylib             	0x00007fff6cc6820d __assert_rtn + 324
4   profanity                     	0x0000000105c396a6 roster_get_contact + 100
5   profanity                     	0x0000000105c5264d _display_name + 70
6   profanity                     	0x0000000105c51e1e status_bar_draw + 644
7   profanity                     	0x0000000105c4efa6 ui_update + 364
8   profanity                     	0x0000000105c372d3 prof_run + 524
9   profanity                     	0x0000000105c8b79b main + 392
10  libdyld.dylib                 	0x00007fff6cbfa3d5 start + 1
```