### PR TITLE
Fix memory leak of presence object

### DIFF
--- a/src/xmpp/roster_list.c
+++ b/src/xmpp/roster_list.c
@@ -140,6 +140,8 @@ roster_update_presence(const char *const barejid, Resource *resource, GDateTime 
 
     PContact contact = roster_get_contact(barejid);
     if (contact == NULL) {
+        /* Don't lose resource when there is no owner. */
+        resource_destroy(resource);
         return FALSE;
     }
     if (!_datetimes_equal(p_contact_last_activity(contact), last_activity)) {


### PR DESCRIPTION
The memory leak happens when a presence is received for a MUC room. The
JID is not present in the roster, so updating its status is ignored. We
have to free resource in this case, because it has no owner and is lost
otherwise.

```
==25736== 47 (32 direct, 15 indirect) bytes in 1 blocks are definitely lost in loss record 1,625 of 3,399
==25736==    at 0x4A330FF: malloc (vg_replace_malloc.c:309)
==25736==    by 0x13A962: resource_new (resource.c:47)
==25736==    by 0x145501: _available_handler (presence.c:665)
==25736==    by 0x145501: _presence_handler (presence.c:399)
==25736==    by 0x145501: _presence_handler (presence.c:358)
==25736==    by 0x80D5F34: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==25736==    by 0x80D2B49: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==25736==    by 0x80E15CE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==25736==    by 0x843EE9B: doContent (in /usr/lib64/libexpat.so.1.6.10)
==25736==    by 0x843F94B: contentProcessor (in /usr/lib64/libexpat.so.1.6.10)
==25736==    by 0x8441E77: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.10)
==25736==    by 0x80D586B: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==25736==    by 0x13E07E: connection_check_events (connection.c:119)
==25736==    by 0x13869C: prof_run (profanity.c:129)
```

Fixes #1279.