### PR TITLE
Possibility to specify alternative config file

### DIFF
--- a/docs/profanity.1
+++ b/docs/profanity.1
@@ -25,6 +25,9 @@ Auto connect to an account on startup,
 .I ACCOUNT
 must be an existing account.
 .TP
+.BI "\-c, \-\-config"
+Use an alternative config file.
+.TP
 .BI "\-l, \-\-log "LEVEL
 Set the logging level,
 .I LEVEL

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -79,10 +79,15 @@ static gboolean _get_default_boolean(preference_t pref);
 static char* _get_default_string(preference_t pref);
 
 void
-prefs_load(void)
+prefs_load(char *config_file)
 {
     GError *err;
-    prefs_loc = files_get_config_path(FILE_PROFRC);
+
+    if (config_file == NULL) {
+        prefs_loc = files_get_config_path(FILE_PROFRC);
+    } else {
+        prefs_loc = config_file;
+    }
 
     if (g_file_test(prefs_loc, G_FILE_TEST_EXISTS)) {
         g_chmod(prefs_loc, S_IRUSR | S_IWUSR);

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -166,7 +166,7 @@ typedef struct prof_winplacement_t {
     int inputwin_pos;
 } ProfWinPlacement;
 
-void prefs_load(void);
+void prefs_load(char *config_file);
 void prefs_save(void);
 void prefs_close(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -61,6 +61,7 @@
 static gboolean version = FALSE;
 static char *log = "INFO";
 static char *account_name = NULL;
+static char *config_file = NULL;
 
 int
 main(int argc, char **argv)
@@ -75,6 +76,7 @@ main(int argc, char **argv)
         { "version", 'v', 0, G_OPTION_ARG_NONE, &version, "Show version information", NULL },
         { "account", 'a', 0, G_OPTION_ARG_STRING, &account_name, "Auto connect to an account on startup" },
         { "log",'l', 0, G_OPTION_ARG_STRING, &log, "Set logging levels, DEBUG, INFO (default), WARN, ERROR", "LEVEL" },
+        { "config",'c', 0, G_OPTION_ARG_STRING, &config_file, "Use an alternative configuration file", NULL },
         { NULL }
     };
 
@@ -169,7 +171,7 @@ main(int argc, char **argv)
         return 0;
     }
 
-    prof_run(log, account_name);
+    prof_run(log, account_name, config_file);
 
     return 0;
 }

--- a/src/profanity.c
+++ b/src/profanity.c
@@ -85,7 +85,7 @@
 #include "omemo/omemo.h"
 #endif
 
-static void _init(char *log_level);
+static void _init(char *log_level, char *config_file);
 static void _shutdown(void);
 static void _connect_default(const char * const account);
 
@@ -93,9 +93,9 @@ static gboolean cont = TRUE;
 static gboolean force_quit = FALSE;
 
 void
-prof_run(char *log_level, char *account_name)
+prof_run(char *log_level, char *account_name, char *config_file)
 {
-    _init(log_level);
+    _init(log_level, config_file);
     plugins_on_start();
     _connect_default(account_name);
 
@@ -156,7 +156,7 @@ _connect_default(const char *const account)
 }
 
 static void
-_init(char *log_level)
+_init(char *log_level, char *config_file)
 {
     setlocale(LC_ALL, "");
     // ignore SIGPIPE
@@ -171,7 +171,7 @@ _init(char *log_level)
     pthread_mutex_lock(&lock);
     files_create_directories();
     log_level_t prof_log_level = log_level_from_string(log_level);
-    prefs_load();
+    prefs_load(config_file);
     log_init(prof_log_level);
     log_stderr_init(PROF_LEVEL_ERROR);
     if (strcmp(PACKAGE_STATUS, "development") == 0) {

--- a/src/profanity.h
+++ b/src/profanity.h
@@ -2,6 +2,7 @@
  * profanity.h
  *
  * Copyright (C) 2012 - 2019 James Booth <boothj5@gmail.com>
+ * Copyright (C) 2019 Michael Vetter <jubalh@iodoru.org>
  *
  * This file is part of Profanity.
  *
@@ -38,7 +39,7 @@
 #include <pthread.h>
 #include <glib.h>
 
-void prof_run(char *log_level, char *account_name);
+void prof_run(char *log_level, char *account_name, char * config_file);
 void prof_set_quit(void);
 
 pthread_mutex_t lock;

--- a/tests/unittests/helpers.c
+++ b/tests/unittests/helpers.c
@@ -45,7 +45,7 @@ void load_preferences(void **state)
     create_config_dir(state);
     FILE *f = fopen("./tests/files/xdg_config_home/profanity/profrc", "ab+");
     if (f) {
-        prefs_load();
+        prefs_load(NULL);
     }
     fclose(f);
 }


### PR DESCRIPTION
Introduce `profanity -c` to specify an alternative config file.