### PR TITLE
Incoming iq stanza - Reset the autoping timer

### DIFF
--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -159,6 +159,8 @@ _iq_handler(xmpp_conn_t *const conn, xmpp_stanza_t *const stanza, void *const us
 {
     log_debug("iq stanza handler fired");
 
+    iq_autoping_timer_cancel(); // reset the autoping timer
+
     char *text;
     size_t text_size;
     xmpp_stanza_to_text(stanza, &text, &text_size);


### PR DESCRIPTION
A autoping is to make sure that there is still a connection between server and
client. If the application receives incoming stanza, the connection is fine.
There is no need to wait for response, if there are other incomings.

Issue: #1333 and #1315