### PR TITLE
Change to .tar.zst archives that latest Arch devtools uses

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -34,17 +34,23 @@ RUN useradd -mb /usr/src --shell=/bin/false aur && usermod -L aur
 USER aur
 
 WORKDIR /usr/src/aur
+
+# NOTE: These will change their extension to .tar.zst if a new snapshot is built
+# due to:
+# https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/
 RUN wget https://aur.archlinux.org/cgit/aur.git/snapshot/libstrophe-git.tar.gz
 RUN wget https://aur.archlinux.org/cgit/aur.git/snapshot/libsignal-protocol-c.tar.gz
+
 RUN tar -zxvf libstrophe-git.tar.gz
 RUN tar -zxvf libsignal-protocol-c.tar.gz
+
 RUN pushd libstrophe-git && makepkg && popd
 RUN pushd libsignal-protocol-c && makepkg && popd
 
 USER root
 
-RUN pacman -U --noconfirm libstrophe-git/libstrophe-git-*.pkg.tar.xz
-RUN pacman -U --noconfirm libsignal-protocol-c/libsignal-protocol-c-*.pkg.tar.xz
+RUN pacman -U --noconfirm libstrophe-git/libstrophe-git-*.pkg.tar.zst
+RUN pacman -U --noconfirm libsignal-protocol-c/libsignal-protocol-c-*.pkg.tar.zst
 
 WORKDIR /usr/src
 RUN git clone git://github.com/boothj5/stabber.git


### PR DESCRIPTION
This is required because of:
https://www.archlinux.org/news/now-using-zstandard-instead-of-xz-for-package-compression/