### PR TITLE
Don't crash if source jid doesn't contain the node part

### DIFF
--- a/src/ui/statusbar.c
+++ b/src/ui/statusbar.c
@@ -198,7 +198,9 @@ _create_tab(const int win, win_type_t wintype, char *identifier, gboolean highli
             char *pref = prefs_get_string(PREF_STATUSBAR_CHAT);
             if (g_strcmp0("user", pref) == 0) {
                 Jid *jidp = jid_create(tab->identifier);
-                tab->display_name = strdup(jidp->localpart);
+                tab->display_name = jidp->localpart != NULL ?
+						strdup(jidp->localpart) :
+						strdup(jidp->barejid);
                 jid_destroy(jidp);
             } else {
                 tab->display_name = strdup(tab->identifier);


### PR DESCRIPTION
Should fix #1153 . @mdosch, @jubalh, please, check it. 