### PR TITLE
Add builds.sr.ht CI for OpenBSD

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,0 +1,40 @@
+image: openbsd/6.6
+
+packages:
+  - cmake
+  - gmake
+  - cmocka
+  - libtool
+  - automake-1.16.1
+  - pkgconf
+  - readline
+  - python-3.7.4
+  - autoconf-2.69p2
+  - autoconf-archive
+  - libmesode
+  - curl
+  - gpgme
+  - glib2
+  - gtk+2
+  - libotr
+  - libassuan
+  - libgpg-error
+  - libgcrypt
+  - libsignal-protocol-c
+
+sources:
+  - https://github.com/profanity-im/profanity
+
+environment:
+  LANG: en_US.UTF-8
+
+tasks:
+  - symlink: |
+      doas ln -sf /usr/local/bin/python3.7 /usr/local/bin/python
+      doas ln -sf /usr/local/bin/python3.7-config /usr/local/bin/python-config
+      doas ln -sf /usr/local/bin/pydoc3.7  /usr/local/bin/pydoc
+  - build: |
+      export AUTOCONF_VERSION=2.69
+      export AUTOMAKE_VERSION=1.16
+      cd profanity
+      ./ci-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,15 @@ matrix:
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      docker build -f Dockerfile."$BUILD_FLAVOR" -t profanity .;
+    docker build -f Dockerfile."$BUILD_FLAVOR" -t profanity .;
     fi
 
 script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      docker run -it profanity ./travis-build.sh;
+    docker run -it profanity ./ci-build.sh;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      ./travis-build.sh;
+    ./ci-build.sh;
     fi
 
 after_failure:

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 error_handler()
 {
     ERR_CODE=$?
     echo
-    echo "Error $ERR_CODE with command '$BASH_COMMAND' on line ${BASH_LINENO[0]}. Exiting."
+    echo "Error ${ERR_CODE} with command '${BASH_COMMAND}' on line ${BASH_LINENO[0]}. Exiting."
     echo
-    exit $ERR_CODE
+    exit ${ERR_CODE}
 }
 
 trap error_handler ERR
@@ -14,6 +14,9 @@ trap error_handler ERR
 ./bootstrap.sh
 
 tests=()
+MAKE="make"
+CC="gcc"
+
 case $(uname | tr '[:upper:]' '[:lower:]') in
     linux*)
         tests=(
@@ -58,22 +61,52 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
         "--disable-c-plugins --disable-python-plugins"
         "")
         ;;
+    openbsd*)
+        MAKE="gmake"
+        # TODO(#1231):
+        # `-std=gnu99 -fexec-charset=UTF-8` to silence:
+        # src/event/server_events.c:1453:19: error: universal character names are only valid in C++ and C99
+        # src/event/server_events.c:1454:19: error: universal character names are only valid in C++ and C99
+        CC="gcc -std=gnu99 -fexec-charset=UTF-8"
+
+        tests=(
+        "--enable-notifications --enable-icons-and-clipboard --enable-otr --enable-pgp
+        --enable-omemo --enable-plugins --enable-c-plugins
+        --enable-python-plugins"
+        "--disable-notifications --disable-icons --disable-otr --disable-pgp
+        --disable-omemo --disable-plugins --disable-c-plugins
+        --disable-python-plugins"
+        "--disable-notifications"
+        "--disable-icons"
+        "--disable-otr"
+        "--disable-pgp"
+        "--disable-omemo"
+        "--disable-pgp --disable-otr"
+        "--disable-pgp --disable-otr --disable-omemo"
+        "--disable-plugins"
+        "--disable-python-plugins"
+        "--disable-c-plugins"
+        "--disable-c-plugins --disable-python-plugins"
+        "")
+        ;;
 esac
 
-for flags in "${tests[@]}"
+for features in "${tests[@]}"
 do
     echo
-    echo "--> Building with ./configure $flags"
+    echo "--> Building with ./configure ${features}"
     echo
+
     # shellcheck disable=SC2086
-    ./configure $flags
-    make
-    make check
+    ./configure $features
+
+    $MAKE CC="${CC}"
+    $MAKE check
+
     if [ $? -eq 1 ]; then
         cat ./test-suite.log
     fi
-    ./profanity -v
-    make clean
 
-    echo "$flags"
+    ./profanity -v
+    $MAKE clean
 done

--- a/configure.ac
+++ b/configure.ac
@@ -106,13 +106,17 @@ else
     if test "x$enable_plugins" = xno; then
         AM_CONDITIONAL([BUILD_C_API], [false])
     elif test "x$enable_c_plugins" != xno; then
