### PR TITLE
docs: fix simple typo, certian -> certain

### DIFF
--- a/src/config/theme.c
+++ b/src/config/theme.c
@@ -712,7 +712,7 @@ theme_hash_attrs(const char* str)
     return COLOR_PAIR(color_pair_cache_hash_str(str, profile));
 }
 
-/* returns the colours (fgnd and bknd) for a certian attribute ie main.text */
+/* returns the colours (fgnd and bknd) for a certain attribute ie main.text */
 int
 theme_attrs(theme_item_t attrs)
 {


### PR DESCRIPTION
There is a small typo in src/config/theme.c.

Should read `certain` rather than `certian`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md