### PR TITLE
Inline images

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,8 @@ AC_ARG_WITH([themes],
     [AS_HELP_STRING([--with-themes[[=PATH]]], [install themes (default yes)])])
 AC_ARG_ENABLE([icons-and-clipboard],
     [AS_HELP_STRING([--enable-icons-and-clipboard], [enable GTK tray icons and clipboard paste support])])
+AC_ARG_ENABLE([inline-images],
+    [AS_HELP_STRING([--enable-inline-images], [enable inline display of images])])
 
 ### plugins
 
@@ -191,9 +193,6 @@ PKG_CHECK_MODULES([glib], [glib-2.0 >= 2.62.0], [],
     [AC_MSG_ERROR([glib 2.62.0 or higher is required for profanity])])
 PKG_CHECK_MODULES([gio], [gio-2.0], [],
     [AC_MSG_ERROR([libgio-2.0 from glib-2.0 is required for profanity])])
-#TODO: only under cond
-PKG_CHECK_MODULES([pixbuf], [gdk-pixbuf-2.0], [],
-    [AC_MSG_ERROR([gdk-pixbuf-2.0 from glib-2.0 is required for profanity])])
 
 ### Check for other profanity dependencies
 AC_SEARCH_LIBS([fmod], [m], [],
@@ -205,10 +204,6 @@ PKG_CHECK_MODULES([curl], [libcurl], [],
 
 PKG_CHECK_MODULES([SQLITE], [sqlite3 >= 3.22.0], [],
     [AC_MSG_ERROR([sqlite3 3.22.0 or higher is required for profanity])])
-
-#TODO: only under cond
-PKG_CHECK_MODULES([chafa], [chafa >= 1.4.1], [],
-    [AC_MSG_ERROR([chafa needed])])
 
 AS_IF([test "x$enable_icons_and_clipboard" != xno],
     [PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.24.0],
@@ -328,6 +323,16 @@ if test "x$enable_omemo" != xno; then
                [AC_MSG_NOTICE([gcrypt >= 1.7.0 not found, OMEMO support not enabled])])])
 
    AM_COND_IF([BUILD_OMEMO], [AC_DEFINE([HAVE_OMEMO], [1], [Have OMEMO])])
