### PR TITLE
Fix messages with receipt request not displayed

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -160,7 +160,6 @@ _message_handler(xmpp_conn_t *const conn, xmpp_stanza_t *const stanza, void *con
         xmpp_stanza_t *receipts = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_RECEIPTS);
         if (receipts) {
             _handle_receipt_received(stanza);
-            return 1;
         }
 
         // XEP-0060: Publish-Subscribe


### PR DESCRIPTION
Messages from Conversations contains:
  ```<request xmlns='urn:xmpp:receipts'/>```

And would not be displayed in Profanity as it never reached
_handle_chat(..).