### PR TITLE
Bugfix: Status with PGP shows offline in titlebar

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -147,13 +147,12 @@ sv_ev_roster_received(void)
         }
         free(err_str);
 
-        // Redraw the screen after entry of the PGP secret key
+        // Redraw the screen after entry of the PGP secret key, but not init
         ProfWin *win = wins_get_current();
         char *theme = prefs_get_string(PREF_THEME);
         win_clear(win);
         theme_init(theme);
         prefs_free_string(theme);
-        ui_init();
         ui_resize();
         ui_show_roster();
     }


### PR DESCRIPTION
There is code to redraw the ui, because the user may enter a passphase for the
private key. There was also a ui_init, which shouldn't be called, because it
will set the status to the initial state, which is 'offline' and 'no tls'.

Issue: #1327