### PR TITLE
Remove blank line after trackbar

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1745,8 +1745,6 @@ win_print_trackbar(ProfWin* window)
     }
 
     wattroff(window->layout->win, theme_attrs(THEME_TRACKBAR));
-
-    wprintw(window->layout->win, "\n");
 }
 
 void


### PR DESCRIPTION
Remove added blank line after trackbar, introduced by 606c1e51e688cb111b9837579a35460508324b63, fixes #1457 