### PR TITLE
Add builds.sr.ht badge for Profanity builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Profanity [![Build Status](https://api.travis-ci.org/profanity-im/profanity.png?branch=master)](https://travis-ci.org/profanity-im/profanity)
+Profanity [![Build Status](https://api.travis-ci.org/profanity-im/profanity.png?branch=master)](https://travis-ci.org/profanity-im/profanity) [![builds.sr.ht status](https://builds.sr.ht/~wstrm/profanity.svg)](https://builds.sr.ht/~wstrm/profanity?)
 =========
 
 Profanity is a console based XMPP client inspired by [Irssi](http://www.irssi.org/).


### PR DESCRIPTION
This PR adds a badge that show the status of the builds on builds.sr.ht. A mirror of the Profanity repository is used that is updated daily, i.e. builds are run at most once per day in case of repository updates.