### PR TITLE
Rework /url and /executable for filetypes

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -123,7 +123,7 @@ static char* _avatar_autocomplete(ProfWin *window, const char *const input, gboo
 static char* _correction_autocomplete(ProfWin *window, const char *const input, gboolean previous);
 static char* _correct_autocomplete(ProfWin *window, const char *const input, gboolean previous);
 static char* _software_autocomplete(ProfWin *window, const char *const input, gboolean previous);
-static char* _urlopen_autocomplete(ProfWin *window, const char *const input, gboolean previous);
+static char* _url_autocomplete(ProfWin *window, const char *const input, gboolean previous);
 static char* _executable_autocomplete(ProfWin *window, const char *const input, gboolean previous);
 
 static char* _script_autocomplete_func(const char *const prefix, gboolean previous, void *context);
@@ -259,6 +259,7 @@ static Autocomplete logging_group_ac;
 static Autocomplete color_ac;
 static Autocomplete correction_ac;
 static Autocomplete avatar_ac;
+static Autocomplete url_ac;
 static Autocomplete executable_ac;
 
 void
@@ -1007,9 +1008,14 @@ cmd_ac_init(void)
     autocomplete_add(avatar_ac, "get");
     autocomplete_add(avatar_ac, "open");
 
+    url_ac = autocomplete_new();
+    autocomplete_add(url_ac, "open");
+    autocomplete_add(url_ac, "save");
+
     executable_ac = autocomplete_new();
     autocomplete_add(executable_ac, "avatar");
     autocomplete_add(executable_ac, "urlopen");
+    autocomplete_add(executable_ac, "urlsave");
 }
 
 void
@@ -1328,6 +1334,7 @@ cmd_ac_reset(ProfWin *window)
     autocomplete_reset(color_ac);
     autocomplete_reset(correction_ac);
     autocomplete_reset(avatar_ac);
+    autocomplete_reset(url_ac);
     autocomplete_reset(executable_ac);
 
     autocomplete_reset(script_ac);
@@ -1489,6 +1496,7 @@ cmd_ac_uninit(void)
     autocomplete_free(color_ac);
     autocomplete_free(correction_ac);
     autocomplete_free(avatar_ac);
+    autocomplete_free(url_ac);
     autocomplete_free(executable_ac);
 }
 
@@ -1749,7 +1757,7 @@ _cmd_ac_complete_params(ProfWin *window, const char *const input, gboolean previ
     g_hash_table_insert(ac_funcs, "/correction",    _correction_autocomplete);
     g_hash_table_insert(ac_funcs, "/correct",       _correct_autocomplete);
     g_hash_table_insert(ac_funcs, "/software",      _software_autocomplete);
-    g_hash_table_insert(ac_funcs, "/urlopen",       _urlopen_autocomplete);
+    g_hash_table_insert(ac_funcs, "/url",           _url_autocomplete);
     g_hash_table_insert(ac_funcs, "/executable",    _executable_autocomplete);
 
     int len = strlen(input);
@@ -4036,14 +4044,24 @@ _software_autocomplete(ProfWin *window, const char *const input, gboolean previo
 }
 
 static char*
-_urlopen_autocomplete(ProfWin *window, const char *const input, gboolean previous)
+_url_autocomplete(ProfWin *window, const char *const input, gboolean previous)
 {
     char *result = NULL;
+
+    result = autocomplete_param_with_ac(input, "/url", url_ac, TRUE, previous);
+    if (result) {
+        return result;
+    }
 
 	if (window->type == WIN_CHAT ||
         window->type == WIN_MUC ||
         window->type == WIN_PRIVATE) {
-        result = autocomplete_param_with_func(input, "/urlopen", wins_get_url, previous, window);
+        result = autocomplete_param_with_func(input, "/url open", wins_get_url, previous, window);
+        if (result) {
+            return result;
+        }
+
+        result = autocomplete_param_with_func(input, "/url save", wins_get_url, previous, window);
     }
 
     return result;

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2472,15 +2472,15 @@ static struct cmd_t command_defs[] =
             CMD_TAG_DISCOVERY)
         CMD_SYN(
             "/executable avatar <cmd>",
-            "/executable urlopen <fileType> <require_save> <cmd>",
-            "/executable urlsave <protocol> <cmd>")
+            "/executable urlopen (<fileType>|*) <require_save> <cmd>",
+            "/executable urlsave (<protocol>|*) <cmd>")
         CMD_DESC(
             "Configure executable that should be called upon a certain command."
             "Default is xdg-open.")
         CMD_ARGS(
             { "avatar", "Set executable that is run in /avatar open. Use your favourite image viewer." },
-            { "urlopen", "Set executable that is run in /url open for a given file type. It may be your favorite browser or a specific viewer." },
-            { "urlsave", "Set executable that is run in /url save for a given protocol. Use your favourite downloader."})
+            { "urlopen", "Set executable that is run in /url open for a given file type. It may be your favorite browser or a specific viewer. Use * to set default command for undefined file type." },
+            { "urlsave", "Set executable that is run in /url save for a given protocol. Use your favourite downloader. Use * to set default command for undefined protocol."})
         CMD_EXAMPLES(
             "/executable avatar xdg-open",
             "/executable urlopen html false \"firefox %u\"",

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2464,40 +2464,49 @@ static struct cmd_t command_defs[] =
             "/software xmpp.vanaheimr.edda")
     },
 
