### PR TITLE
plugins/python: fix double _XOPEN_SOURCE definition

### DIFF
--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -32,6 +32,7 @@
  *
  */
 
+#undef _XOPEN_SOURCE
 #include <Python.h>
 
 #include "config.h"

--- a/src/plugins/python_plugins.c
+++ b/src/plugins/python_plugins.c
@@ -32,6 +32,7 @@
  *
  */
 
+#undef _XOPEN_SOURCE
 #include <Python.h>
 
 #include "log.h"


### PR DESCRIPTION
ncursesw defines _XOPEN_SOURCE macro via command-line. In particular, it
is defined in ncursesw.pc and extracted via pkg-config. From other side,
Python defines the same macro unconditionally in pyconfig.h. Python-3.x
defines the macro with value different than ncursesw does. In turn, this
causes a warning that the macro is redefined. And warnings are treated
as errors.

Since both entities define the mecro unconditionally, we can't simply
reorder headers as Python developers suggest. So, undefine the macro
just before the <Python.h> to fix this silly issue.

Fixes #1203.