### PR TITLE
Use whole path as logfile when defined via -f

### DIFF
--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1859,7 +1859,7 @@ static struct cmd_t command_defs[] = {
               { "where", "Show the current log file location." },
               { "rotate on|off", "Rotate log, default on." },
               { "maxsize <bytes>", "With rotate enabled, specifies the max log size, defaults to 1048580 (1MB)." },
-              { "shared on|off", "Share logs between all instances, default: on. When off, the process id will be included in the log filename." })
+              { "shared on|off", "Share logs between all instances, default: on. When off, the process id will be included in the log filename. Does not take effect if you specified a filename yourself when starting Profanity." })
       CMD_NOEXAMPLES
     },
 

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1857,7 +1857,7 @@ static struct cmd_t command_defs[] = {
               "Manage profanity log settings.")
       CMD_ARGS(
               { "where", "Show the current log file location." },
-              { "rotate on|off", "Rotate log, default on." },
+              { "rotate on|off", "Rotate log, default on. Does not take effect if you specified a filename yourself when starting Profanity." },
               { "maxsize <bytes>", "With rotate enabled, specifies the max log size, defaults to 1048580 (1MB)." },
               { "shared on|off", "Share logs between all instances, default: on. When off, the process id will be included in the log filename. Does not take effect if you specified a filename yourself when starting Profanity." })
       CMD_NOEXAMPLES

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6375,7 +6375,7 @@ cmd_log(ProfWin* window, const char* const command, gchar** args)
             return TRUE;
         }
         _cmd_set_boolean_preference(value, command, "Shared log", PREF_LOG_SHARED);
-        log_reinit();
+        cons_show("Setting only takes effect after saving and restarting Profanity.");
         return TRUE;
     }
 

--- a/src/config/files.c
+++ b/src/config/files.c
@@ -116,20 +116,26 @@ char*
 files_get_log_file(const char* const log_file)
 {
     gchar* xdg_data = _files_get_xdg_data_home();
-    GString* logfile = g_string_new(xdg_data);
+    GString* logfile;
 
     if (log_file) {
-        g_string_append(logfile, "/profanity/logs/");
-        g_string_append(logfile, log_file);
+        gchar *log_path = g_path_get_dirname(log_file);
+        if (!mkdir_recursive(log_path)) {
+            log_error("Error while creating directory %s", log_path);
+        }
+        g_free(log_path);
+
+        logfile = g_string_new(log_file);
     } else {
+        logfile = g_string_new(xdg_data);
         g_string_append(logfile, "/profanity/logs/profanity");
-    }
 
-    if (!prefs_get_boolean(PREF_LOG_SHARED)) {
-        g_string_append_printf(logfile, "%d", getpid());
-    }
+        if (!prefs_get_boolean(PREF_LOG_SHARED)) {
+            g_string_append_printf(logfile, "%d", getpid());
+        }
 
-    g_string_append(logfile, ".log");
+        g_string_append(logfile, ".log");
+    }
 
     char* result = g_strdup(logfile->str);
 

--- a/src/log.c
+++ b/src/log.c
@@ -56,6 +56,7 @@
 
 static FILE* logp;
 static gchar* mainlogfile = NULL;
+static gboolean user_provided_log = FALSE;
 
 static GTimeZone* tz;
 static GDateTime* dt;
@@ -150,6 +151,11 @@ log_init(log_level_t filter, char* log_file)
 {
     level_filter = filter;
     tz = g_time_zone_new_local();
+
+    if (log_file) {
+        user_provided_log = TRUE;
+    }
+
     gchar* lf = files_get_log_file(log_file);
 
     logp = fopen(lf, "a");
@@ -198,7 +204,7 @@ log_msg(log_level_t level, const char* const area, const char* const msg)
         fflush(logp);
         g_free(date_fmt);
 
-        if (prefs_get_boolean(PREF_LOG_ROTATE)) {
+        if (prefs_get_boolean(PREF_LOG_ROTATE) && !user_provided_log) {
             long result = ftell(logp);
             if (result != -1 && result >= prefs_get_max_log_size()) {
                 _rotate_log_file();

--- a/src/log.c
+++ b/src/log.c
@@ -159,20 +159,6 @@ log_init(log_level_t filter, char* log_file)
     g_free(lf);
 }
 
-void
-log_reinit(void)
-{
-    char* lf = strdup(mainlogfile);
-    char* start = strrchr(lf, '/') + 1;
-    char* end = strstr(start, ".log");
-    *end = '\0';
-
-    log_close();
-    log_init(level_filter, start);
-
-    free(lf);
-}
-
 const char*
 get_log_file_location(void)
 {

--- a/src/log.h
+++ b/src/log.h
@@ -56,7 +56,6 @@ typedef enum {
 void log_init(log_level_t filter, char* log_file);
 log_level_t log_get_filter(void);
 void log_close(void);
-void log_reinit(void);
 const char* get_log_file_location(void);
 void log_debug(const char* const msg, ...);
 void log_info(const char* const msg, ...);

--- a/tests/unittests/log/stub_log.c
+++ b/tests/unittests/log/stub_log.c
@@ -37,10 +37,6 @@ log_get_filter(void)
 }
 
 void
-log_reinit(void)
-{
-}
-void
 log_close(void)
 {
 }


### PR DESCRIPTION
`profanity -f my` created ~/.local/share/profanity/logs/my.log`.

It would be nicer if one could define the actual path, so one can choose
another directory or even use /dev/null.

Fixes https://github.com/profanity-im/profanity/issues/1442