### PR TITLE
Add option for legacy authentication

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -195,6 +195,7 @@ static Autocomplete omemo_sendfile_ac;
 #endif
 static Autocomplete connect_property_ac;
 static Autocomplete tls_property_ac;
+static Autocomplete auth_property_ac;
 static Autocomplete alias_ac;
 static Autocomplete aliases_ac;
 static Autocomplete join_property_ac;
@@ -425,6 +426,7 @@ cmd_ac_init(void)
     autocomplete_add(account_set_ac, "pgpkeyid");
     autocomplete_add(account_set_ac, "startscript");
     autocomplete_add(account_set_ac, "tls");
+    autocomplete_add(account_set_ac, "auth");
     autocomplete_add(account_set_ac, "theme");
 
     account_clear_ac = autocomplete_new();
@@ -686,6 +688,7 @@ cmd_ac_init(void)
 #endif
 
     connect_property_ac = autocomplete_new();
+    autocomplete_add(connect_property_ac, "auth");
     autocomplete_add(connect_property_ac, "server");
     autocomplete_add(connect_property_ac, "port");
     autocomplete_add(connect_property_ac, "tls");
@@ -696,6 +699,10 @@ cmd_ac_init(void)
     autocomplete_add(tls_property_ac, "trust");
     autocomplete_add(tls_property_ac, "legacy");
     autocomplete_add(tls_property_ac, "disable");
+
+    auth_property_ac = autocomplete_new();
+    autocomplete_add(auth_property_ac, "default");
+    autocomplete_add(auth_property_ac, "legacy");
 
     join_property_ac = autocomplete_new();
     autocomplete_add(join_property_ac, "nick");
@@ -1263,6 +1270,7 @@ cmd_ac_reset(ProfWin *window)
 #endif
     autocomplete_reset(connect_property_ac);
     autocomplete_reset(tls_property_ac);
+    autocomplete_reset(auth_property_ac);
     autocomplete_reset(alias_ac);
     autocomplete_reset(aliases_ac);
     autocomplete_reset(join_property_ac);
@@ -1419,6 +1427,7 @@ cmd_ac_uninit(void)
 #endif
     autocomplete_free(connect_property_ac);
     autocomplete_free(tls_property_ac);
+    autocomplete_free(auth_property_ac);
     autocomplete_free(alias_ac);
     autocomplete_free(aliases_ac);
     autocomplete_free(join_property_ac);