+fi
+
+if test "x$enable_inline_images" = xyes; then
+    PKG_CHECK_MODULES([pixbuf], [gdk-pixbuf-2.0], [],
+        [AC_MSG_ERROR([gdk-pixbuf-2.0 from glib-2.0 is required for inline image support])])
+
+    PKG_CHECK_MODULES([chafa], [chafa >= 1.4.1], [],
+        [AC_MSG_ERROR([chafa >= 1.4.1 needed for inline image support])])
+
+   AC_DEFINE([HAVE_INLINE_IMAGE], [1], [Have inline image])
 fi
 
 AS_IF([test "x$with_themes" = xno],

--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,9 @@ PKG_CHECK_MODULES([glib], [glib-2.0 >= 2.62.0], [],
     [AC_MSG_ERROR([glib 2.62.0 or higher is required for profanity])])
 PKG_CHECK_MODULES([gio], [gio-2.0], [],
     [AC_MSG_ERROR([libgio-2.0 from glib-2.0 is required for profanity])])
+#TODO: only under cond
+PKG_CHECK_MODULES([pixbuf], [gdk-pixbuf-2.0], [],
+    [AC_MSG_ERROR([gdk-pixbuf-2.0 from glib-2.0 is required for profanity])])
 
 ### Check for other profanity dependencies
 AC_SEARCH_LIBS([fmod], [m], [],
@@ -202,6 +205,10 @@ PKG_CHECK_MODULES([curl], [libcurl], [],
 
 PKG_CHECK_MODULES([SQLITE], [sqlite3 >= 3.22.0], [],
     [AC_MSG_ERROR([sqlite3 3.22.0 or higher is required for profanity])])
+
+#TODO: only under cond
+PKG_CHECK_MODULES([chafa], [chafa >= 1.4.1], [],
+    [AC_MSG_ERROR([chafa needed])])
 
 AS_IF([test "x$enable_icons_and_clipboard" != xno],
     [PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.24.0],
@@ -359,9 +366,9 @@ AS_IF([test "x$PACKAGE_STATUS" = xdevelopment],
 AS_IF([test "x$PLATFORM" = xosx],
     [AM_CFLAGS="$AM_CFLAGS -Qunused-arguments"])
 AM_LDFLAGS="$AM_LDFLAGS -export-dynamic"
-AM_CPPFLAGS="$AM_CPPFLAGS $glib_CFLAGS $gio_CFLAGS $curl_CFLAGS $libnotify_CFLAGS $PYTHON_CPPFLAGS ${GTK_CFLAGS} ${SQLITE_CFLAGS}"
+AM_CPPFLAGS="$AM_CPPFLAGS $glib_CFLAGS $gio_CFLAGS $curl_CFLAGS $libnotify_CFLAGS $PYTHON_CPPFLAGS ${GTK_CFLAGS} ${SQLITE_CFLAGS} ${chafa_CFLAGS}"
 AM_CPPFLAGS="$AM_CPPFLAGS -DTHEMES_PATH=\"\\\"$THEMES_PATH\\\"\" -DICONS_PATH=\"\\\"$ICONS_PATH\\\"\""
-LIBS="$glib_LIBS $gio_LIBS $curl_LIBS $libnotify_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_LDFLAGS ${GTK_LIBS} ${SQLITE_LIBS} $LIBS"
+LIBS="$glib_LIBS $gio_LIBS $curl_LIBS $libnotify_LIBS $PYTHON_LIBS $PYTHON_EXTRA_LIBS $PYTHON_LDFLAGS ${GTK_LIBS} ${SQLITE_LIBS} ${chafa_LIBS} $LIBS"
 
 AC_SUBST(AM_LDFLAGS)
 AC_SUBST(AM_CFLAGS)

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -407,7 +407,9 @@ cons_about(void)
     getmaxyx(stdscr, rows, cols);
 
     if (prefs_get_boolean(PREF_SPLASH)) {
+#ifdef HAVE_INLINE_IMAGE
         win_pictest(console);
+#endif
         _cons_splash_logo();
     } else {
 

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -407,6 +407,7 @@ cons_about(void)
     getmaxyx(stdscr, rows, cols);
 
     if (prefs_get_boolean(PREF_SPLASH)) {
+        win_pictest(console);
         _cons_splash_logo();
     } else {
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -44,16 +44,17 @@
 
 #include <glib.h>
 
-//TODO: ifdef
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <chafa.h>
-
 #ifdef HAVE_NCURSESW_NCURSES_H
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
 #include <ncurses.h>
 #elif HAVE_CURSES_H
 #include <curses.h>
+#endif
+
+#ifdef HAVE_INLINE_IMAGE
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <chafa.h>
 #endif
 
 #include "log.h"
@@ -1958,6 +1959,7 @@ win_insert_last_read_position_marker(ProfWin* window, char* id)
     g_date_time_unref(time);
 }
 
+#ifdef HAVE_INLINE_IMAGE
 void
 win_pictest(ProfWin* window)
 {
@@ -2010,3 +2012,4 @@ win_pictest(ProfWin* window)
     GString *gs = chafa_canvas_build_ansi (canvas);
     win_println(window, THEME_DEFAULT, "!", gs->str);
 }
+#endif

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -44,6 +44,10 @@
 
 #include <glib.h>
 
+//TODO: ifdef
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <chafa.h>
+
 #ifdef HAVE_NCURSESW_NCURSES_H
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H
@@ -1952,4 +1956,49 @@ win_insert_last_read_position_marker(ProfWin* window, char* id)
     win_redraw(window);
 
     g_date_time_unref(time);
+}
+
+void
+win_pictest(ProfWin* window)
+{
+    GdkPixbuf *file = gdk_pixbuf_new_from_file ("/home/michael/Pictures/test.png", NULL);
+    //GdkPixbuf *file = gdk_pixbuf_new_from_file ("/home/michael/ask2.png", NULL);
+    if (file == NULL) {
+        win_println(window, THEME_ERROR, "!", "pictest");
+        return;
+    }
+    ChafaCanvasConfig *config;
+    ChafaCanvas *canvas;
+    ChafaSymbolMap *symbol_map;
+
+    symbol_map = chafa_symbol_map_new ();
+    //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_ALL);
+    chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_ASCII);
+    //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_BRAILLE);
+    //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_BLOCK | CHAFA_SYMBOL_TAG_BORDER);
+    //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_BLOCK | CHAFA_SYMBOL_TAG_BORDER | CHAFA_SYMBOL_TAG_SPACE);
+
+    // TODO: use chafa_calc_canvas_geometry() to get recommended canvas size
+    // TODO: could be a that a user shrinks its terminal. then we would need to redraw I guess?
+
+    config = chafa_canvas_config_new ();
+    //chafa_canvas_config_set_geometry (config, 23, 12);
+    chafa_canvas_config_set_geometry (config, 100, 65);
+    chafa_canvas_config_set_symbol_map (config, symbol_map);
+    // mono for now (no escape code)
+    chafa_canvas_config_set_canvas_mode (config, CHAFA_CANVAS_MODE_FGBG);
+
+    canvas = chafa_canvas_new (config);
+
+                                  //CHAFA_PIXEL_RGBA8_UNASSOCIATED,
+    guchar *pixels = gdk_pixbuf_get_pixels (file);
+    chafa_canvas_draw_all_pixels (canvas,
+                                  CHAFA_PIXEL_ARGB8_UNASSOCIATED,
+                                  pixels,
+                                  gdk_pixbuf_get_width(file),
+                                  gdk_pixbuf_get_height(file),
+                                  gdk_pixbuf_get_rowstride(file));
+
+    GString *gs = chafa_canvas_build_ansi (canvas);
+    win_print(window, THEME_DEFAULT, "!", gs->str);
 }

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1963,11 +1963,15 @@ win_insert_last_read_position_marker(ProfWin* window, char* id)
 void
 win_pictest(ProfWin* window)
 {
-    GdkPixbuf *file = gdk_pixbuf_new_from_file ("/home/michael/Pictures/test.png", NULL);
+    gchar *path = get_expanded_path("~/test.png");
+    GdkPixbuf *file = gdk_pixbuf_new_from_file (path, NULL);
     if (file == NULL) {
         win_println(window, THEME_ERROR, "!", "pictest");
+        g_free(path);
         return;
     }
+    g_free(path);
+
     ChafaCanvasConfig *config;
     ChafaCanvas *canvas;
     ChafaSymbolMap *symbol_map;

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1962,7 +1962,6 @@ void
 win_pictest(ProfWin* window)
 {
     GdkPixbuf *file = gdk_pixbuf_new_from_file ("/home/michael/Pictures/test.png", NULL);
-    //GdkPixbuf *file = gdk_pixbuf_new_from_file ("/home/michael/ask2.png", NULL);
     if (file == NULL) {
         win_println(window, THEME_ERROR, "!", "pictest");
         return;
@@ -1972,25 +1971,34 @@ win_pictest(ProfWin* window)
     ChafaSymbolMap *symbol_map;
 
     symbol_map = chafa_symbol_map_new ();
-    //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_ALL);
     chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_ASCII);
+    //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_ALL);
     //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_BRAILLE);
     //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_BLOCK | CHAFA_SYMBOL_TAG_BORDER);
     //chafa_symbol_map_add_by_tags (symbol_map, CHAFA_SYMBOL_TAG_BLOCK | CHAFA_SYMBOL_TAG_BORDER | CHAFA_SYMBOL_TAG_SPACE);
 
-    // TODO: use chafa_calc_canvas_geometry() to get recommended canvas size
+    // calculate how much space we have on curent screen
+    gint width = getmaxx(stdscr);
+    gint height = screen_mainwin_row_end() - screen_mainwin_row_end();
+    // get recommended canvas size. image will be scaled accordingly
+    chafa_calc_canvas_geometry(gdk_pixbuf_get_width(file), gdk_pixbuf_get_height(file),
+            &width,
+            &height,
+            0.5,
+            TRUE,
+            FALSE);
+
     // TODO: could be a that a user shrinks its terminal. then we would need to redraw I guess?
 
     config = chafa_canvas_config_new ();
-    //chafa_canvas_config_set_geometry (config, 23, 12);
-    chafa_canvas_config_set_geometry (config, 100, 65);
+    chafa_canvas_config_set_geometry (config, width, height);
     chafa_canvas_config_set_symbol_map (config, symbol_map);
+
     // mono for now (no escape code)
     chafa_canvas_config_set_canvas_mode (config, CHAFA_CANVAS_MODE_FGBG);
 
     canvas = chafa_canvas_new (config);
 
-                                  //CHAFA_PIXEL_RGBA8_UNASSOCIATED,
     guchar *pixels = gdk_pixbuf_get_pixels (file);
     chafa_canvas_draw_all_pixels (canvas,
                                   CHAFA_PIXEL_ARGB8_UNASSOCIATED,
@@ -2000,5 +2008,5 @@ win_pictest(ProfWin* window)
                                   gdk_pixbuf_get_rowstride(file));
 
     GString *gs = chafa_canvas_build_ansi (canvas);
-    win_print(window, THEME_DEFAULT, "!", gs->str);
+    win_println(window, THEME_DEFAULT, "!", gs->str);
 }

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -93,7 +93,8 @@ void win_sub_page_up(ProfWin* window);
 void win_insert_last_read_position_marker(ProfWin* window, char* id);
 void win_remove_entry_message(ProfWin* window, const char* const id);
 
-// TODO: ifdef
+#ifdef HAVE_INLINE_IMAGE
 void win_pictest(ProfWin* window);
+#endif
 
 #endif

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -93,4 +93,7 @@ void win_sub_page_up(ProfWin* window);
 void win_insert_last_read_position_marker(ProfWin* window, char* id);
 void win_remove_entry_message(ProfWin* window, const char* const id);
 
+// TODO: ifdef
+void win_pictest(ProfWin* window);
+
 #endif


### PR DESCRIPTION
PR for https://github.com/profanity-im/profanity/issues/1301

So far this is just a test. Displaying an image `~/test.png` when Profanitys "about" is printed.
So far in ASCII art.

libchafa can also return colourful images using escape codes. But not sure how to use them inside ncurses yet.

I assume later we want a setting that either displays all images (URLs which we assume to be images based on ending) or we want it only explicitly with somethine like `/image` / `/imagepreview` / `/inlineimage` where one can tab through the latest URLs with image endings.