-        AC_CHECK_LIB([dl], [main],
-            [AM_CONDITIONAL([BUILD_C_API], [true]) LIBS="$LIBS -ldl" AC_DEFINE([HAVE_C], [1], [C support])],
-            [AS_IF(
-                [test "x$enable_c_plugins" = xyes],
-                    [AC_MSG_ERROR([dl library needed to run C plugins])],
-                [AM_CONDITIONAL([BUILD_C_API], [false])])
-            ])
+        # libdl doesn't exist as a separate library in OpenBSD/FreeBSD and is
+        # provided in the standard libraries.
+        AS_IF([test "x$PLATFORM" = xopenbsd -o "x$PLATFORM" = xfreebsd],
+            [AM_CONDITIONAL([BUILD_C_API], [true]) AC_DEFINE([HAVE_C], [1], [C support])],
+            [AC_CHECK_LIB([dl], [main],
+                [AM_CONDITIONAL([BUILD_C_API], [true]) LIBS="$LIBS -ldl" AC_DEFINE([HAVE_C], [1], [C support])],
+                [AS_IF(
+                    [test "x$enable_c_plugins" = xyes],
+                        [AC_MSG_ERROR([dl library needed to run C plugins])],
+                    [AM_CONDITIONAL([BUILD_C_API], [false])])
+                ])])
     else
         AM_CONDITIONAL([BUILD_C_API], [false])
     fi

--- a/src/ui/rosterwin.c
+++ b/src/ui/rosterwin.c
@@ -353,7 +353,7 @@ _rosterwin_contact(ProfLayoutSplit *layout, PContact contact)
     }
 
     theme_item_t presence_colour = _get_roster_theme(theme_type, presence);
-    int colour;
+    int colour = 0;
     if (prefs_get_boolean(PREF_ROSTER_COLOR_NICK)) {
         colour = theme_hash_attrs(name);
         wattron(layout->subwin, colour);
@@ -1290,4 +1290,3 @@ _filter_contacts_with_presence(GSList *contacts, const char *const presence)
 
     return filtered_contacts;
 }
-

--- a/tests/unittests/test_cmd_otr.c
+++ b/tests/unittests/test_cmd_otr.c
@@ -250,6 +250,7 @@ test_cmd_otr_theirfp_from_wintype(win_type_t wintype)
     gchar *args[] = { "theirfp", NULL };
     ProfWin window;
     window.type = wintype;
+    window.layout = NULL;
 
     will_return(connection_get_status, JABBER_CONNECTED);
 
@@ -281,6 +282,7 @@ void cmd_otr_theirfp_shows_message_when_non_otr_chat_window(void **state)
 
     ProfWin window;
     window.type = WIN_CHAT;
+    window.layout = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.memcheck = PROFCHATWIN_MEMCHECK;
@@ -307,6 +309,7 @@ void cmd_otr_theirfp_shows_fingerprint(void **state)
 
     ProfWin window;
     window.type = WIN_CHAT;
+    window.layout = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;
@@ -333,6 +336,7 @@ test_cmd_otr_start_from_wintype(win_type_t wintype)
     gchar *args[] = { "start", NULL };
     ProfWin window;
     window.type = wintype;
+    window.layout = NULL;
 
     will_return(connection_get_status, JABBER_CONNECTED);
 
@@ -366,6 +370,7 @@ void cmd_otr_start_shows_message_when_already_started(void **state)
 
     ProfWin window;
     window.type = WIN_CHAT;
+    window.layout = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;
@@ -389,6 +394,7 @@ void cmd_otr_start_shows_message_when_no_key(void **state)
 
     ProfWin window;
     window.type = WIN_CHAT;
+    window.layout = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;


### PR DESCRIPTION
See my failures at: https://builds.sr.ht/~wstrm

The package cache at sr.ht is currently broken for FreeBSD, so I'll have to add that build manifest in a later PR.

How to hook it up with builds.sr.ht and GitHub:
(You need to authorize sr.ht to read from the `profanity-im` organization, too)

**On commit push hook**
 * Go to https://dispatch.sr.ht
 * Click `Configure new task`
 * Click on `Configure task` for:
![2020-02-15-130503_730x44_scrot](https://user-images.githubusercontent.com/4541181/74587517-d3f64200-4ff3-11ea-86c5-1af3bbca6ecd.png)
 * Click `Add task` for `profanity-im/profanity`
 * Save

**On PR push hook**
 * Go to https://dispatch.sr.ht
 * Click `Configure new task`
 * Click on `Configure task` for:
![2020-02-15-130657_736x53_scrot](https://user-images.githubusercontent.com/4541181/74587541-0dc74880-4ff4-11ea-984a-dcb209fec74b.png)
 * Click `Add task` for `profanity-im/profanity`
 * Save