### PR TITLE
Print logs on error in CI

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
+log_content()
+{
+    echo
+    echo "Content of $1:"
+    cat "$1"
+}
+
 error_handler()
 {
     ERR_CODE=$?
+
+    log_content ./config.log
+    log_content ./test-suite.log
+
     echo
     echo "Error ${ERR_CODE} with command '${BASH_COMMAND}' on line ${BASH_LINENO[0]}. Exiting."
     echo
@@ -113,10 +124,6 @@ do
 
     $MAKE CC="${CC}"
     $MAKE check
-
-    if [ $? -eq 1 ]; then
-        cat ./test-suite.log
-    fi
 
     ./profanity -v
     $MAKE clean


### PR DESCRIPTION
Because we trap the error signal and run a error handler, logs were not
printed. I moved the printing of test-suite.log to the error handler and
also added so that config.log is printed on failure.