### PR TITLE
Disallow sendfile in e2ee chat sessions

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -4796,6 +4796,16 @@ cmd_sendfile(ProfWin *window, const char *const command, gchar **args)
         free(filename);
         return TRUE;
     }
+    
+    ProfChatWin *chatwin = (ProfChatWin*)window;
+    assert(chatwin->memcheck == PROFCHATWIN_MEMCHECK);
+    
+    if (chatwin->pgp_send || chatwin->is_omemo || chatwin->is_otr) {
+		cons_show_error("Uploading '%s' failed: Encrypted file uploads not yet implemented!", filename); 
+        win_println(window, THEME_ERROR, '-', "Sending encrypted files via http_upload is not possible yet.");
+        free(filename);
+        return TRUE;
+    }
 
     if (access(filename, R_OK) != 0) {
         cons_show_error("Uploading '%s' failed: File not found!", filename);


### PR DESCRIPTION
Currently, the /sendfile command sends files via http_upload, but these files are not encrypted. 
However, users that have e2ee enabled in a chat session reasonably expect file encryption. 
That is why we should disallow /sendfile in e2ee sessions until file encryption is implemented.