### PR TITLE
Since the string from strerror should never be modified, use const.

### DIFF
--- a/src/config/scripts.c
+++ b/src/config/scripts.c
@@ -58,7 +58,7 @@ scripts_init(void)
     errno = 0;
     int res = g_mkdir_with_parents(scriptsdir, S_IRWXU);
     if (res == -1) {
-        char* errmsg = strerror(errno);
+        const char* errmsg = strerror(errno);
         if (errmsg) {
             log_error("Error creating directory: %s, %s", scriptsdir, errmsg);
         } else {

--- a/src/database.c
+++ b/src/database.c
@@ -60,7 +60,7 @@ _get_db_filename(ProfAccount* account)
 
     int res = g_mkdir_with_parents(database_dir, S_IRWXU);
     if (res == -1) {
-        char* errmsg = strerror(errno);
+        const char* errmsg = strerror(errno);
         if (errmsg) {
             log_error("DATABASE: error creating directory: %s, %s", database_dir, errmsg);
         } else {

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -240,7 +240,7 @@ omemo_on_connect(ProfAccount* account)
     errno = 0;
     int res = g_mkdir_with_parents(omemo_dir, S_IRWXU);
     if (res == -1) {
-        char* errmsg = strerror(errno);
+        const char* errmsg = strerror(errno);
         if (errmsg) {
             log_error("OMEMO: error creating directory: %s, %s", omemo_dir, errmsg);
         } else {

--- a/src/pgp/gpg.c
+++ b/src/pgp/gpg.c
@@ -167,7 +167,7 @@ p_gpg_on_connect(const char* const barejid)
     errno = 0;
     int res = g_mkdir_with_parents(pubsfile, S_IRWXU);
     if (res == -1) {
-        char* errmsg = strerror(errno);
+        const char* errmsg = strerror(errno);
         if (errmsg) {
             log_error("Error creating directory: %s, %s", pubsfile, errmsg);
         } else {

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -172,7 +172,7 @@ inp_readline(void)
     pthread_mutex_lock(&lock);
     if (r < 0) {
         if (errno != EINTR) {
-            char* err_msg = strerror(errno);
+            const char* err_msg = strerror(errno);
             log_error("Readline failed: %s", err_msg);
         }
         return NULL;

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -229,7 +229,7 @@ _avatar_request_item_result_handler(xmpp_stanza_t* const stanza, void* const use
     errno = 0;
     int res = g_mkdir_with_parents(filename->str, S_IRWXU);
     if (res == -1) {
-        char* errmsg = strerror(errno);
+        const char* errmsg = strerror(errno);
         if (errmsg) {
             log_error("Avatar: error creating directory: %s, %s", filename->str, errmsg);
         } else {


### PR DESCRIPTION
This is just a very minor issue.

profanity contains some calls to strerror where the result is assigned to a char *. However, according to the strerror specification, the string returned by strerror should never be changed, so I think it would be better to use const char * instead.

Philipp
