### PR TITLE
Fix use-after-free which is introduced in cons_alert()

### DIFF
--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2408,7 +2408,7 @@ cons_alert(ProfWin* alert_origin_window)
 
         GList* item = g_list_find_custom(alert_list, win_name, (GCompareFunc)g_strcmp0);
         if (!item) {
-            alert_list = g_list_append(alert_list, win_name);
+            alert_list = g_list_append(alert_list, g_strdup(win_name));
         }
 
         free(win_name);


### PR DESCRIPTION
Commit f12161f fixes memory leak, but introduces use-after-free issue.
Allocate new memory for win_name with g_strdup() since it is freed with
g_free() later.