### PR TITLE
Create download directory under XDG data path

### DIFF
--- a/src/tools/http_download.c
+++ b/src/tools/http_download.c
@@ -123,7 +123,7 @@ http_file_get(void* userdata)
                                    "output file at '%s' for writing (%s).",
                                    download->url, download->filename,
                                    g_strerror(errno));
-        return NULL;
+        goto out;
     }
 
     char* cert_path = prefs_get_string(PREF_TLS_CERTPATH);
@@ -185,9 +185,6 @@ http_file_get(void* userdata)
         }
     }
 
-    download_processes = g_slist_remove(download_processes, download);
-    pthread_mutex_unlock(&lock);
-
     if (download->cmd_template != NULL) {
         gchar** argv = format_call_external_argv(download->cmd_template,
                                                  download->url,
@@ -207,6 +204,11 @@ http_file_get(void* userdata)
         g_strfreev(argv);
         free(download->cmd_template);
     }
+
+out:
+
+    download_processes = g_slist_remove(download_processes, download);
+    pthread_mutex_unlock(&lock);
 
     free(download->url);
     free(download->filename);


### PR DESCRIPTION
 * If the downloads directory does not exist, create it.
 * Change some cons_show to cons_show_error (because they log errors).
 * There was a deadlock that occured if an error occurs before HTTP download had begun, e.g. if fopen returned an error.