### PR TITLE
Fix color for win_print_outgoing()

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1213,7 +1213,6 @@ win_print_outgoing(ProfWin* window, const char* show_char, const char* const id,
     if (replace_id) {
         _win_correct(window, message, id, replace_id, myjid);
     } else {
-        //TODO my jid
         _win_printf(window, show_char, 0, timestamp, 0, THEME_TEXT_ME, "me", myjid, id, "%s", message);
     }
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1214,7 +1214,7 @@ win_print_outgoing(ProfWin* window, const char* show_char, const char* const id,
         _win_correct(window, message, id, replace_id, myjid);
     } else {
         //TODO my jid
-        _win_printf(window, show_char, 0, timestamp, 0, THEME_TEXT_THEM, "me", myjid, id, "%s", message);
+        _win_printf(window, show_char, 0, timestamp, 0, THEME_TEXT_ME, "me", myjid, id, "%s", message);
     }
 
     inp_nonblocking(TRUE);


### PR DESCRIPTION
Discovered by @aba-hollerer.

Mistake was introduced in b6b7dd5ad497a71e250b8b3cef0bb987314b141d
probably due to a wrong copy/paste.

First wasn't reproducible because I had `/receipts request on` and thus
win_print_outgoing_receipts() is used which has the correct
THEME_TEXT_ME.