-    { "/urlopen",
-        parse_args, 1, -1, NULL,
-        CMD_NOSUBFUNCS
-        CMD_MAINFUNC(cmd_urlopen)
-        CMD_TAGS(
-            CMD_TAG_CHAT,
-            CMD_TAG_GROUPCHAT)
-        CMD_SYN(
-            "/urlopen <url>")
-        CMD_DESC(
-            "Open the URL")
-        CMD_ARGS(
-            { "<url>",    "URL to open."})
-        CMD_NOEXAMPLES
-    },
-
     { "/executable",
-        parse_args, 2, 2, &cons_executable_setting,
+        parse_args, 2, 4, &cons_executable_setting,
         CMD_NOSUBFUNCS
         CMD_MAINFUNC(cmd_executable)
         CMD_TAGS(
             CMD_TAG_DISCOVERY)
         CMD_SYN(
             "/executable avatar <cmd>",
-            "/executable urlopen <cmd>")
+            "/executable urlopen <fileType> <require_save> <cmd>",
+            "/executable urlsave <protocol> <cmd>")
         CMD_DESC(
             "Configure executable that should be called upon a certain command."
             "Default is xdg-open.")
         CMD_ARGS(
             { "avatar", "Set executable that is run in /avatar open. Use your favourite image viewer." },
-            { "urlopen", "Set executable that is run in /urlopen. Use your favourite browser." })
+            { "urlopen", "Set executable that is run in /url open for a given file type. It may be your favorite browser or a specific viewer." },
+            { "urlsave", "Set executable that is run in /url save for a given protocol. Use your favourite downloader."})
         CMD_EXAMPLES(
             "/executable avatar xdg-open",
-            "/executable urlopen firefox")
+            "/executable urlopen html firefox %u",
+            "/executable urlsave aesgcm omut -d %u %p")
+    },
+
+    { "/url",
+        parse_args, 2, 3, NULL,
+        CMD_SUBFUNCS(
+            { "open", cmd_url_open},
+            { "save", cmd_url_save })
+        CMD_NOMAINFUNC
+        CMD_TAGS(
+            CMD_TAG_CHAT,
+            CMD_TAG_GROUPCHAT)
+        CMD_SYN(
+            "/url open <url>",
+            "/url save <url> [<path>]")
+        CMD_DESC(
+            "Deal with URLs")
+        CMD_ARGS(
+            { "open", "Open URL with predefined executable." },
+            { "save", "Save URL to optional path, default path is current directory"})
+        CMD_EXAMPLES(
+            "/url open https://profanity-im.github.io",
+            "/url save https://profanity-im.github.io/guide/latest/userguide.html /home/user/Download/")
     },
 };
 

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2483,8 +2483,8 @@ static struct cmd_t command_defs[] =
             { "urlsave", "Set executable that is run in /url save for a given protocol. Use your favourite downloader."})
         CMD_EXAMPLES(
             "/executable avatar xdg-open",
-            "/executable urlopen html firefox %u",
-            "/executable urlsave aesgcm omut -d %u %p")
+            "/executable urlopen html false \"firefox %u\"",
+            "/executable urlsave aesgcm \"omut -d %u %p\"")
     },
 
     { "/url",

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2472,17 +2472,18 @@ static struct cmd_t command_defs[] =
             CMD_TAG_DISCOVERY)
         CMD_SYN(
             "/executable avatar <cmd>",
-            "/executable urlopen (<fileType>|*) <require_save> <cmd>",
-            "/executable urlsave (<protocol>|*) <cmd>")
+            "/executable urlopen (<fileType>|DEF <require_save> <cmd>",
+            "/executable urlsave (<protocol>|DEF) <cmd>")
         CMD_DESC(
             "Configure executable that should be called upon a certain command."
             "Default is xdg-open.")
         CMD_ARGS(
             { "avatar", "Set executable that is run in /avatar open. Use your favourite image viewer." },
-            { "urlopen", "Set executable that is run in /url open for a given file type. It may be your favorite browser or a specific viewer. Use * to set default command for undefined file type." },
-            { "urlsave", "Set executable that is run in /url save for a given protocol. Use your favourite downloader. Use * to set default command for undefined protocol."})
+            { "urlopen", "Set executable that is run in /url open for a given file type. It may be your favorite browser or a specific viewer. Use DEF to set default command for undefined file type." },
+            { "urlsave", "Set executable that is run in /url save for a given protocol. Use your favourite downloader. Use DEF to set default command for undefined protocol."})
         CMD_EXAMPLES(
             "/executable avatar xdg-open",
+            "/executable urlopen DEF false \"xdg-open %u\"",
             "/executable urlopen html false \"firefox %u\"",
             "/executable urlsave aesgcm \"omut -d %u %p\"")
     },

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -8955,8 +8955,6 @@ cmd_url_open(ProfWin *window, const char *const command, gchar **args)
 
     gboolean require_save = false;
 
