### PR TITLE
Don't render (all) delayed messages as MUC history

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -821,12 +821,14 @@ _handle_groupchat(xmpp_stanza_t *const stanza)
     }
 
     // determine if the notifications happened whilst offline
-    message->timestamp = stanza_get_delay(stanza);
-    if (message->timestamp) {
+    gchar *from;
+    message->timestamp = stanza_get_delay_from(stanza, &from);
+    if (message->timestamp && g_strcmp0(jid->barejid, from) == 0) {
         sv_ev_room_history(message);
     } else {
         sv_ev_room_message(message);
     }
+    g_free(from);
 
 out:
     message_free(message);

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -1174,6 +1174,12 @@ stanza_create_caps_sha1_from_query(xmpp_stanza_t *const query)
 GDateTime*
 stanza_get_delay(xmpp_stanza_t *const stanza)
 {
+    return stanza_get_delay_from(stanza, NULL);
+}
+
+GDateTime*
+stanza_get_delay_from(xmpp_stanza_t *const stanza, gchar **from)
+{
     GTimeVal utc_stamp;
     // first check for XEP-0203 delayed delivery
     xmpp_stanza_t *delay = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_DELAY);
@@ -1185,6 +1191,9 @@ stanza_get_delay(xmpp_stanza_t *const stanza)
                 GDateTime *utc_datetime = g_date_time_new_from_timeval_utc(&utc_stamp);
                 GDateTime *local_datetime = g_date_time_to_local(utc_datetime);
                 g_date_time_unref(utc_datetime);
+                if (from) {
+                    *from = g_strdup(xmpp_stanza_get_attribute(delay, STANZA_ATTR_FROM));
+                }
                 return local_datetime;
             }
         }
@@ -1201,11 +1210,17 @@ stanza_get_delay(xmpp_stanza_t *const stanza)
                 GDateTime *utc_datetime = g_date_time_new_from_timeval_utc(&utc_stamp);
                 GDateTime *local_datetime = g_date_time_to_local(utc_datetime);
                 g_date_time_unref(utc_datetime);
+                if (from) {
+                    *from = g_strdup(xmpp_stanza_get_attribute(x, STANZA_ATTR_FROM));
+                }
                 return local_datetime;
             }
         }
     }
 
+    if (from) {
+        *from = NULL;
+    }
     return NULL;
 }
 

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -267,6 +267,7 @@ xmpp_stanza_t* stanza_create_mediated_invite(xmpp_ctx_t *ctx, const char *const 
 gboolean stanza_contains_chat_state(xmpp_stanza_t *stanza);
 
 GDateTime* stanza_get_delay(xmpp_stanza_t *const stanza);
+GDateTime* stanza_get_delay_from(xmpp_stanza_t *const stanza, gchar **from);
 
 gboolean stanza_is_muc_presence(xmpp_stanza_t *const stanza);
 gboolean stanza_is_muc_self_presence(xmpp_stanza_t *const stanza,


### PR DESCRIPTION
Double-check that a `<delay/>` tag on a groupchat message was actually added by the MUC service (rather than the sending client) before assuming it was received from the MUC history.