### PR TITLE
OMEMO: Messages are not shown in ChatSecure 

### DIFF
--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -98,7 +98,7 @@ struct omemo_context_t {
     GHashTable *pre_key_store;
     GHashTable *signed_pre_key_store;
     identity_key_store_t identity_key_store;
-    GHashTable *device_ids;
+//    GHashTable *device_ids;
     GString *identity_filename;
     GKeyFile *identity_keyfile;
     GString *trust_filename;


### PR DESCRIPTION
In 0.9.x we fixed an issue, because OMEMO devices should be defined in "item"
with id "current". This should work, but it won't work if there is no "current".
If there is no "current" we will just use the first item.

Issue #1384