### PR TITLE
Free GError objects

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -114,6 +114,8 @@ copy_file(const char *const sourcepath, const char *const targetpath, const gboo
     GError *error = NULL;
     GFileCopyFlags flags = overwrite_existing ? G_FILE_COPY_OVERWRITE : G_FILE_COPY_NONE;
     gboolean success = g_file_copy (source, dest, flags, NULL, NULL, NULL, &error);
+    if (error != NULL)
+        g_error_free(error);
     g_object_unref(source);
     g_object_unref(dest);
     return success;

--- a/src/ui/notifier.c
+++ b/src/ui/notifier.c
@@ -224,9 +224,10 @@ notify(const char *const message, int timeout, const char *const category)
             log_error("Error sending desktop notification:");
             log_error("  -> Message : %s", message);
             log_error("  -> Error   : %s", error->message);
+            g_error_free(error);
         } else {
-	    log_debug("Notification sent.");
-	}
+            log_debug("Notification sent.");
+        }
     } else {
         log_error("Libnotify not initialised.");
     }


### PR DESCRIPTION
glib functions can allocate a GError object that must be freed with
`g_error_free()`. Otherwise a memory leak happens.

There are similar unfixed places in omemo, check:
```
    grep "&error" src/omemo/omemo.c
```

Fixes #1304.