### PR TITLE
Cleanup carbons/chat handling in message.c

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1322,7 +1322,7 @@ _handle_chat(xmpp_stanza_t *const stanza, gboolean is_mam, gboolean is_carbon)
             char *mybarejid = connection_get_barejid();
 
             // if we are the recipient, treat as standard incoming message
-            if (g_strcmp0(mybarejid, to_jid->barejid) == 0) {
+            if (g_strcmp0(mybarejid, message->to_jid->barejid) == 0) {
                 sv_ev_incoming_carbon(message);
                 // else treat as a sent message
             } else {


### PR DESCRIPTION
We basically had a lot of duplicate code in _handle_chat() and _handle_carbons().
I try to improve the situation.

There is still more to be done. But I would like to get a review of it as is, just to make sure that I'm keeping the old behaviour.
Added some TODOs for more stuff that I need to check later on.