### PR TITLE
Fix memleak in /cmd exec

### DIFF
--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -765,15 +765,22 @@ iq_submit_command_config(ProfConfWin *confwin)
 
     iq_send_stanza(iq);
     xmpp_stanza_release(iq);
+    free(data->sessionid);
+    free(data->command);
+    free(data);
 }
 
 void
 iq_cancel_command_config(ProfConfWin *confwin)
 {
     xmpp_ctx_t * const ctx = connection_get_ctx();
+    CommandConfigData *data = (CommandConfigData *)confwin->userdata;
     xmpp_stanza_t *iq = stanza_create_room_config_cancel_iq(ctx, confwin->roomjid);
     iq_send_stanza(iq);
     xmpp_stanza_release(iq);
+    free(data->sessionid);
+    free(data->command);
+    free(data);
 }
 
 static void


### PR DESCRIPTION
Free form userdata used to pass command node.