### PR TITLE
Make legacy auth optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,11 +129,20 @@ CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 AS_IF([test "x$PTHREAD_CC" != x], [ CC="$PTHREAD_CC" ])
 
 ### Check for libmesode, fall back to libstrophe
+### TODO libmesode support will be removed in the future, rewrite this section
 PKG_CHECK_MODULES([libmesode], [libmesode >= 0.9.3],
     [LIBS="$libmesode_LIBS $LIBS" CFLAGS="$CFLAGS $libmesode_CFLAGS" XMPP_LIB="libmesode" AC_DEFINE([HAVE_LIBMESODE], [1], [libmesode])],
     [PKG_CHECK_MODULES([libstrophe], [libstrophe >= 0.9.3],
         [LIBS="$libstrophe_LIBS $LIBS" CFLAGS="$CFLAGS $libstrophe_CFLAGS" XMPP_LIB="libstrophe" AC_DEFINE([HAVE_LIBSTROPHE], [1], [libstrophe])],
-        [AC_MSG_ERROR([Neither libmesode or libstrophe in version >= 0.9.3 found, either is required for profanity])])])
+        [XMPP_LIB=""])])
+if test "x$XMPP_LIB" = x; then
+    PKG_CHECK_MODULES([libmesode], [libmesode >= 0.9.2],
+        [LIBS="$libmesode_LIBS $LIBS" CFLAGS="$CFLAGS $libmesode_CFLAGS" XMPP_LIB="libmesode" AC_DEFINE([HAVE_LIBMESODE], [1], [libmesode])],
+        [PKG_CHECK_MODULES([libstrophe], [libstrophe >= 0.9.2],
+            [LIBS="$libstrophe_LIBS $LIBS" CFLAGS="$CFLAGS $libstrophe_CFLAGS" XMPP_LIB="libstrophe" AC_DEFINE([HAVE_LIBSTROPHE], [1], [libstrophe])],
+            [AC_MSG_ERROR([libstrophe-0.9.2 or later is required for profanity])])])
+    AC_DEFINE([HAVE_LIBSTROPHE_LT_0_9_3], [1], [Old libstrophe is present])
+fi
 
 AC_MSG_CHECKING([whether ${XMPP_LIB} works])
 AC_LINK_IFELSE([AC_LANG_SOURCE([[

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -59,6 +59,7 @@
 #include "xmpp/connection.h"
 #include "xmpp/session.h"
 #include "xmpp/iq.h"
+#include "ui/ui.h"
 
 typedef struct prof_conn_t {
     xmpp_log_t *xmpp_log;
@@ -191,7 +192,13 @@ connection_connect(const char *const jid, const char *const passwd, const char *
     }
 
     if (auth_policy && (g_strcmp0(auth_policy, "legacy") == 0)) {
+#ifdef HAVE_LIBSTROPHE_LT_0_9_3
+        log_warning("Legacy authentication is requested, but it hasn't been "
+                    "built. Update libstrophe and rebuild Profanity.");
+        cons_show("Legacy authentication is requested, but it hasn't been built.");
+#else
         flags |= XMPP_CONN_FLAG_LEGACY_AUTH;
+#endif /* HAVE_LIBSTROPHE_LT_0_9_3 */
     }
 
     xmpp_conn_set_flags(conn.xmpp_conn, flags);
@@ -204,7 +211,9 @@ connection_connect(const char *const jid, const char *const passwd, const char *
         LOG_FLAG_IF_SET(XMPP_CONN_FLAG_TRUST_TLS);
         LOG_FLAG_IF_SET(XMPP_CONN_FLAG_DISABLE_TLS);
         LOG_FLAG_IF_SET(XMPP_CONN_FLAG_LEGACY_SSL);
+#ifndef HAVE_LIBSTROPHE_LT_0_9_3
         LOG_FLAG_IF_SET(XMPP_CONN_FLAG_LEGACY_AUTH);
+#endif /* HAVE_LIBSTROPHE_LT_0_9_3 */
 #undef LOG_FLAG_IF_SET
     }
 


### PR DESCRIPTION
Some systems don't provide recent libstrophe releases. When older
version of libstrophe is detected, don't build legacy auth support.

To simplify this patch, report about unsupported legacy auth and
keep commands option as is.

/!\ This patch adds `ui/ui.h`. Is it ok?