### PR TITLE
xmpp/bookmark: don't use uninitialised field

### DIFF
--- a/src/xmpp/bookmark.c
+++ b/src/xmpp/bookmark.c
@@ -126,6 +126,7 @@ bookmark_add(const char* jid, const char* nick, const char* password, const char
     } else {
         bookmark->name = NULL;
     }
+    bookmark->ext_gajim_minimize = 0;
 
     if (g_strcmp0(autojoin_str, "on") == 0) {
         bookmark->autojoin = TRUE;


### PR DESCRIPTION
When a bookmark is created with '/bookmark add' command,
ext_gajim_minimize remains uninitialised in new bookmark object and
is read further in _send_bookmarks().

Initialise the field with 0.

Fixes #1432.