-    char *suffix_cmd = NULL;
-    char *suffix = NULL;
     gchar *fileStart = g_strrstr(args[1], "/");
     if (fileStart == NULL) {
         cons_show("URL '%s' is not valid.", args[1]);
@@ -8972,6 +8970,8 @@ cmd_url_open(ProfWin *window, const char *const command, gchar **args)
       // fileStart is set to the end of the URL.
       fileStart = args[1] + strlen(args[1]);
     }
+
+    gchar *suffix = NULL;
     gchar *suffixStart = g_strrstr(fileStart, ".");
     if (suffixStart != NULL) {
         suffixStart++;
@@ -8989,17 +8989,15 @@ cmd_url_open(ProfWin *window, const char *const command, gchar **args)
         g_strfreev(suffix_cmd_pref);
         suffix_cmd_pref = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, lowercase_suffix);
         g_free(lowercase_suffix);
-        lowercase_suffix = NULL;
         g_free(suffix);
-        suffix = NULL;
     }
 
     if (0 == g_strcmp0(suffix_cmd_pref[0], "true")) {
         require_save = true;
     }
-    suffix_cmd = g_strdup(suffix_cmd_pref[1]);
+
+    gchar *suffix_cmd = g_strdup(suffix_cmd_pref[1]);
     g_strfreev(suffix_cmd_pref);
