### PR TITLE
Calm OpenBSD syslog

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -334,14 +334,14 @@ _add_to_db(ProfMessage* message, char* type, const Jid* const from_jid, const Ji
                  from_jid->resourcepart ? from_jid->resourcepart : "",
                  to_jid->barejid,
                  to_jid->resourcepart ? to_jid->resourcepart : "",
-                 escaped_message,
-                 date_fmt,
+                 escaped_message ? escaped_message : "",
+                 date_fmt ? date_fmt : "",
                  message->id ? message->id : "",
                  message->stanzaid ? message->stanzaid : "",
                  message->replace_id ? message->replace_id : "",
-                 type,
-                 enc,
-                 message->stanzaid)
+                 type ? type : "",
+                 enc ? enc : "",
+                 message->stanzaid ? message->stanzaid : "")
         == -1) {
         log_error("log_database_add(): SQL query. could not allocate memory");
         return;


### PR DESCRIPTION
On every write to `chatlog.db` syslog throws
```
profanity: vfprintf %s NULL in "INSERT INTO `ChatLogs` (`from_jid`,
`from_resource`, `to_jid`, `to_resource`, `message`, `timestamp`,
`stanza_id`, `archive_id`, `replace_id`, `type`, `encryption`) SELECT
'%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' WHERE
NOT EXISTS (SELECT 1 FROM `ChatLogs` WHERE `archive_id` = '%s')"
```
in `/var/log/messages`. Checking for `NULL` except in the fields the DB
is expected to throw errors for, satisfies OpenBSDs security measures