### PR TITLE
Fix few memory leaks

### DIFF
--- a/src/ui/rosterwin.c
+++ b/src/ui/rosterwin.c
@@ -562,6 +562,7 @@ _rosterwin_resources(ProfLayoutSplit *layout, PContact contact, int current_inde
 
                 wattron(layout->subwin, theme_attrs(presence_colour));
                 win_sub_print(layout->subwin, unreadmsg->str, FALSE, wrap, current_indent);
+                g_string_free(unreadmsg, TRUE);
                 wattroff(layout->subwin, theme_attrs(presence_colour));
             }
             prefs_free_string(unreadpos);

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2627,6 +2627,7 @@ stanza_attach_correction(xmpp_ctx_t *ctx, xmpp_stanza_t *stanza, const char *con
     xmpp_stanza_set_id(replace_stanza, replace_id);
     xmpp_stanza_set_ns(replace_stanza, STANZA_NS_LAST_MESSAGE_CORRECTION);
     xmpp_stanza_add_child(stanza, replace_stanza);
+    xmpp_stanza_release(replace_stanza);
 
     return stanza;
 }


### PR DESCRIPTION
```
==5519== 32 (24 direct, 8 indirect) bytes in 1 blocks are definitely lost in loss record 1,904 of 4,424
==5519==    at 0x4A330FF: malloc (vg_replace_malloc.c:309)
==5519==    by 0x654B4A8: g_malloc (in /usr/lib64/libglib-2.0.so.0.6400.1)
==5519==    by 0x65634C1: g_slice_alloc (in /usr/lib64/libglib-2.0.so.0.6400.1)
==5519==    by 0x6567EC3: g_string_sized_new (in /usr/lib64/libglib-2.0.so.0.6400.1)
==5519==    by 0x167193: _rosterwin_resources (rosterwin.c:557)
==5519==    by 0x167193: _rosterwin_contact (rosterwin.c:407)
==5519==    by 0x16761A: _rosterwin_contacts_by_presence (rosterwin.c:244)
==5519==    by 0x168509: rosterwin_roster (rosterwin.c:130)
==5519==    by 0x147D19: _handle_chat (message.c:1220)
==5519==    by 0x147D19: _message_handler (message.c:154)
==5519==    by 0x147D19: _message_handler (message.c:94)
==5519==    by 0x78120AE: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==5519==    by 0x780EB8A: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==5519==    by 0x781DD3E: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==5519==    by 0x7B81972: doContent (in /usr/lib64/libexpat.so.1.6.11)
==5519==
==5519== 1,215 (216 direct, 999 indirect) bytes in 3 blocks are definitely lost in loss record 4,250 of 4,424
==5519==    at 0x4A330FF: malloc (vg_replace_malloc.c:309)
==5519==    by 0x781BDED: xmpp_stanza_new (in /usr/lib64/libstrophe.so.0.0.0)
==5519==    by 0x14E94F: stanza_attach_correction (stanza.c:2625)
==5519==    by 0x146BED: message_send_chat (message.c:287)
==5519==    by 0x153F2F: cl_ev_send_msg_correct (client_events.c:189)
==5519==    by 0x17D903: cmd_correct (cmd_funcs.c:8806)
==5519==    by 0x16EE96: _cmd_execute (cmd_funcs.c:7998)
==5519==    by 0x16ED6D: cmd_process_input (cmd_funcs.c:143)
==5519==    by 0x16ED6D: cmd_process_input (cmd_funcs.c:120)
==5519==    by 0x13B867: prof_run (profanity.c:117)
==5519==    by 0x137C3C: main (main.c:180)
```