-    suffix_cmd_pref = NULL;
 
     gchar *scheme = g_uri_parse_scheme(args[1]);
     if( 0 == g_strcmp0(scheme, "aesgcm")) {
@@ -9118,11 +9116,9 @@ cmd_url_save(ProfWin *window, const char *const command, gchar **args)
     }
 
     g_free(scheme);
-    scheme = NULL;
 
     gchar **argv = g_strsplit(scheme_cmd, " ", 0);
     g_free(scheme_cmd);
-    scheme_cmd = NULL;
 
     guint num_args = 0;
     while (argv[num_args]) {

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -8939,26 +8939,26 @@ cmd_slashguard(ProfWin *window, const char *const command, gchar **args)
 gboolean
 cmd_urlopen(ProfWin *window, const char *const command, gchar **args)
 {
-	if (window->type == WIN_CHAT ||
-        window->type == WIN_MUC ||
-        window->type == WIN_PRIVATE) {
-
-        if (args[0] == NULL) {
-            cons_bad_cmd_usage(command);
-            return TRUE;
-        }
-
-        gchar* cmd = prefs_get_string(PREF_URL_OPEN_CMD);
-        gchar *argv[] = {cmd, args[0], NULL};
-
-        if (!call_external(argv, NULL, NULL)) {
-          cons_show_error("Unable to open url: check the logs for more information.");
-        }
-
-        g_free(cmd);
-    } else {
+    if (window->type != WIN_CHAT &&
+        window->type != WIN_MUC &&
+        window->type != WIN_PRIVATE) {
         cons_show("urlopen not supported in this window");
+        return TRUE;
     }
+
+    if (args[0] == NULL) {
+        cons_bad_cmd_usage(command);
+        return TRUE;
+    }
+
+    gchar* cmd = prefs_get_string(PREF_URL_OPEN_CMD);
+    gchar *argv[] = {cmd, args[0], NULL};
+
+    if (!call_external(argv, NULL, NULL)) {
+      cons_show_error("Unable to open url: check the logs for more information.");
+    }
+
+    g_free(cmd);
 
     return TRUE;
 }

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9138,6 +9138,8 @@ cmd_url_save(ProfWin *window, const char *const command, gchar **args)
 
     if (!call_external(argv, NULL, NULL)) {
         cons_show_error("Unable to save url: check the logs for more information.");
+    } else {
+        cons_show("URL '%s' has been saved into '%s'.", uri, target_path);
     }
 
     g_free(target_dir);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9156,12 +9156,22 @@ cmd_executable(ProfWin *window, const char *const command, gchar **args)
         prefs_set_string(PREF_AVATAR_CMD, args[1]);
         cons_show("Avatar command set to: %s", args[1]);
     } else if (g_strcmp0(args[0], "urlopen") == 0) {
+        if (g_strv_length(args) < 4) {
+            cons_bad_cmd_usage(command);
+            return TRUE;
+        }
+
         char *str = g_strjoinv(" ", &args[3]);
         const gchar* const list[] = {args[2], str, NULL};
         prefs_set_string_list_with_option(PREF_URL_OPEN_CMD, args[1], list);
         cons_show("`url open` command set to: %s for %s files", str, args[1]);
         g_free(str);
     } else if (g_strcmp0(args[0], "urlsave") == 0) {
+        if (g_strv_length(args) < 3) {
+            cons_bad_cmd_usage(command);
+            return TRUE;
+        }
+
         char *str = g_strjoinv(" ", &args[2]);
         prefs_set_string_with_option(PREF_URL_SAVE_CMD, args[1], str);
         cons_show("`url save` command set to: %s for scheme %s", str, args[1]);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -8983,7 +8983,7 @@ cmd_url_open(ProfWin *window, const char *const command, gchar **args)
         }
     }
 
