### PR TITLE
OX: Bugfixes for OX implementation

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -2461,7 +2461,7 @@ _ox_autocomplete(ProfWin* window, const char* const input, gboolean previous)
 
     gboolean result;
     gchar** args = parse_args(input, 2, 3, &result);
-    if ((strncmp(input, "/ox", 4) == 0) && (result == TRUE)) {
+    if ((strncmp(input, "/ox ", 4) == 0) && (result == TRUE)) {
         GString* beginning = g_string_new("/ox ");
         g_string_append(beginning, args[0]);
         if (args[1]) {
@@ -2485,11 +2485,8 @@ _ox_autocomplete(ProfWin* window, const char* const input, gboolean previous)
     }
 
     found = autocomplete_param_with_ac(input, "/ox", ox_ac, TRUE, previous);
-    if (found) {
-        return found;
-    }
 
-    return NULL;
+    return found;
 }
 #endif
 

--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -2442,6 +2442,13 @@ _ox_autocomplete(ProfWin* window, const char* const input, gboolean previous)
         }
     }
 
+    if (conn_status == JABBER_CONNECTED) {
+        found = autocomplete_param_with_func(input, "/ox discover", roster_contact_autocomplete, previous, NULL);
+        if (found) {
+            return found;
+        }
+    }
+
     found = autocomplete_param_with_ac(input, "/ox log", ox_log_ac, TRUE, previous);
     if (found) {
         return found;

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1699,10 +1699,11 @@ static struct cmd_t command_defs[] = {
               "/ox char <char>",
               "/ox sendfile on|off",
               "/ox announce <file>",
-              "/ox discover",
-              "/ox request <jid>")
+              "/ox discover <jid>",
+              "/ox request <jid> <keyid>")
       CMD_DESC(
-              "OpenPGP (OX) commands to manage keys, and perform PGP encryption during chat sessions. ")
+              "OpenPGP (OX) commands to manage keys, and perform OpenPGP encryption during chat sessions."
+              "Your key need a OpenPGP UI with xmpp:local@domain.tld as name.")
       CMD_ARGS(
               { "keys", "List all keys known to the system." },
               { "contacts", "Show contacts with assigned public keys." },
@@ -1712,7 +1713,7 @@ static struct cmd_t command_defs[] = {
               { "log redact", "Log PGP encrypted messages, but replace the contents with [redacted]. This is the default." },
               { "char <char>", "Set the character to be displayed next to PGP encrypted messages." },
               { "announce <file>", "Announce a public key by pushing it on the XMPP Server" },
-              { "discover <jid>", "Discover public keys of a jid " },
+              { "discover <jid>", "Discover public keys of a jid. The keyids will be displayed" },
               { "request <jid>", "Request public keys" },
               { "sendfile on|off", "Allow /sendfile to send unencrypted files while otherwise using PGP." })
       CMD_EXAMPLES(

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7413,6 +7413,22 @@ cmd_ox(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
+    if (strcmp(args[0], "char") == 0) {
+        if (args[1] == NULL) {
+            cons_bad_cmd_usage(command);
+            return TRUE;
+        } else if (g_utf8_strlen(args[1], 4) == 1) {
+            if (prefs_set_ox_char(args[1])) {
+                cons_show("OX char set to %s.", args[1]);
+            } else {
+                cons_show_error("Could not set OX char: %s.", args[1]);
+            }
+            return TRUE;
+        }
+        cons_bad_cmd_usage(command);
+        return TRUE;
+    }
+
     // The '/ox keys' command - same like in pgp
     // Should we move this to a common command
     // e.g. '/openpgp keys'?.
@@ -7557,13 +7573,13 @@ cmd_ox(ProfWin* window, const char* const command, gchar** args)
         if (args[1]) {
             ox_discover_public_key(args[1]);
         } else {
-            cons_show("JID is required");
+            cons_show("To discover the OpenPGP keys of an user, the JID is required");
         }
     } else if (g_strcmp0(args[0], "request") == 0) {
         if (args[1] && args[2]) {
             ox_request_public_key(args[1], args[2]);
         } else {
-            cons_show("JID and Fingerprint is required");
+            cons_show("JID and KeyID is required");
         }
     } else {
         cons_show("OX not implemented");

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1371,21 +1371,39 @@ _handle_ox_chat(xmpp_stanza_t* const stanza, ProfMessage* message, gboolean is_m
 
 #ifdef HAVE_LIBGPGME
     xmpp_stanza_t* ox = xmpp_stanza_get_child_by_name_and_ns(stanza, "openpgp", STANZA_NS_OPENPGP_0);
-    message->plain = p_ox_gpg_decrypt(xmpp_stanza_get_text(ox));
+    if ( ox ) {
+        message->plain = p_ox_gpg_decrypt(xmpp_stanza_get_text(ox));
+        if ( message->plain ) {
+            xmpp_stanza_t *x =  xmpp_stanza_new_from_string(connection_get_ctx(), message->plain);
+            if ( x ) {
+                xmpp_stanza_t *p =  xmpp_stanza_get_child_by_name(x, "payload");
+                if ( !p ) {
+                    log_warning("OX Stanza - no Payload");
+                    return;
+                }
+                xmpp_stanza_t *b =  xmpp_stanza_get_child_by_name(p, "body");
+                if ( !b ) {
+                    log_warning("OX Stanza - no body");
+                    return;
+                }
+                message->plain = xmpp_stanza_get_text(b);
+                if(message->plain == NULL ) {
+                    message->plain = xmpp_stanza_get_text(stanza);
+                }
+    	        message->encrypted = xmpp_stanza_get_text(ox);
 
-    xmpp_stanza_t *x =  xmpp_stanza_new_from_string(connection_get_ctx(), message->plain);
-    xmpp_stanza_t *p =  xmpp_stanza_get_child_by_name(x, "payload");
-    xmpp_stanza_t *b =  xmpp_stanza_get_child_by_name(p, "body");
-    message->plain = xmpp_stanza_get_text(b);
-    if(message->plain == NULL ) {
-        message->plain = xmpp_stanza_get_text(stanza);
+                if (message->plain == NULL) {
+                    message->plain = xmpp_stanza_get_text(stanza);
+                }
+                message->encrypted = xmpp_stanza_get_text(ox);
+            } else {
+                log_warning("OX Stanza text to stanza failed");
+            }
+        }
+    } else {
+        log_warning("OX Stanza without openpgp stanza");
     }
-	message->encrypted = xmpp_stanza_get_text(ox);
 
-    if (message->plain == NULL) {
-        message->plain = xmpp_stanza_get_text(stanza);
-    }
-    message->encrypted = xmpp_stanza_get_text(ox);
 #endif // HAVE_LIBGPGME
 }
 

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -43,6 +43,9 @@
 #include "pgp/gpg.h"
 
 #ifdef HAVE_LIBGPGME
+
+#define KEYID_LENGTH 40
+
 static void _ox_metadata_node__public_key(const char* const fingerprint);
 static int _ox_metadata_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata);
 
@@ -161,13 +164,14 @@ ox_announce_public_key(const char* const filename)
 void
 ox_discover_public_key(const char* const jid)
 {
-    assert(jid);
-    log_info("Discovering Public Key for %s", jid);
+    assert(jid && strlen(jid) > 0);
+    log_info("[OX] Discovering Public Key for %s", jid);
     cons_show("Discovering Public Key for %s", jid);
     // iq
     xmpp_ctx_t* const ctx = connection_get_ctx();
     char* id = xmpp_uuid_gen(ctx);
     xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_GET, id);
+ 
     xmpp_stanza_set_from(iq, xmpp_conn_get_jid(connection_get_conn()));
     xmpp_stanza_set_to(iq, jid);
     // pubsub
@@ -184,6 +188,7 @@ ox_discover_public_key(const char* const jid)
 
     xmpp_id_handler_add(connection_get_conn(), _ox_metadata_result, id, strdup(jid));
     xmpp_send(connection_get_conn(), iq);
+    xmpp_stanza_release(iq);
 }
 
 void
@@ -224,7 +229,7 @@ _ox_metadata_node__public_key(const char* const fingerprint)
 {
     log_info("Annonuce OpenPGP metadata: %s", fingerprint);
     assert(fingerprint);
-    assert(strlen(fingerprint) == 40);
+    assert(strlen(fingerprint) == KEYID_LENGTH );
     // iq
     xmpp_ctx_t* const ctx = connection_get_ctx();
     char* id = xmpp_uuid_gen(ctx);
@@ -262,10 +267,10 @@ _ox_metadata_node__public_key(const char* const fingerprint)
 static int
 _ox_metadata_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata)
 {
-    log_debug("OX: Processing result %s's metadata.", (char*)userdata);
+    log_debug("[OX] Processing result %s's metadata.", (char*)userdata);
 
     if (g_strcmp0(xmpp_stanza_get_type(stanza), "result") != 0) {
-        cons_show("OX: Error:");
+        cons_show("OX Error: Unable to load metadata of user %s - Not a stanza result type", (char*)userdata );
         return FALSE;
     }
     // pubsub
@@ -297,7 +302,12 @@ _ox_metadata_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* 
 
     while (pubkeymetadata) {
         const char* fingerprint = xmpp_stanza_get_attribute(pubkeymetadata, STANZA_ATTR_V4_FINGERPRINT);
-        cons_show(fingerprint);
+        if ( strlen( fingerprint ) == KEYID_LENGTH ) {
+            cons_show(fingerprint);
+        } else {
+            cons_show("OX: Wrong char size of public key");
+            log_error("[OX] Wrong chat size of public key %s", fingerprint);
+        }
         pubkeymetadata = xmpp_stanza_get_next(pubkeymetadata);
     }
 
@@ -326,7 +336,7 @@ _ox_request_public_key(const char* const jid, const char* const fingerprint)
 {
     assert(jid);
     assert(fingerprint);
-    assert(strlen(fingerprint) == 40);
+    assert(strlen(fingerprint) == KEYID_LENGTH );
     cons_show("Requesting Public Key %s for %s", fingerprint, jid);
     log_info("OX: Request %s's public key %s.", jid, fingerprint);
     // iq


### PR DESCRIPTION
- [x]  /ox char O leads to OX not implemented
- [ ] /ox k<tab> autocompletion starts cycling somewhere, but not with and option starting with the letter k
- [ ] /ox <tab> autocompletion does not start with letter a announce
- [x] /ox discover on jid without OX leads to OX: ERROR:
- [x] /ox request <jid> leads to JID and Fingerprint is required, so further documentation