@@ -3206,7 +3215,7 @@ _connect_autocomplete(ProfWin *window, const char *const input, gboolean previou
     char *found = NULL;
     gboolean result = FALSE;
 
-    gchar **args = parse_args(input, 1, 7, &result);
+    gchar **args = parse_args(input, 1, 9, &result);
 
     if (result) {
         gboolean space_at_end = g_str_has_suffix(input, " ");
@@ -3268,6 +3277,74 @@ _connect_autocomplete(ProfWin *window, const char *const input, gboolean previou
             GString *beginning = g_string_new("/connect");
             g_string_append_printf(beginning, " %s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5]);
             found = autocomplete_param_with_ac(input, beginning->str, tls_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+        if ((num_args == 7 && space_at_end) || (num_args == 8 && !space_at_end)) {
+            GString *beginning = g_string_new("/connect");
+            g_string_append_printf(beginning, " %s %s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5], args[6]);
+            found = autocomplete_param_with_ac(input, beginning->str, connect_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+        if ((num_args == 8 && space_at_end && (g_strcmp0(args[7], "tls") == 0))
+                || (num_args == 9 && (g_strcmp0(args[7], "tls") == 0) && !space_at_end))  {
+            GString *beginning = g_string_new("/connect");
+            g_string_append_printf(beginning, " %s %s %s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+            found = autocomplete_param_with_ac(input, beginning->str, tls_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+
+        /* auth option */
+
+        if ((num_args == 2 && space_at_end && (g_strcmp0(args[1], "auth") == 0))
+                || (num_args == 3 && (g_strcmp0(args[1], "auth") == 0) && !space_at_end))  {
+            GString *beginning = g_string_new("/connect");
+            g_string_append_printf(beginning, " %s %s", args[0], args[1]);
+            found = autocomplete_param_with_ac(input, beginning->str, auth_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+        if ((num_args == 4 && space_at_end && (g_strcmp0(args[3], "auth") == 0))
+                || (num_args == 5 && (g_strcmp0(args[3], "auth") == 0) && !space_at_end))  {
+            GString *beginning = g_string_new("/connect");
+            g_string_append_printf(beginning, " %s %s %s %s", args[0], args[1], args[2], args[3]);
+            found = autocomplete_param_with_ac(input, beginning->str, auth_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+        if ((num_args == 6 && space_at_end && (g_strcmp0(args[5], "auth") == 0))
+                || (num_args == 7 && (g_strcmp0(args[5], "auth") == 0) && !space_at_end))  {
+            GString *beginning = g_string_new("/connect");
+            g_string_append_printf(beginning, " %s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5]);
+            found = autocomplete_param_with_ac(input, beginning->str, auth_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+        if ((num_args == 8 && space_at_end && (g_strcmp0(args[7], "auth") == 0))
+                || (num_args == 9 && (g_strcmp0(args[7], "auth") == 0) && !space_at_end))  {
+            GString *beginning = g_string_new("/connect");
+            g_string_append_printf(beginning, " %s %s %s %s %s %s %s %s", args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]);
+            found = autocomplete_param_with_ac(input, beginning->str, auth_property_ac, TRUE, previous);
             g_string_free(beginning, TRUE);
             if (found) {
                 g_strfreev(args);
@@ -3478,6 +3555,17 @@ _account_autocomplete(ProfWin *window, const char *const input, gboolean previou
             GString *beginning = g_string_new("/account");
             g_string_append_printf(beginning, " %s %s %s", args[0], args[1], args[2]);
             found = autocomplete_param_with_ac(input, beginning->str, tls_property_ac, TRUE, previous);
+            g_string_free(beginning, TRUE);
+            if (found) {
+                g_strfreev(args);
+                return found;
+            }
+        }
+        if ((num_args == 3 && space_at_end && (g_strcmp0(args[2], "auth") == 0))
+                || (num_args == 4 && (g_strcmp0(args[2], "auth") == 0) && !space_at_end))  {
+            GString *beginning = g_string_new("/account");
+            g_string_append_printf(beginning, " %s %s %s", args[0], args[1], args[2]);
+            found = autocomplete_param_with_ac(input, beginning->str, auth_property_ac, TRUE, previous);
             g_string_free(beginning, TRUE);
             if (found) {
                 g_strfreev(args);

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -160,7 +160,7 @@ static struct cmd_t command_defs[] =
             CMD_TAG_CONNECTION)
         CMD_SYN(
             "/connect [<account>]",
-            "/connect <account> [server <server>] [port <port>] [tls force|allow|trust|legacy|disable]")
+            "/connect <account> [server <server>] [port <port>] [tls force|allow|trust|legacy|disable] [auth default|legacy]")
         CMD_DESC(
             "Login to a chat service. "
             "If no account is specified, the default is used if one is configured. "
@@ -173,7 +173,9 @@ static struct cmd_t command_defs[] =
             { "tls allow",         "Use TLS for the connection if it is available." },
             { "tls trust",         "Force TLS connection and trust server's certificate." },
             { "tls legacy",        "Use legacy TLS for the connection. It means server doesn't support STARTTLS and TLS is forced just after TCP connection is established." },
-            { "tls disable",       "Disable TLS for the connection." })
+            { "tls disable",       "Disable TLS for the connection." },
+            { "auth default",      "Default authentication process." },
+            { "auth legacy",       "Allow legacy authentication." })
         CMD_EXAMPLES(
             "/connect",
             "/connect odin@valhalla.edda",
@@ -2003,6 +2005,7 @@ static struct cmd_t command_defs[] =
             "/account set <account> pgpkeyid <pgpkeyid>",
             "/account set <account> startscript <script>",
             "/account set <account> tls force|allow|trust|legacy|disable",
+            "/account set <account> auth default|legacy",
             "/account set <account> theme <theme>",
             "/account clear <account> password",
             "/account clear <account> eval_password",
@@ -2045,6 +2048,8 @@ static struct cmd_t command_defs[] =
             { "set <account> tls trust",                "Force TLS connection and trust server's certificate." },
             { "set <account> tls legacy",               "Use legacy TLS for the connection. It means server doesn't support STARTTLS and TLS is forced just after TCP connection is established." },
             { "set <account> tls disable",              "Disable TLS for the connection." },
+            { "set <account> auth default",             "Use default authentication process." },
+            { "set <account> auth legacy",              "Allow legacy authentication." },
             { "set <account> <theme>",                  "Set the UI theme for the account." },
             { "clear <account> server",                 "Remove the server setting for this account." },
             { "clear <account> port",                   "Remove the port setting for this account." },

--- a/src/config/account.c
+++ b/src/config/account.c
@@ -55,7 +55,7 @@ account_new(const gchar *const name, const gchar *const jid,
     const gchar *const otr_policy, GList *otr_manual, GList *otr_opportunistic,
     GList *otr_always,  const gchar *const omemo_policy, GList *omemo_enabled,
     GList *omemo_disabled, const gchar *const pgp_keyid, const char *const startscript,
-    const char *const theme, gchar *tls_policy)
+    const char *const theme, gchar *tls_policy, gchar *auth_policy)
 {
     ProfAccount *new_account = malloc(sizeof(ProfAccount));
     memset(new_account, 0, sizeof(ProfAccount));
@@ -175,6 +175,12 @@ account_new(const gchar *const name, const gchar *const jid,
         new_account->tls_policy = NULL;
     }
 
+    if (auth_policy != NULL) {
+        new_account->auth_policy = strdup(auth_policy);
+    } else {
+        new_account->auth_policy = NULL;
+    }
+
     return new_account;
 }
 
@@ -247,6 +253,7 @@ account_free(ProfAccount *account)
     free(account->startscript);
     free(account->theme);
     free(account->tls_policy);
+    free(account->auth_policy);
     g_list_free_full(account->otr_manual, g_free);
     g_list_free_full(account->otr_opportunistic, g_free);
     g_list_free_full(account->otr_always, g_free);
@@ -270,4 +277,10 @@ void account_set_tls_policy(ProfAccount *account, const char *tls_policy)
 {
     free(account->tls_policy);
     account->tls_policy = strdup(tls_policy);
+}
+
+void account_set_auth_policy(ProfAccount *account, const char *auth_policy)
+{
+    free(account->auth_policy);
+    account->auth_policy = strdup(auth_policy);
 }

--- a/src/config/account.h
+++ b/src/config/account.h
@@ -67,6 +67,7 @@ typedef struct prof_account_t {
     gchar *startscript;
     gchar *theme;
     gchar *tls_policy;
+    gchar *auth_policy;
 } ProfAccount;
 
 ProfAccount* account_new(const gchar *const name, const gchar *const jid,
@@ -78,12 +79,13 @@ ProfAccount* account_new(const gchar *const name, const gchar *const jid,
     const gchar *const otr_policy, GList *otr_manual, GList *otr_opportunistic,
     GList *otr_always, const gchar *const omemo_policy, GList *omemo_enabled,
     GList *omemo_disabled, const gchar *const pgp_keyid, const char *const startscript,
-    const char *const theme, gchar *tls_policy);
+    const char *const theme, gchar *tls_policy, gchar *auth_policy);
 char* account_create_connect_jid(ProfAccount *account);
 gboolean account_eval_password(ProfAccount *account);
 void account_free(ProfAccount *account);
 void account_set_server(ProfAccount *account, const char *server);
 void account_set_port(ProfAccount *account, int port);
 void account_set_tls_policy(ProfAccount *account, const char *tls_policy);
+void account_set_auth_policy(ProfAccount *account, const char *auth_policy);
 
 #endif

--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -121,7 +121,7 @@ accounts_reset_enabled_search(void)
 }
 
 void
-accounts_add(const char *account_name, const char *altdomain, const int port, const char *const tls_policy)
+accounts_add(const char *account_name, const char *altdomain, const int port, const char *const tls_policy, const char *const auth_policy)
 {
     // set account name and resource
     const char *barejid = account_name;
@@ -151,6 +151,9 @@ accounts_add(const char *account_name, const char *altdomain, const int port, co
     }
     if (tls_policy) {
         g_key_file_set_string(accounts, account_name, "tls.policy", tls_policy);
+    }
+    if (auth_policy) {
+        g_key_file_set_string(accounts, account_name, "auth.policy", auth_policy);
     }
 
     Jid *jidp = jid_create(barejid);
@@ -326,12 +329,15 @@ accounts_get_account(const char *const name)
             tls_policy = NULL;
         }
 
+        gchar *auth_policy = g_key_file_get_string(accounts, name, "auth.policy", NULL);
+
         ProfAccount *new_account = account_new(name, jid, password, eval_password, enabled,
             server, port, resource, last_presence, login_presence,
             priority_online, priority_chat, priority_away, priority_xa,
             priority_dnd, muc_service, muc_nick, otr_policy, otr_manual,
             otr_opportunistic, otr_always, omemo_policy, omemo_enabled,
-            omemo_disabled,  pgp_keyid, startscript, theme, tls_policy);
+            omemo_disabled,  pgp_keyid, startscript, theme, tls_policy,
+            auth_policy);
 
         g_free(jid);
         g_free(password);
@@ -348,6 +354,7 @@ accounts_get_account(const char *const name)
         g_free(startscript);
         g_free(theme);
         g_free(tls_policy);
+        g_free(auth_policy);
 
         return new_account;
     }
@@ -731,6 +738,15 @@ accounts_set_tls_policy(const char *const account_name, const char *const value)
 {
     if (accounts_account_exists(account_name)) {
         g_key_file_set_string(accounts, account_name, "tls.policy", value);
+        _save_accounts();
+    }
+}
+
+void
+accounts_set_auth_policy(const char *const account_name, const char *const value)
+{
+    if (accounts_account_exists(account_name)) {
+        g_key_file_set_string(accounts, account_name, "auth.policy", value);
         _save_accounts();
     }
 }

--- a/src/config/accounts.h
+++ b/src/config/accounts.h
@@ -48,7 +48,7 @@ char* accounts_find_all(const char *const prefix, gboolean previous, void *conte
 char* accounts_find_enabled(const char *const prefix, gboolean previous, void *context);
 void accounts_reset_all_search(void);
 void accounts_reset_enabled_search(void);
-void accounts_add(const char *jid, const char *altdomain, const int port, const char *const tls_policy);
+void accounts_add(const char *jid, const char *altdomain, const int port, const char *const tls_policy, const char *const auth_policy);
 int  accounts_remove(const char *jid);
 gchar** accounts_get_list(void);
 ProfAccount* accounts_get_account(const char *const name);
@@ -67,6 +67,7 @@ void accounts_set_muc_service(const char *const account_name, const char *const 
 void accounts_set_muc_nick(const char *const account_name, const char *const value);
 void accounts_set_otr_policy(const char *const account_name, const char *const value);
 void accounts_set_tls_policy(const char *const account_name, const char *const value);
+void accounts_set_auth_policy(const char *const account_name, const char *const value);
 void accounts_set_last_presence(const char *const account_name, const char *const value);
 void accounts_set_last_status(const char *const account_name, const char *const value);
 void accounts_set_last_activity(const char *const account_name);

--- a/src/event/client_events.c
+++ b/src/event/client_events.c
@@ -61,10 +61,10 @@
 #endif
 
 jabber_conn_status_t
-cl_ev_connect_jid(const char *const jid, const char *const passwd, const char *const altdomain, const int port, const char *const tls_policy)
+cl_ev_connect_jid(const char *const jid, const char *const passwd, const char *const altdomain, const int port, const char *const tls_policy, const char *const auth_policy)
 {
     cons_show("Connecting as %s", jid);
-    return session_connect_with_details(jid, passwd, altdomain, port, tls_policy);
+    return session_connect_with_details(jid, passwd, altdomain, port, tls_policy, auth_policy);
 }
 
 jabber_conn_status_t

--- a/src/event/client_events.h
+++ b/src/event/client_events.h
@@ -38,7 +38,7 @@
 
 #include "xmpp/xmpp.h"
 
-jabber_conn_status_t cl_ev_connect_jid(const char *const jid, const char *const passwd, const char *const altdomain, const int port, const char *const tls_policy);
+jabber_conn_status_t cl_ev_connect_jid(const char *const jid, const char *const passwd, const char *const altdomain, const int port, const char *const tls_policy, const char *const auth_policy);
 jabber_conn_status_t cl_ev_connect_account(ProfAccount *account);
 
 void cl_ev_disconnect(void);

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -908,6 +908,9 @@ cons_show_account(ProfAccount *account)
     if (account->tls_policy) {
         cons_show   ("TLS policy        : %s", account->tls_policy);
     }
+    if (account->auth_policy) {
+        cons_show   ("Auth policy       : %s", account->auth_policy);
+    }
     if (account->last_presence) {
         cons_show   ("Last presence     : %s", account->last_presence);
     }

--- a/src/xmpp/connection.h
+++ b/src/xmpp/connection.h
@@ -43,7 +43,7 @@ void connection_shutdown(void);
 void connection_check_events(void);
 
 jabber_conn_status_t connection_connect(const char *const fulljid, const char *const passwd, const char *const altdomain, int port,
-    const char *const tls_policy);
+    const char *const tls_policy, const char *const auth_policy);
 void connection_disconnect(void);
 void connection_set_disconnected(void);
 

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -164,7 +164,7 @@ typedef struct prof_message_t {
 
 void session_init(void);
 jabber_conn_status_t session_connect_with_details(const char *const jid, const char *const passwd,
-    const char *const altdomain, const int port, const char *const tls_policy);
+    const char *const altdomain, const int port, const char *const tls_policy, const char *const auth_policy);
 jabber_conn_status_t session_connect_with_account(const ProfAccount *const account);
 void session_disconnect(void);
 void session_shutdown(void);

--- a/tests/unittests/config/stub_accounts.c
+++ b/tests/unittests/config/stub_accounts.c
@@ -128,6 +128,7 @@ void accounts_set_pgp_keyid(const char * const account_name, const char * const 
 void accounts_set_script_start(const char * const account_name, const char * const value) {}
 void accounts_set_theme(const char * const account_name, const char * const value) {}
 void accounts_set_tls_policy(const char * const account_name, const char * const value) {}
+void accounts_set_auth_policy(const char * const account_name, const char * const value) {}
 
 void accounts_set_login_presence(const char * const account_name, const char * const value)
 {

--- a/tests/unittests/test_cmd_account.c
+++ b/tests/unittests/test_cmd_account.c
@@ -33,7 +33,7 @@ void cmd_account_shows_usage_when_not_connected_and_no_args(void **state)
 void cmd_account_shows_account_when_connected_and_no_args(void **state)
 {
     ProfAccount *account = account_new("jabber_org", "me@jabber.org", NULL, NULL,
-        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     gchar *args[] = { NULL };
 
     will_return(connection_get_status, JABBER_CONNECTED);
@@ -93,7 +93,7 @@ void cmd_account_show_shows_account_when_exists(void **state)
 {
     gchar *args[] = { "show", "account_name", NULL };
     ProfAccount *account = account_new("jabber_org", "me@jabber.org", NULL, NULL,
-        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_get_account, name);
     will_return(accounts_get_account, account);
@@ -409,7 +409,7 @@ void cmd_account_set_password_sets_password(void **state)
 {
     gchar *args[] = { "set", "a_account", "password", "a_password", NULL };
     ProfAccount *account = account_new("a_account", NULL, NULL, NULL,
-    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 
     expect_any(accounts_account_exists, account_name);
@@ -432,7 +432,7 @@ void cmd_account_set_eval_password_sets_eval_password(void **state)
 {
     gchar *args[] = { "set", "a_account", "eval_password", "a_password", NULL };
     ProfAccount *account = account_new("a_account", NULL, NULL, NULL,
-    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -453,7 +453,7 @@ void cmd_account_set_eval_password_sets_eval_password(void **state)
 void cmd_account_set_password_when_eval_password_set(void **state) {
     gchar *args[] = { "set", "a_account", "password", "a_password", NULL };
     ProfAccount *account = account_new("a_account", NULL, NULL, "a_password",
-    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -470,7 +470,7 @@ void cmd_account_set_password_when_eval_password_set(void **state) {
 void cmd_account_set_eval_password_when_password_set(void **state) {
     gchar *args[] = { "set", "a_account", "eval_password", "a_password", NULL };
     ProfAccount *account = account_new("a_account", NULL, "a_password", NULL,
-    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -800,7 +800,7 @@ void cmd_account_set_priority_updates_presence_when_account_connected_with_prese
 
 #ifdef HAVE_LIBGPGME
     ProfAccount *account = account_new("a_account", "a_jid", NULL, NULL, TRUE, NULL, 5222, "a_resource",
-        NULL, NULL, 10, 10, 10, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        NULL, NULL, 10, 10, 10, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(session_get_account_name, "a_account");
     expect_any(accounts_get_account, name);

--- a/tests/unittests/test_cmd_connect.c
+++ b/tests/unittests/test_cmd_connect.c
@@ -116,7 +116,7 @@ void cmd_connect_lowercases_argument_with_account(void **state)
 {
 gchar *args[] = { "Jabber_org", NULL };
     ProfAccount *account = account_new("Jabber_org", "me@jabber.org", "password", NULL,
-        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 
@@ -136,7 +136,7 @@ void cmd_connect_asks_password_when_not_in_account(void **state)
 {
     gchar *args[] = { "jabber_org", NULL };
     ProfAccount *account = account_new("jabber_org", "me@jabber.org", NULL, NULL,
-        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 
@@ -383,7 +383,7 @@ void cmd_connect_shows_message_when_connecting_with_account(void **state)
 {
     gchar *args[] = { "jabber_org", NULL };
     ProfAccount *account = account_new("jabber_org", "user@jabber.org", "password", NULL,
-        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 
@@ -403,7 +403,7 @@ void cmd_connect_connects_with_account(void **state)
 {
     gchar *args[] = { "jabber_org", NULL };
     ProfAccount *account = account_new("jabber_org", "me@jabber.org", "password", NULL,
-        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 

--- a/tests/unittests/test_cmd_join.c
+++ b/tests/unittests/test_cmd_join.c
@@ -65,7 +65,7 @@ void cmd_join_uses_account_mucservice_when_no_service_specified(void **state)
     char *expected_room = "room@conference.server.org";
     gchar *args[] = { room, "nick", nick, NULL };
     ProfAccount *account = account_new(account_name, "user@server.org", NULL, NULL,
-        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 
@@ -92,7 +92,7 @@ void cmd_join_uses_supplied_nick(void **state)
     char *nick = "bob";
     gchar *args[] = { room, "nick", nick, NULL };
     ProfAccount *account = account_new(account_name, "user@server.org", NULL, NULL,
-        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 
@@ -119,7 +119,7 @@ void cmd_join_uses_account_nick_when_not_supplied(void **state)
     char *account_nick = "a_nick";
     gchar *args[] = { room, NULL };
     ProfAccount *account = account_new(account_name, "user@server.org", NULL, NULL,
-        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 
@@ -149,7 +149,7 @@ void cmd_join_uses_password_when_supplied(void **state)
     char *expected_room = "room@a_service";
     gchar *args[] = { room, "password", password, NULL };
     ProfAccount *account = account_new(account_name, "user@server.org", NULL, NULL,
-        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 

--- a/tests/unittests/test_cmd_otr.c
+++ b/tests/unittests/test_cmd_otr.c
@@ -182,7 +182,7 @@ void cmd_otr_gen_generates_key_for_connected_account(void **state)
     gchar *args[] = { "gen", NULL };
     char *account_name = "myaccount";
     ProfAccount *account = account_new(account_name, "me@jabber.org", NULL, NULL,
-        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_CONNECTED);
     will_return(session_get_account_name, account_name);

--- a/tests/unittests/test_cmd_rooms.c
+++ b/tests/unittests/test_cmd_rooms.c
@@ -46,7 +46,7 @@ void cmd_rooms_uses_account_default_when_no_arg(void **state)
     gchar *args[] = { NULL };
 
     ProfAccount *account = account_new("testaccount", NULL, NULL, NULL, TRUE, NULL, 0, NULL, NULL, NULL,
-        0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_CONNECTED);
     will_return(session_get_account_name, "account_name");
@@ -85,7 +85,7 @@ void cmd_rooms_filter_arg_used_when_passed(void **state)
 
 
     ProfAccount *account = account_new("testaccount", NULL, NULL, NULL, TRUE, NULL, 0, NULL, NULL, NULL,
-        0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_CONNECTED);
     will_return(session_get_account_name, "account_name");

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -11,7 +11,8 @@ void session_init_activity(void) {}
 void session_check_autoaway(void) {}
 
 jabber_conn_status_t session_connect_with_details(const char * const jid,
-    const char * const passwd, const char * const altdomain, const int port, const char *const tls_policy)
+    const char * const passwd, const char * const altdomain, const int port, const char *const tls_policy,
+    const char *const auth_policy)
 {
     check_expected(jid);
     check_expected(passwd);


### PR DESCRIPTION
New options:
  /connect <account> [auth default|legacy]
  /account <account> set auth default|legacy

Fixes #1236.