-    char **suffix_cmd_pref = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, NULL);
+    gchar **suffix_cmd_pref = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, NULL);
     if (suffix != NULL) {
         gchar *lowercase_suffix = g_ascii_strdown(suffix, -1);
         g_strfreev(suffix_cmd_pref);
@@ -9158,7 +9158,7 @@ cmd_executable(ProfWin *window, const char *const command, gchar **args)
             return TRUE;
         }
 
-        char *str = g_strjoinv(" ", &args[3]);
+        gchar *str = g_strjoinv(" ", &args[3]);
         const gchar* const list[] = {args[2], str, NULL};
         prefs_set_string_list_with_option(PREF_URL_OPEN_CMD, args[1], list);
         cons_show("`url open` command set to: %s for %s files", str, args[1]);
@@ -9169,7 +9169,7 @@ cmd_executable(ProfWin *window, const char *const command, gchar **args)
             return TRUE;
         }
 
-        char *str = g_strjoinv(" ", &args[2]);
+        gchar *str = g_strjoinv(" ", &args[2]);
         prefs_set_string_with_option(PREF_URL_SAVE_CMD, args[1], str);
         cons_show("`url save` command set to: %s for scheme %s", str, args[1]);
         g_free(str);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9003,6 +9003,7 @@ cmd_url_open(ProfWin *window, const char *const command, gchar **args)
     if( 0 == g_strcmp0(scheme, "aesgcm")) {
         require_save = true;
     }
+    g_free(scheme);
 
     if (require_save) {
         gchar *save_args[] = { "open", args[1], "/tmp/profanity.tmp", NULL};

--- a/src/command/cmd_funcs.h
+++ b/src/command/cmd_funcs.h
@@ -233,7 +233,8 @@ gboolean cmd_correction(ProfWin *window, const char *const command, gchar **args
 gboolean cmd_correct(ProfWin *window, const char *const command, gchar **args);
 gboolean cmd_slashguard(ProfWin *window, const char *const command, gchar **args);
 gboolean cmd_serversoftware(ProfWin *window, const char *const command, gchar **args);
-gboolean cmd_urlopen(ProfWin *window, const char *const command, gchar **args);
+gboolean cmd_url_open(ProfWin *window, const char *const command, gchar **args);
+gboolean cmd_url_save(ProfWin *window, const char *const command, gchar **args);
 gboolean cmd_executable(ProfWin *window, const char *const command, gchar **args);
 
 #endif

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -64,6 +64,7 @@
 #define PREF_GROUP_OMEMO "omemo"
 #define PREF_GROUP_MUC "muc"
 #define PREF_GROUP_PLUGINS "plugins"
+#define PREF_GROUP_EXECUTABLES "executables"
 
 #define INPBLOCK_DEFAULT 1000
 
@@ -1855,9 +1856,11 @@ _get_group(preference_t pref)
         case PREF_GRLOG:
         case PREF_LOG_ROTATE:
         case PREF_LOG_SHARED:
+            return PREF_GROUP_LOGGING;
         case PREF_AVATAR_CMD:
         case PREF_URL_OPEN_CMD:
-            return PREF_GROUP_LOGGING;
+        case PREF_URL_SAVE_CMD:
+            return PREF_GROUP_EXECUTABLES;
         case PREF_AUTOAWAY_CHECK:
         case PREF_AUTOAWAY_MODE:
         case PREF_AUTOAWAY_MESSAGE:
@@ -2147,7 +2150,9 @@ _get_key(preference_t pref)
         case PREF_MAM:
             return "mam";
         case PREF_URL_OPEN_CMD:
-            return "urlopen.cmd";
+            return "url.open.cmd";
+        case PREF_URL_SAVE_CMD:
+            return "url.save.cmd";
         default:
             return NULL;
     }
@@ -2284,8 +2289,9 @@ _get_default_string(preference_t pref)
         case PREF_COLOR_NICK:
             return "false";
         case PREF_AVATAR_CMD:
-        case PREF_URL_OPEN_CMD:
             return "xdg-open";
+        case PREF_URL_SAVE_CMD:
+            return "curl -o %p %u";
         default:
             return NULL;
     }
