### PR TITLE
Register nickname with MUC

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -756,6 +756,7 @@ cmd_ac_init(void)
     affiliation_cmd_ac = autocomplete_new();
     autocomplete_add(affiliation_cmd_ac, "list");
     autocomplete_add(affiliation_cmd_ac, "request");
+    autocomplete_add(affiliation_cmd_ac, "register");
     autocomplete_add(affiliation_cmd_ac, "set");
 
     role_cmd_ac = autocomplete_new();

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -695,14 +695,16 @@ static struct cmd_t command_defs[] = {
       CMD_SYN(
               "/affiliation set <affiliation> <jid> [<reason>]",
               "/affiliation list [<affiliation>]",
-              "/affiliation request")
+              "/affiliation request",
+              "/affiliation register")
       CMD_DESC(
               "Manage room affiliations. "
               "Affiliation may be one of owner, admin, member, outcast or none.")
       CMD_ARGS(
               { "set <affiliation> <jid> [<reason>]", "Set the affiliation of user with jid, with an optional reason." },
               { "list [<affiliation>]", "List all users with the specified affiliation, or all if none specified." },
-              { "request", "Request voice."})
+              { "request", "Request voice."},
+              { "register", "Register your nickname with the MUC."})
       CMD_NOEXAMPLES
     },
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -4166,6 +4166,11 @@ cmd_affiliation(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
+    if (g_strcmp0(cmd, "register") == 0) {
+        iq_muc_register_nick(mucwin->roomjid);
+        return TRUE;
+    }
+
     cons_bad_cmd_usage(command);
     return TRUE;
 }

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2828,3 +2828,18 @@ stanza_create_approve_voice(xmpp_ctx_t* ctx, const char* const id, const char* c
 
     return message;
 }
+
+xmpp_stanza_t*
+stanza_create_muc_register_nick(xmpp_ctx_t* ctx, const char* const id, const char* const jid, const char* const node, DataForm* form)
+{
+    xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, id);
+
+    xmpp_stanza_set_to(iq, jid);
+
+    xmpp_stanza_t* x = form_create_submission(form);
+
+    xmpp_stanza_add_child(iq, x);
+    xmpp_stanza_release(x);
+
+    return iq;
+}

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -159,6 +159,8 @@
 #define STANZA_TYPE_ERROR        "error"
 #define STANZA_TYPE_RESULT       "result"
 #define STANZA_TYPE_SUBMIT       "submit"
+#define STANZA_TYPE_CANCEL       "cancel"
+#define STANZA_TYPE_MODIFY       "modify"
 
 #define STANZA_ATTR_TO             "to"
 #define STANZA_ATTR_FROM           "from"
@@ -393,13 +395,10 @@ XMPPCaps* stanza_parse_caps(xmpp_stanza_t* const stanza);
 void stanza_free_caps(XMPPCaps* caps);
 
 xmpp_stanza_t* stanza_create_avatar_retrieve_data_request(xmpp_ctx_t* ctx, const char* stanza_id, const char* const item_id, const char* const jid);
-
 xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const lastid);
-
 xmpp_stanza_t* stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* const password);
-
 xmpp_stanza_t* stanza_request_voice(xmpp_ctx_t* ctx, const char* const room);
-
 xmpp_stanza_t* stanza_create_approve_voice(xmpp_ctx_t* ctx, const char* const id, const char* const jid, const char* const node, DataForm* form);
+xmpp_stanza_t* stanza_create_muc_register_nick(xmpp_ctx_t* ctx, const char* const id, const char* const jid, const char* const node, DataForm* form);
 
 #endif

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -259,6 +259,7 @@ void iq_command_list(const char* const target);
 void iq_command_exec(const char* const target, const char* const command);
 void iq_mam_request(ProfChatWin* win);
 void iq_register_change_password(const char* const user, const char* const password);
+void iq_muc_register_nick(const char* const roomjid);
 
 EntityCapabilities* caps_lookup(const char* const jid);
 void caps_close(void);

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -409,15 +409,22 @@ iq_register_change_password(const char* const user, const char* const password)
 {
 }
 
+void
+iq_muc_register_nick(const char* const roomjid)
+{
+}
+
 // caps functions
 void
 caps_add_feature(char* feature)
 {
 }
+
 void
 caps_remove_feature(char* feature)
 {
 }
+
 EntityCapabilities*
 caps_lookup(const char* const jid)
 {
@@ -428,14 +435,17 @@ void
 caps_close(void)
 {
 }
+
 void
 caps_destroy(EntityCapabilities* caps)
 {
 }
+
 void
 caps_reset_ver(void)
 {
 }
+
 gboolean
 caps_jid_has_feature(const char* const jid, const char* const feature)
 {


### PR DESCRIPTION
`/affiliation register` can now be used to register a nickname with a
MUC.

Tested with a server without forms. Couldn't find a server which
supports forms yet.
