### PR TITLE
NetBSD support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_CANONICAL_HOST
 PLATFORM="unknown"
 AS_CASE([$host_os],
     [freebsd*], [PLATFORM="freebsd"],
+    [netbsd*], [PLATFORM="netbsd"],
     [openbsd*], [PLATFORM="openbsd"],
     [darwin*], [PLATFORM="osx"],
     [cygwin], [PLATFORM="cygwin"],
@@ -81,7 +82,7 @@ elif test "x$enable_python_plugins" != xno; then
         rm -f Python.framework
         ln -s $PYTHON_FRAMEWORK Python.framework ])
     AC_CHECK_PROG(PYTHON_CONFIG_EXISTS, python-config, yes, no)
-    if test "$PYTHON_CONFIG_EXISTS" == "yes"; then
+    if test "$PYTHON_CONFIG_EXISTS" = "yes"; then
         AX_PYTHON_DEVEL
         AM_CONDITIONAL([BUILD_PYTHON_API], [true])
         AC_DEFINE([HAVE_PYTHON], [1], [Python support])
@@ -106,9 +107,9 @@ else
     if test "x$enable_plugins" = xno; then
         AM_CONDITIONAL([BUILD_C_API], [false])
     elif test "x$enable_c_plugins" != xno; then
-        # libdl doesn't exist as a separate library in OpenBSD/FreeBSD and is
+        # libdl doesn't exist as a separate library in the BSDs and is
         # provided in the standard libraries.
-        AS_IF([test "x$PLATFORM" = xopenbsd -o "x$PLATFORM" = xfreebsd],
+        AS_IF([test "x$PLATFORM" = xopenbsd -o "x$PLATFORM" = xfreebsd -o "x$PLATFORM" = xnetbsd],
             [AM_CONDITIONAL([BUILD_C_API], [true]) AC_DEFINE([HAVE_C], [1], [C support])],
             [AC_CHECK_LIB([dl], [main],
                 [AM_CONDITIONAL([BUILD_C_API], [true]) LIBS="$LIBS -ldl" AC_DEFINE([HAVE_C], [1], [C support])],
@@ -160,21 +161,23 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([[
     [AC_MSG_RESULT([yes])],
     [AC_MSG_ERROR([${XMPP_LIB} is broken, check config.log for details])])
 
-### Check for ncurses library
+### Check for curses library
 PKG_CHECK_MODULES([ncursesw], [ncursesw],
-    [NCURSES_CFLAGS="$ncursesw_CFLAGS"; NCURSES_LIBS="$ncursesw_LIBS"; NCURSES="ncursesw"],
+    [NCURSES_CFLAGS="$ncursesw_CFLAGS"; NCURSES_LIBS="$ncursesw_LIBS"; CURSES="ncursesw"],
     [PKG_CHECK_MODULES([ncurses], [ncurses],
-        [NCURSES_CFLAGS="$ncurses_CFLAGS"; NCURSES_LIBS="$ncurses_LIBS"; NCURSES="ncurses"],
+        [NCURSES_CFLAGS="$ncurses_CFLAGS"; NCURSES_LIBS="$ncurses_LIBS"; CURSES="ncurses"],
         [AC_CHECK_LIB([ncursesw], [main], [],
             [AC_CHECK_LIB([ncurses], [main], [],
-            	[AC_MSG_ERROR([ncurses is required for profanity])])])])])
+                [AC_CHECK_LIB([curses], [main],
+                    [LIBS="$LIBS -lcurses"; CURSES="curses"],
+                    [AC_MSG_ERROR([ncurses or curses is required for profanity])])])])])])
 AM_CPPFLAGS="$AM_CPPFLAGS $NCURSES_CFLAGS"
 LIBS="$NCURSES_LIBS $LIBS"
 
-### Check wide characters support in ncurses library
+### Check wide characters support in curses library
 CFLAGS_RESTORE="$CFLAGS"
 CFLAGS="$CFLAGS $NCURSES_CFLAGS"