@@ -2296,8 +2302,15 @@ _get_default_string(preference_t pref)
 static char**
 _get_default_string_list(preference_t pref)
 {
+    char **str_array = NULL;
+
     switch (pref)
     {
+        case PREF_URL_OPEN_CMD:
+            str_array = g_malloc0(3);
+            str_array[0] = g_strdup("false");
+            str_array[1] = g_strdup("xdg-open %u");
+            return str_array;
         default:
             return NULL;
     }

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -537,13 +537,10 @@ prefs_get_string_list_with_option(preference_t pref, gchar *option)
     }
 }
 
-
 void
 prefs_free_string(char *pref)
 {
-    if (pref) {
-        g_free(pref);
-    }
+    g_free(pref);
 }
 
 void

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -526,14 +526,19 @@ prefs_get_string_with_option(preference_t pref, gchar *option)
     char *result = g_key_file_get_locale_string(prefs, group, key, option, NULL);
 
     if (result == NULL) {
-        if (def) {
-            return g_strdup(def);
-        } else {
-            return NULL;
+        // check for user set default
+        result = g_key_file_get_locale_string(prefs, group, key, "DEF", NULL);
+        if (result == NULL) {
+            if (def) {
+                // use hardcoded profanity default
+                return g_strdup(def);
+            } else {
+                return NULL;
+            }
         }
-    } else {
-        return result;
     }
+
+    return result;
 }
 
 gchar**

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -161,6 +161,20 @@ static void _prefs_load(void)
         }
     }
 
+    // 0.9.0 introduced /urlopen. It was saved under "logging" section. Now we have a new "executables" section.
+    if (g_key_file_has_key(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL)) {
+        char *value = g_key_file_get_string(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL);
+        g_key_file_set_string(prefs, PREF_GROUP_EXECUTABLES, "url.open.cmd", value);
+        g_key_file_remove_key(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL);
+    }
+
+    // 0.9.0 introduced configurable /avatar. It was saved under "logging" section. Now we have a new "executables" section.
+    if (g_key_file_has_key(prefs, PREF_GROUP_LOGGING, "avatar.cmd", NULL)) {
+        char *value = g_key_file_get_string(prefs, PREF_GROUP_LOGGING, "avatar.cmd", NULL);
+        g_key_file_set_string(prefs, PREF_GROUP_EXECUTABLES, "avatar.cmd", value);
+        g_key_file_remove_key(prefs, PREF_GROUP_LOGGING, "avatar.cmd", NULL);
+    }
+
     _save_prefs();
 
     boolean_choice_ac = autocomplete_new();

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -537,17 +537,22 @@ prefs_get_string_list_with_option(preference_t pref, gchar *option)
     char **def = _get_default_string_list(pref);
 
     gchar **result = g_key_file_get_locale_string_list(prefs, group, key, option, NULL, NULL);
-
-    if (result == NULL) {
-        if (def) {
-            return def;
-        } else {
-            g_strfreev(def);
-            return NULL;
-        }
-    } else {
+    if (result) {
         g_strfreev(def);
         return result;
+    }
+
+    result = g_key_file_get_string_list(prefs, group, key, NULL, NULL);
+    if (result) {
+        g_strfreev(def);
+        return result;
+    }
+
+    if (def) {
+        return def;
+    } else {
+        g_strfreev(def);
+        return NULL;
     }
 }
 
