### PR TITLE
Create cmd to generate man pages for prof commands

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -213,7 +213,7 @@ icons_sources = $(top_srcdir)/icons/*
 
 script_sources = bootstrap.sh
 
-man_sources = docs/profanity.1
+man_sources = docs/profanity*.1
 
 if BUILD_PGP
 core_sources += $(pgp_sources)

--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -15,6 +15,10 @@ Usually release candidates are tagged 0.6.0.rc1, 0.6.0.rc2 and tested for a week
 * Generate HTML docs (the docgen argument only works when package status is development)
     `./profanity docgen`
 
+* Generate manpages for profanity commands (the mangen argument only works when package status is development)
+    `./profanity mangen`
+  These files should be added to the docs subfolder and added to git whenever a command changes.
+
 * Determine if libprofanitys version needs to be [increased](https://github.com/profanity-im/profanity/issues/973)
 * Update plugin API docs (./apidocs/c and ./apidocs/python) need to run the `gen.sh` and commit the results to the website git repo
 * Update CHANGELOG

--- a/docs/profanity.1
+++ b/docs/profanity.1
@@ -46,6 +46,7 @@ The user guide can be found at <https://profanity-im.github.io/userguide.html>.
 .B Profanity
 itself has a lot of built\-in help. Check the /help command for more information.
 Type "/help help" for information on how to use help itself.
+Profanity ships with one man page for each built-in command. For /account there is man profanity-account.
 .SH CONFIGURATION
 Configuration for
 .B Profanity

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2876,9 +2876,8 @@ command_mangen(void)
         if (pcmd->help.args[0][0] != NULL) {
             fputs("\n.SH ARGUMENTS\n", manpage);
             for (i = 0; pcmd->help.args[i][0] != NULL; i++) {
-                fprintf(manpage, "%s\n", pcmd->help.args[i][0]);
-                fprintf(manpage, "%s\n", pcmd->help.args[i][1]);
-                fputs("\n.BR\n", manpage);
+                fprintf(manpage, ".PP\n%s\n", pcmd->help.args[i][0]);
+                fprintf(manpage, ".RS 4\n%s\n.RE\n", pcmd->help.args[i][1]);
             }
         }
 

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2846,6 +2846,16 @@ command_mangen(void)
 
     mkdir_recursive("docs");
 
+    char* header = NULL;
+    GDateTime *now = g_date_time_new_now_local();
+    gchar *date = g_date_time_format(now, "%F");
+    if (asprintf(&header, ".TH man 1 \"%s\" \""PACKAGE_VERSION"\" \"Profanity XMPP client\"\n", date) == -1) {
+        // TODO: error
+        return;
+    }
+    g_date_time_unref(now);
+    g_free(date);
+
     GList* curr = cmds;
     while (curr) {
         Command* pcmd = curr->data;
@@ -2858,7 +2868,7 @@ command_mangen(void)
         FILE* manpage = fopen(filename, "w");
         free(filename);
 
-        fputs(".TH man 1 \"2020-07-01\" \""PACKAGE_VERSION"\" \"Profanity XMPP client\"\n", manpage);
+        fprintf(manpage, "%s\n", header);
         fputs(".SH NAME\n", manpage);
         fprintf(manpage, "%s\n", pcmd->cmd);
 
@@ -2891,11 +2901,12 @@ command_mangen(void)
             }
         }
 
-        curr = g_list_next(curr);
-
         fclose(manpage);
+        curr = g_list_next(curr);
     }
 
     printf("\nProcessed %d commands.\n\n", g_list_length(cmds));
+
+    free(header);
     g_list_free(cmds);
 }

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2869,7 +2869,7 @@ command_mangen(void)
         int i = 0;
         while (pcmd->help.synopsis[i]) {
             fprintf(manpage, "%s\n", pcmd->help.synopsis[i]);
-            fputs("\n.BR\n", manpage);
+            fputs("\n.LP\n", manpage);
             i++;
         }
 
@@ -2886,7 +2886,7 @@ command_mangen(void)
             int i = 0;
             while (pcmd->help.examples[i]) {
                 fprintf(manpage, "%s\n", pcmd->help.examples[i]);
-                fputs("\n.BR\n", manpage);
+                fputs("\n.LP\n", manpage);
                 i++;
             }
         }

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2886,7 +2886,7 @@ command_mangen(void)
         if (pcmd->help.args[0][0] != NULL) {
             fputs("\n.SH ARGUMENTS\n", manpage);
             for (i = 0; pcmd->help.args[i][0] != NULL; i++) {
-                fprintf(manpage, ".PP\n%s\n", pcmd->help.args[i][0]);
+                fprintf(manpage, ".PP\n\\fB%s\\fR\n", pcmd->help.args[i][0]);
                 fprintf(manpage, ".RS 4\n%s\n.RE\n", pcmd->help.args[i][1]);
             }
         }

--- a/src/command/cmd_defs.h
+++ b/src/command/cmd_defs.h
@@ -50,6 +50,7 @@ GList* cmd_get_ordered(const char* const tag);
 gboolean cmd_valid_tag(const char* const str);
 
 void command_docgen(void);
+void command_mangen(void);
 
 GList* cmd_search_index_all(char* term);
 GList* cmd_search_index_any(char* term);

--- a/src/main.c
+++ b/src/main.c
@@ -69,9 +69,14 @@ static char* theme_name = NULL;
 int
 main(int argc, char** argv)
 {
-    if (argc == 2 && g_strcmp0(argv[1], "docgen") == 0 && g_strcmp0(PACKAGE_STATUS, "development") == 0) {
-        command_docgen();
-        return 0;
+    if (argc == 2  && g_strcmp0(PACKAGE_STATUS, "development") == 0) {
+        if (g_strcmp0(argv[1], "docgen") == 0) {
+            command_docgen();
+            return 0;
+        } else if (g_strcmp0(argv[1], "mangen") == 0) {
+            command_mangen();
+            return 0;
+        }
     }
 
     static GOptionEntry entries[] = {


### PR DESCRIPTION
`profanity mangen` will create for each command (`/account`, `/roster`)
an own manpage (`profanity-account.1`, `profanity-roster.1`)

See https://github.com/profanity-im/profanity/issues/1444