### PR TITLE
configure.ac: add additional check for libstrophe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,10 +130,21 @@ AS_IF([test "x$PTHREAD_CC" != x], [ CC="$PTHREAD_CC" ])
 
 ### Check for libmesode, fall back to libstrophe
 PKG_CHECK_MODULES([libmesode], [libmesode >= 0.9.2],
-    [LIBS="$libmesode_LIBS $LIBS" CFLAGS="$CFLAGS $libmesode_CFLAGS" AC_DEFINE([HAVE_LIBMESODE], [1], [libmesode])],
+    [LIBS="$libmesode_LIBS $LIBS" CFLAGS="$CFLAGS $libmesode_CFLAGS" XMPP_LIB="libmesode" AC_DEFINE([HAVE_LIBMESODE], [1], [libmesode])],
     [PKG_CHECK_MODULES([libstrophe], [libstrophe >= 0.9.2],
-        [LIBS="$libstrophe_LIBS $LIBS" CFLAGS="$CFLAGS $libstrophe_CFLAGS" AC_DEFINE([HAVE_LIBSTROPHE], [1], [libstrophe])],
+        [LIBS="$libstrophe_LIBS $LIBS" CFLAGS="$CFLAGS $libstrophe_CFLAGS" XMPP_LIB="libstrophe" AC_DEFINE([HAVE_LIBSTROPHE], [1], [libstrophe])],
         [AC_MSG_ERROR([Neither libmesode or libstrophe in version >= 0.9.2 found, either is required for profanity])])])
+
+AC_MSG_CHECKING([whether ${XMPP_LIB} works])
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #include <strophe.h>
+    int main() {
+        xmpp_initialize();
+        return 0;
+    }
+    ]])],
+    [AC_MSG_RESULT([yes])],
+    [AC_MSG_ERROR([${XMPP_LIB} is broken, check config.log for details])])
 
 ### Check for ncurses library
 PKG_CHECK_MODULES([ncursesw], [ncursesw],

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,12 @@ PKG_CHECK_MODULES([libmesode], [libmesode >= 0.9.2],
 
 AC_MSG_CHECKING([whether ${XMPP_LIB} works])
 AC_LINK_IFELSE([AC_LANG_SOURCE([[
+    #ifdef HAVE_LIBMESODE
+    #include <mesode.h>
+    #else
     #include <strophe.h>
+    #endif
+
     int main() {
         xmpp_initialize();
         return 0;


### PR DESCRIPTION
After the library is found by pkg-config, try to build a simple program
to check the installation. The motivation of this check is that the
chance that users manually install libstrophe/libmesode is higher than
for other libs.

Fixes #1334.