### PR TITLE
use always c99; fixes "universal character names" error msg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,7 +329,7 @@ AC_CHECK_HEADERS([ncursesw/ncurses.h], [], [])
 AC_CHECK_HEADERS([ncurses.h], [], [])
 
 ### Default parameters
-AM_CFLAGS="-Wall -Wno-deprecated-declarations"
+AM_CFLAGS="-Wall -Wno-deprecated-declarations -std=c99"
 AS_IF([test "x$PACKAGE_STATUS" = xdevelopment],
     [AM_CFLAGS="$AM_CFLAGS -Wunused -Werror"])
 AS_IF([test "x$PLATFORM" = xosx],


### PR DESCRIPTION
without this, i receive this error on openbsd 6.7:

src/event/server_events.c:1477:19: error: universal character names are only valid in C++ and C99
src/event/server_events.c:1478:19: error: universal character names are only valid in C++ and C99
gmake[1]: *** [Makefile:1925: src/event/server_events.o] Error 1
gmake[1]: Leaving directory '/home/toogley/profanity'
gmake: *** [Makefile:1212: all] Error 2