### PR TITLE
Fixed memory leak in ProfMucWin

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -519,6 +519,8 @@ win_free(ProfWin* window)
         free(mucwin->room_name);
         free(mucwin->enctext);
         free(mucwin->message_char);
+        free(mucwin->last_message);
+        free(mucwin->last_msg_id);
         break;
     }
     case WIN_CONFIG:


### PR DESCRIPTION
Profanity remembers last message and its id for the message correction
feature. We must free them in window destructor.