-AC_CACHE_CHECK([for wget_wch support in $NCURSES], ncurses_cv_wget_wch,
+AC_CACHE_CHECK([for wget_wch support in $CURSES], ncurses_cv_wget_wch,
    [AC_LINK_IFELSE([AC_LANG_SOURCE([
        void wget_wch(void);
        int main() {
@@ -354,6 +357,7 @@ AC_CHECK_LIB([expect], [exp_expectl], [AM_CONDITIONAL([HAVE_EXPECT], [true])],
 ### Check for ncursesw/ncurses.h first, Arch linux uses ncurses.h for ncursesw
 AC_CHECK_HEADERS([ncursesw/ncurses.h], [], [])
 AC_CHECK_HEADERS([ncurses.h], [], [])
+AC_CHECK_HEADERS([curses.h], [], [])
 
 ### Default parameters
 AM_CFLAGS="-Wall -Wno-deprecated-declarations -std=gnu99"

--- a/src/common.c
+++ b/src/common.c
@@ -54,6 +54,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "log.h"

--- a/src/config/color.c
+++ b/src/config/color.c
@@ -46,6 +46,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "config/color.h"

--- a/src/config/theme.c
+++ b/src/config/theme.c
@@ -45,6 +45,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "common.h"

--- a/src/ui/buffer.c
+++ b/src/ui/buffer.c
@@ -46,6 +46,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "ui/window.h"

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -42,6 +42,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "common.h"

--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -55,6 +55,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "log.h"

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -52,6 +52,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "profanity.h"

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -308,7 +308,9 @@ _inp_win_update_virtual(void)
 {
     int wcols = getmaxx(stdscr);
     int row = screen_inputwin_row();
-    pnoutrefresh(inp_win, 0, pad_start, row, 0, row, wcols - 2);
+    if (inp_win != NULL) {
+        pnoutrefresh(inp_win, 0, pad_start, row, 0, row, wcols - 2);
+    }
 }
 
 static void

--- a/src/ui/rosterwin.c
+++ b/src/ui/rosterwin.c
@@ -95,7 +95,10 @@ rosterwin_roster(void)
 
     ProfLayoutSplit* layout = (ProfLayoutSplit*)console->layout;
     assert(layout->memcheck == LAYOUT_SPLIT_MEMCHECK);
-    werase(layout->subwin);
+
+    if (layout->subwin != NULL) {
+        werase(layout->subwin);
+    }
 
     char* roomspos = prefs_get_string(PREF_ROSTER_ROOMS_POS);
     if (prefs_get_boolean(PREF_ROSTER_ROOMS) && (g_strcmp0(roomspos, "first") == 0)) {
@@ -1106,9 +1109,11 @@ _rosterwin_contacts_header(ProfLayoutSplit* layout, const char* const title, GSL
 
     gboolean wrap = prefs_get_boolean(PREF_ROSTER_WRAP);
 
-    wattron(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
-    win_sub_print(layout->subwin, header->str, FALSE, wrap, 1);
-    wattroff(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
+    if (layout->subwin != NULL) {
+        wattron(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
+        win_sub_print(layout->subwin, header->str, FALSE, wrap, 1);
+        wattroff(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
+    }
 
     g_string_free(header, TRUE);
 }
@@ -1166,9 +1171,11 @@ _rosterwin_rooms_header(ProfLayoutSplit* layout, GList* rooms, char* title)
 
     gboolean wrap = prefs_get_boolean(PREF_ROSTER_WRAP);
 
-    wattron(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
-    win_sub_print(layout->subwin, header->str, FALSE, wrap, 1);
-    wattroff(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
+    if (layout->subwin != NULL) {
+        wattron(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
+        win_sub_print(layout->subwin, header->str, FALSE, wrap, 1);
+        wattroff(layout->subwin, theme_attrs(THEME_ROSTER_HEADER));
+    }
 
     g_string_free(header, TRUE);
 }

--- a/src/ui/screen.c
+++ b/src/ui/screen.c
@@ -39,6 +39,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "config/preferences.h"

--- a/src/ui/statusbar.c
+++ b/src/ui/statusbar.c
@@ -44,6 +44,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "config/theme.h"

--- a/src/ui/win_types.h
+++ b/src/ui/win_types.h
@@ -45,6 +45,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "tools/autocomplete.h"

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -48,6 +48,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "log.h"

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1863,7 +1863,12 @@ win_sub_print(WINDOW* win, char* msg, gboolean newline, gboolean wrap, int inden
 void
 win_sub_newline_lazy(WINDOW* win)
 {
-    int curx = getcurx(win);
+    int curx;
+
+    if (win == NULL) {
+        return;
+    }
+    curx = getcurx(win);
     if (curx > 0) {
         int cury = getcury(win);
         wmove(win, cury + 1, 0);

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -45,6 +45,8 @@
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
+#elif HAVE_CURSES_H
+#include <curses.h>
 #endif
 
 #include "ui/ui.h"


### PR DESCRIPTION
The following changes were required:

- Added NetBSD as a platform that does not have a separate `libdl` to `configure.ac`.
- Changed a `==` condition in `configure.ac` to use `=` instead. These are identical, it's just that `=` is in POSIX and `==` isn't. NetBSD's `/bin/sh` only supports the POSIX syntax.
- Recognize NetBSD `libcurses` as a valid curses implementation.
  AFAIK, NetBSD is now the only operating system that does not primarily use ncurses. Its own curses library has support for wide characters and similar features -- there's also a [port of it to Linux](https://github.com/sabotage-linux/netbsd-curses).
- NetBSD curses is less permissive when handed null pointers than ncurses, apparently. I had to add a few checks to avoid null pointer deref.

Notes for building profanity on NetBSD:

- To get it to pick up `python-config`, either create a non-versioned symlink in `/usr/local/bin` or install `pkg_alternatives` - the executable is versioned in NetBSD, but this isn't really a problem for local builds or packaging.
- To test these changes, it's helpful to not have the ncurses or ncursesw packages installed. Alternatively, I moved the `*.pc` files out the way, and configured with: `MAKE=gmake ac_cv_header_ncursesw_ncurses_h=no ac_cv_lib_ncursesw_main=no ac_cv_lib_ncurses_main=no ./configure`
- As with other BSDs, GNU make is spelled `gmake`.
- Installing `autoconf-archive` probably helps