@@ -587,13 +592,21 @@ prefs_set_string_list_with_option(preference_t pref, char *option, const gchar* 
     const char *group = _get_group(pref);
     const char *key = _get_key(pref);
     if (values == NULL || *values == NULL){
-        g_key_file_set_locale_string_list(prefs, group, key, option, NULL, 0);
+        if (g_strcmp0(option, "*") == 0) {
+            g_key_file_set_string_list(prefs, group, key, NULL, 0);
+        } else {
+            g_key_file_set_locale_string_list(prefs, group, key, option, NULL, 0);
+        }
     } else {
         guint num_values = 0;
         while(values[num_values]) {
-          num_values++;
+            num_values++;
         }
-        g_key_file_set_locale_string_list(prefs, group, key, option, values, num_values);
+        if (g_strcmp0(option, "*") == 0) {
+            g_key_file_set_string_list(prefs, group, key, values, num_values);
+        } else {
+            g_key_file_set_locale_string_list(prefs, group, key, option, values, num_values);
+        }
     }
 }
 

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -536,7 +536,7 @@ prefs_get_string_with_option(preference_t pref, gchar *option)
     }
 }
 
-char**
+gchar**
 prefs_get_string_list_with_option(preference_t pref, gchar *option)
 {
     const char *group = _get_group(pref);

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -169,7 +169,7 @@ static void _prefs_load(void)
         value = g_string_append(value, val);
         value = g_string_append(value, " %u;");
 
-        g_key_file_set_string(prefs, PREF_GROUP_EXECUTABLES, "url.open.cmd", value->str);
+        g_key_file_set_locale_string(prefs, PREF_GROUP_EXECUTABLES, "url.open.cmd", "DEF", value->str);
         g_key_file_remove_key(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL);
 
         g_string_free(value, TRUE);

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -163,9 +163,16 @@ static void _prefs_load(void)
 
     // 0.9.0 introduced /urlopen. It was saved under "logging" section. Now we have a new "executables" section.
     if (g_key_file_has_key(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL)) {
-        char *value = g_key_file_get_string(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL);
-        g_key_file_set_string(prefs, PREF_GROUP_EXECUTABLES, "url.open.cmd", value);
+        char *val = g_key_file_get_string(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL);
+
+        GString *value = g_string_new("false;");
+        value = g_string_append(value, val);
+        value = g_string_append(value, " %u;");
+
+        g_key_file_set_string(prefs, PREF_GROUP_EXECUTABLES, "url.open.cmd", value->str);
         g_key_file_remove_key(prefs, PREF_GROUP_LOGGING, "urlopen.cmd", NULL);
+
+        g_string_free(value, TRUE);
     }
 
     // 0.9.0 introduced configurable /avatar. It was saved under "logging" section. Now we have a new "executables" section.

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -172,6 +172,7 @@ typedef enum {
     PREF_SLASH_GUARD,
     PREF_MAM,
     PREF_URL_OPEN_CMD,
+    PREF_URL_SAVE_CMD,
 } preference_t;
 
 typedef struct prof_alias_t {

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -316,7 +316,7 @@ gboolean prefs_get_boolean(preference_t pref);
 void prefs_set_boolean(preference_t pref, gboolean value);
 char* prefs_get_string(preference_t pref);
 char* prefs_get_string_with_option(preference_t pref, gchar *option);
-char **prefs_get_string_list_with_option(preference_t pref, gchar *option);
+gchar **prefs_get_string_list_with_option(preference_t pref, gchar *option);
 void prefs_free_string(char *pref);
 void prefs_set_string(preference_t pref, char *value);
 void prefs_set_string_with_option(preference_t pref, char *option, char *value);

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -314,8 +314,12 @@ void prefs_save_win_placement(ProfWinPlacement *placement);
 gboolean prefs_get_boolean(preference_t pref);
 void prefs_set_boolean(preference_t pref, gboolean value);
 char* prefs_get_string(preference_t pref);
+char* prefs_get_string_with_option(preference_t pref, gchar *option);
+char **prefs_get_string_list_with_option(preference_t pref, gchar *option);
 void prefs_free_string(char *pref);
 void prefs_set_string(preference_t pref, char *value);
+void prefs_set_string_with_option(preference_t pref, char *option, char *value);
+void prefs_set_string_list_with_option(preference_t pref, char *option, const gchar* const *values);
 
 char* prefs_get_tls_certpath(void);
 

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2067,12 +2067,16 @@ void
 cons_executable_setting(void)
 {
     char *avatar = prefs_get_string(PREF_AVATAR_CMD);
-    cons_show("Avatar command (/executable avatar)                                   : %s", avatar);
-    prefs_free_string(avatar);
+    cons_show("'/avatar' command (/executable avatar)                                   : %s", avatar);
+    g_free(avatar);
 
-    char *exec = prefs_get_string(PREF_URL_OPEN_CMD);
-    cons_show("urlopen command (/executable urlopen)                                 : %s", exec);
-    prefs_free_string(exec);
+    char **urlopen = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, "");
+    cons_show("Default '/url open' command (/executable urlopen)                        : %s", urlopen[1]);
+    g_strfreev(urlopen);
+
+    char *urlsave = prefs_get_string(PREF_URL_SAVE_CMD);
+    cons_show("Default '/url save' command (/executable urlsave)                        : %s", urlsave);
+    g_free(urlsave);
 }
 
 void

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2067,7 +2067,7 @@ void
 cons_executable_setting(void)
 {
     char *avatar = prefs_get_string(PREF_AVATAR_CMD);
-    cons_show("'/avatar' command (/executable avatar)                                   : %s", avatar);
+    cons_show("Default '/avatar open' command (/executable avatar)                      : %s", avatar);
     prefs_free_string(avatar);
 
     char **urlopen = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, "");

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2068,7 +2068,7 @@ cons_executable_setting(void)
 {
     char *avatar = prefs_get_string(PREF_AVATAR_CMD);
     cons_show("'/avatar' command (/executable avatar)                                   : %s", avatar);
-    g_free(avatar);
+    prefs_free_string(avatar);
 
     char **urlopen = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, "");
     cons_show("Default '/url open' command (/executable urlopen)                        : %s", urlopen[1]);

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2070,6 +2070,8 @@ cons_executable_setting(void)
     cons_show("Default '/avatar open' command (/executable avatar)                      : %s", avatar);
     prefs_free_string(avatar);
 
+    //TODO: there needs to be a way to get all the "locales"/schemes so we can
+    //display the defualt openers for all filetypes
     gchar **urlopen = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, "");
     cons_show("Default '/url open' command (/executable urlopen)                        : %s", urlopen[1]);
     g_strfreev(urlopen);

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2070,7 +2070,7 @@ cons_executable_setting(void)
     cons_show("Default '/avatar open' command (/executable avatar)                      : %s", avatar);
     prefs_free_string(avatar);
 
-    char **urlopen = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, "");
+    gchar **urlopen = prefs_get_string_list_with_option(PREF_URL_OPEN_CMD, "");
     cons_show("Default '/url open' command (/executable urlopen)                        : %s", urlopen[1]);
     g_strfreev(urlopen);
 

--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -1156,7 +1156,7 @@ wins_add_urls_ac(const ProfWin *const win, const ProfMessage *const message)
     GRegex *regex;
     GMatchInfo *match_info;
 
-    regex = g_regex_new("https?://\\S+", 0, 0, NULL);
+    regex = g_regex_new("(https?|aesgcm)://\\S+", 0, 0, NULL);
     g_regex_match (regex, message->plain, 0, &match_info);
 
     while (g_match_info_matches (match_info))


### PR DESCRIPTION
This PR includes the (rebased, organized and squashed) commits from @pmaziere from his repo https://framagit.org/peetah/profanity/ revampUrlopen branch.
It is about https://github.com/profanity-im/profanity/issues/1361 with the purpose of  defining external commands to open and save URLs according to file types and protocols.

One benefit of this is that it will allow users to download and decrypt OMEMO file extensions using [omut](https://github.com/wstrm/omemo-utils).