### PR TITLE
Don't print subscribed message if contact is already in roster

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -863,9 +863,13 @@ sv_ev_subscription(const char *barejid, jabber_subscr_t type)
         }
         break;
     case PRESENCE_SUBSCRIBED:
-        cons_show("Subscription received from %s", barejid);
         log_info("Subscription received from %s", barejid);
-        ui_print_system_msg_from_recipient(barejid, "Subscribed");
+        cons_show("Subscription received from %s", barejid);
+
+        PContact contact = roster_get_contact(barejid);
+        if (contact == NULL) {
+            ui_print_system_msg_from_recipient(barejid, "Subscribed");
+        }
         break;
     case PRESENCE_UNSUBSCRIBED:
         cons_show("%s deleted subscription", barejid);


### PR DESCRIPTION
This occured with a user running Cisco Jabber. It seems this server
sends repeated presence subscribed stanzas. And although I find this
strange according to RFC this seems to be ok.

So let's filter them and only display in the console output and to the
log. But don't open seperate windows.

Fix https://github.com/profanity-im/profanity/issues/1165