### PR TITLE
Remove "file://" from file names

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -577,6 +577,9 @@ get_expanded_path(const char* path)
     GString* exp_path = g_string_new("");
     gchar* result;
 
+    if (g_str_has_prefix(path, "file://")) {
+        path += strlen("file://");
+    }
     if (strlen(path) >= 2 && path[0] == '~' && path[1] == '/') {
         g_string_printf(exp_path, "%s/%s", getenv("HOME"), path + 2);
     } else {


### PR DESCRIPTION
Rationale: When copying an image in some application, a URL instead of a
path is copied to the clipboard.