### PR TITLE
Fix gcc warnings for cygwin

### DIFF
--- a/src/ui/notifier.c
+++ b/src/ui/notifier.c
@@ -234,20 +234,21 @@ notify(const char *const message, int timeout, const char *const category)
 #endif
 #ifdef PLATFORM_CYGWIN
     NOTIFYICONDATA nid;
+    memset(&nid, 0, sizeof(nid));
     nid.cbSize = sizeof(NOTIFYICONDATA);
     //nid.hWnd = hWnd;
     nid.uID = 100;
     nid.uVersion = NOTIFYICON_VERSION;
     //nid.uCallbackMessage = WM_MYMESSAGE;
     nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
-    strncpy(nid.szTip, "Tray Icon", 10);
+    strcpy(nid.szTip, "Tray Icon");
     nid.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
     Shell_NotifyIcon(NIM_ADD, &nid);
 
     // For a Ballon Tip
     nid.uFlags = NIF_INFO;
-    strncpy(nid.szInfoTitle, "Profanity", 10); // Title
-    strncpy(nid.szInfo, message, 256); // Copy Tip
+    strcpy(nid.szInfoTitle, "Profanity"); // Title
+    strncpy(nid.szInfo, message, sizeof(nid.szInfo) - 1); // Copy Tip
     nid.uTimeout = timeout;  // 3 Seconds
     nid.dwInfoFlags = NIIF_INFO;
 


### PR DESCRIPTION
strncpy(3) is not so safe function and can lead to mistakes. For
example, strncpy(dest, "Profanity", 10); is redundant and leads to
problems when someone changes the source string.

Different example is when 3rd argument equals to length of the
destination buffer. strncpy(3) doesn't terminate string with '\0' when
it truncates. Therefore, the destination string becomes corrupted.

Zeroize storage for 'nid', so the last byte remains '\0' in case of
truncate.