### PR TITLE
Fix potential problems caused by unexpected stanzas

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -214,6 +214,8 @@ log_database_get_previous_chat(const gchar* const contact_barejid)
     char* query;
     const char* jid = connection_get_fulljid();
     Jid* myjid = jid_create(jid);
+    if (!myjid)
+        return NULL;
 
     if (asprintf(&query, "SELECT * FROM (SELECT `message`, `timestamp`, `from_jid`, `type` from `ChatLogs` WHERE (`from_jid` = '%s' AND `to_jid` = '%s') OR (`from_jid` = '%s' AND `to_jid` = '%s') ORDER BY `timestamp` DESC LIMIT 10) ORDER BY `timestamp` ASC;", contact_barejid, myjid->barejid, myjid->barejid, contact_barejid) == -1) {
         log_error("log_database_get_previous_chat(): SQL query. could not allocate memory");

--- a/src/database.c
+++ b/src/database.c
@@ -161,8 +161,7 @@ log_database_add_incoming(ProfMessage* message)
     if (message->to_jid) {
         _add_to_db(message, NULL, message->from_jid, message->to_jid);
     } else {
-        const char* jid = connection_get_fulljid();
-        Jid* myjid = jid_create(jid);
+        Jid* myjid = jid_create(connection_get_fulljid());
 
         _add_to_db(message, NULL, message->from_jid, myjid);
 

--- a/src/database.c
+++ b/src/database.c
@@ -181,8 +181,7 @@ _log_database_add_outgoing(char* type, const char* const id, const char* const b
     msg->timestamp = g_date_time_new_now_local(); //TODO: get from outside. best to have whole ProfMessage from outside
     msg->enc = enc;
 
-    const char* jid = connection_get_fulljid();
-    Jid* myjid = jid_create(jid);
+    Jid* myjid = jid_create(connection_get_fulljid());
 
     _add_to_db(msg, type, myjid, msg->from_jid); // TODO: myjid now in profmessage
 

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -373,8 +373,10 @@ sv_ev_room_message(ProfMessage* message)
 
     if (prefs_do_room_notify(is_current, mucwin->roomjid, mynick, message->from_jid->resourcepart, message->plain, mention, triggers != NULL)) {
         Jid* jidp = jid_create(mucwin->roomjid);
-        notify_room_message(message->from_jid->resourcepart, jidp->localpart, num, message->plain);
-        jid_destroy(jidp);
+        if (jidp) {
+            notify_room_message(message->from_jid->resourcepart, jidp->localpart, num, message->plain);
+            jid_destroy(jidp);
+        }
     }
 
     if (triggers) {

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -113,6 +113,9 @@ static int
 _avatar_metadata_handler(xmpp_stanza_t* const stanza, void* const userdata)
 {
     const char* from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    if (!from) {
+        return 1;
+    }
 
     if (!g_hash_table_contains(looking_for, from)) {
         return 1;
@@ -141,22 +144,28 @@ _avatar_metadata_handler(xmpp_stanza_t* const stanza, void* const userdata)
     xmpp_stanza_t* item = xmpp_stanza_get_child_by_name(items, "item");
     if (item) {
         xmpp_stanza_t* metadata = xmpp_stanza_get_child_by_name(item, "metadata");
-        if (!metadata)
-            return 1;
+        if (metadata) {
 
-        xmpp_stanza_t* info = xmpp_stanza_get_child_by_name(metadata, "info");
+            xmpp_stanza_t* info = xmpp_stanza_get_child_by_name(metadata, "info");
+            if (info) {
 
-        const char* id = xmpp_stanza_get_id(info);
-        const char* type = xmpp_stanza_get_attribute(info, "type");
+                const char* id = xmpp_stanza_get_id(info);
+                const char* type = xmpp_stanza_get_attribute(info, "type");
 
-        log_debug("Avatar ID for %s is: %s", from, id);
+                if(id && type) {
+                    log_debug("Avatar ID for %s is: %s", from, id);
 
-        avatar_metadata* data = malloc(sizeof(avatar_metadata));
-        data->type = strdup(type);
-        data->id = strdup(id);
+                    avatar_metadata* data = malloc(sizeof(avatar_metadata));
+                    if(data) {
+                        data->type = strdup(type);
+                        data->id = strdup(id);
 
-        // request the actual (image) data
-        _avatar_request_item_by_id(from, data);
+                        // request the actual (image) data
+                        _avatar_request_item_by_id(from, data);
+                    }
+                }
+            }
+        }
     }
 
     return 1;

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -224,6 +224,10 @@ _avatar_request_item_result_handler(xmpp_stanza_t* const stanza, void* const use
     }
 
     char* buf = xmpp_stanza_get_text(st_data);
+    if (!buf) {
+        return 1;
+    }
+
     gsize size;
     gchar* de = (gchar*)g_base64_decode(buf, &size);
     free(buf);

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -288,11 +288,13 @@ void
 iq_id_handler_add(const char* const id, ProfIqCallback func, ProfIqFreeCallback free_func, void* userdata)
 {
     ProfIqHandler* handler = malloc(sizeof(ProfIqHandler));
-    handler->func = func;
-    handler->free_func = free_func;
-    handler->userdata = userdata;
+    if (handler) {
+        handler->func = func;
+        handler->free_func = free_func;
+        handler->userdata = userdata;
 
-    g_hash_table_insert(id_handlers, strdup(id), handler);
+        g_hash_table_insert(id_handlers, strdup(id), handler);
+    }
 }
 
 void
@@ -481,15 +483,17 @@ iq_room_info_request(const char* const room, gboolean display_result)
     xmpp_stanza_t* iq = stanza_create_disco_info_iq(ctx, id, room, NULL);
 
     ProfRoomInfoData* cb_data = malloc(sizeof(ProfRoomInfoData));
-    cb_data->room = strdup(room);
-    cb_data->display = display_result;
+    if (cb_data) {
+        cb_data->room = strdup(room);
+        cb_data->display = display_result;
 
-    iq_id_handler_add(id, _room_info_response_id_handler, (ProfIqFreeCallback)_iq_free_room_data, cb_data);
+        iq_id_handler_add(id, _room_info_response_id_handler, (ProfIqFreeCallback)_iq_free_room_data, cb_data);
+
+        iq_send_stanza(iq);
+        xmpp_stanza_release(iq);
+    }
 
     free(id);
-
-    iq_send_stanza(iq);
-    xmpp_stanza_release(iq);
 }
 
 void
@@ -667,13 +671,15 @@ iq_room_affiliation_list(const char* const room, char* affiliation, bool show_ui
     const char* id = xmpp_stanza_get_id(iq);
 
     ProfAffiliationList* affiliation_list = malloc(sizeof(ProfAffiliationList));
-    affiliation_list->affiliation = strdup(affiliation);
-    affiliation_list->show_ui_message = show_ui_message;
+    if (affiliation_list) {
+        affiliation_list->affiliation = strdup(affiliation);
+        affiliation_list->show_ui_message = show_ui_message;
 
-    iq_id_handler_add(id, _room_affiliation_list_result_id_handler, (ProfIqFreeCallback)_iq_free_affiliation_list, affiliation_list);
+        iq_id_handler_add(id, _room_affiliation_list_result_id_handler, (ProfIqFreeCallback)_iq_free_affiliation_list, affiliation_list);
 
-    iq_send_stanza(iq);
-    xmpp_stanza_release(iq);
+        iq_send_stanza(iq);
+        xmpp_stanza_release(iq);
+    }
 }
 
 void
@@ -699,13 +705,15 @@ iq_room_affiliation_set(const char* const room, const char* const jid, char* aff
     const char* id = xmpp_stanza_get_id(iq);
 
     ProfPrivilegeSet* affiliation_set = malloc(sizeof(struct privilege_set_t));
-    affiliation_set->item = strdup(jid);
-    affiliation_set->privilege = strdup(affiliation);
+    if (affiliation_set) {
+        affiliation_set->item = strdup(jid);
+        affiliation_set->privilege = strdup(affiliation);
 
-    iq_id_handler_add(id, _room_affiliation_set_result_id_handler, (ProfIqFreeCallback)_iq_free_affiliation_set, affiliation_set);
+        iq_id_handler_add(id, _room_affiliation_set_result_id_handler, (ProfIqFreeCallback)_iq_free_affiliation_set, affiliation_set);
 
-    iq_send_stanza(iq);
-    xmpp_stanza_release(iq);
+        iq_send_stanza(iq);
+        xmpp_stanza_release(iq);
+    }
 }
 
 void
@@ -718,13 +726,15 @@ iq_room_role_set(const char* const room, const char* const nick, char* role,
     const char* id = xmpp_stanza_get_id(iq);
 
     struct privilege_set_t* role_set = malloc(sizeof(ProfPrivilegeSet));
-    role_set->item = strdup(nick);
-    role_set->privilege = strdup(role);
+    if (role_set) {
+        role_set->item = strdup(nick);
+        role_set->privilege = strdup(role);
 
-    iq_id_handler_add(id, _room_role_set_result_id_handler, (ProfIqFreeCallback)_iq_free_affiliation_set, role_set);
+        iq_id_handler_add(id, _room_role_set_result_id_handler, (ProfIqFreeCallback)_iq_free_affiliation_set, role_set);
 
-    iq_send_stanza(iq);
-    xmpp_stanza_release(iq);
+        iq_send_stanza(iq);
+        xmpp_stanza_release(iq);
+    }
 }
 
 void
@@ -2162,27 +2172,29 @@ _room_info_response_id_handler(xmpp_stanza_t* const stanza, void* const userdata
                 if (name || category || type) {
                     DiscoIdentity* identity = malloc(sizeof(struct disco_identity_t));
 
-                    if (name) {
-                        identity->name = strdup(name);
-                        ProfMucWin* mucwin = wins_get_muc(cb_data->room);
-                        if (mucwin) {
-                            mucwin->room_name = strdup(name);
+                    if (identity) {
+                        if (name) {
+                            identity->name = strdup(name);
+                            ProfMucWin* mucwin = wins_get_muc(cb_data->room);
+                            if (mucwin) {
+                                mucwin->room_name = strdup(name);
+                            }
+                        } else {
+                            identity->name = NULL;
                         }
-                    } else {
-                        identity->name = NULL;
-                    }
-                    if (category) {
-                        identity->category = strdup(category);
-                    } else {
-                        identity->category = NULL;
-                    }
-                    if (type) {
-                        identity->type = strdup(type);
-                    } else {
-                        identity->type = NULL;
-                    }
+                        if (category) {
+                            identity->category = strdup(category);
+                        } else {
+                            identity->category = NULL;
+                        }
+                        if (type) {
+                            identity->type = strdup(type);
+                        } else {
+                            identity->type = NULL;
+                        }
 
-                    identities = g_slist_append(identities, identity);
+                        identities = g_slist_append(identities, identity);
+                    }
                 }
             }
 
@@ -2309,23 +2321,25 @@ _disco_info_response_id_handler(xmpp_stanza_t* const stanza, void* const userdat
                 if (name || category || type) {
                     DiscoIdentity* identity = malloc(sizeof(struct disco_identity_t));
 
-                    if (name) {
-                        identity->name = strdup(name);
-                    } else {
-                        identity->name = NULL;
-                    }
-                    if (category) {
-                        identity->category = strdup(category);
-                    } else {
-                        identity->category = NULL;
-                    }
-                    if (type) {
-                        identity->type = strdup(type);
-                    } else {
-                        identity->type = NULL;
-                    }
+                    if (identity) {
+                        if (name) {
+                            identity->name = strdup(name);
+                        } else {
+                            identity->name = NULL;
+                        }
+                        if (category) {
+                            identity->category = strdup(category);
+                        } else {
+                            identity->category = NULL;
+                        }
+                        if (type) {
+                            identity->type = strdup(type);
+                        } else {
+                            identity->type = NULL;
+                        }
 
-                    identities = g_slist_append(identities, identity);
+                        identities = g_slist_append(identities, identity);
+                    }
                 }
             }
 
@@ -2491,14 +2505,16 @@ _disco_items_result_handler(xmpp_stanza_t* const stanza)
             const char* item_jid = xmpp_stanza_get_attribute(child, STANZA_ATTR_JID);
             if (item_jid) {
                 DiscoItem* item = malloc(sizeof(struct disco_item_t));
-                item->jid = strdup(item_jid);
-                const char* item_name = xmpp_stanza_get_attribute(child, STANZA_ATTR_NAME);
-                if (item_name) {
-                    item->name = strdup(item_name);
-                } else {
-                    item->name = NULL;
+                if (item) {
+                    item->jid = strdup(item_jid);
+                    const char* item_name = xmpp_stanza_get_attribute(child, STANZA_ATTR_NAME);
+                    if (item_name) {
+                        item->name = strdup(item_name);
+                    } else {
+                        item->name = NULL;
+                    }
+                    items = g_slist_append(items, item);
                 }
-                items = g_slist_append(items, item);
             }
         }
 
@@ -2578,10 +2594,12 @@ iq_mam_request(ProfChatWin* win)
     xmpp_stanza_t* iq = stanza_create_mam_iq(ctx, win->barejid, datestr, NULL);
 
     MamRsmUserdata* data = malloc(sizeof(MamRsmUserdata));
-    data->datestr = strdup(datestr);
-    data->barejid = strdup(win->barejid);
+    if (data) {
+        data->datestr = strdup(datestr);
+        data->barejid = strdup(win->barejid);
 
-    iq_id_handler_add(xmpp_stanza_get_id(iq), _mam_rsm_id_handler, NULL, data);
+        iq_id_handler_add(xmpp_stanza_get_id(iq), _mam_rsm_id_handler, NULL, data);
+    }
 
     g_free(datestr);
     g_date_time_unref(timestamp);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1142,7 +1142,7 @@ _handle_receipt_received(xmpp_stanza_t* const stanza)
     xmpp_stanza_t* receipt = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_RECEIPTS);
     if (receipt) {
         const char* name = xmpp_stanza_get_name(receipt);
-        if (g_strcmp0(name, "received") != 0) {
+        if ((name == NULL) || (g_strcmp0(name, "received") != 0)) {
             return;
         }
 
@@ -1157,6 +1157,10 @@ _handle_receipt_received(xmpp_stanza_t* const stanza)
         }
 
         Jid* jidp = jid_create(fulljid);
+        if(!jidp) {
+            return;
+        }
+
         sv_ev_message_receipt(jidp->barejid, id);
         jid_destroy(jidp);
     }

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1290,6 +1290,9 @@ _handle_chat(xmpp_stanza_t* const stanza, gboolean is_mam, gboolean is_carbon, c
         return;
     }
     Jid* jid = jid_create(from);
+    if (!jid) {
+        return;
+    }
 
     // private message from chat room use full jid (room/nick)
     if (muc_active(jid->barejid)) {

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1131,24 +1131,26 @@ static void
 _handle_receipt_received(xmpp_stanza_t* const stanza)
 {
     xmpp_stanza_t* receipt = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_RECEIPTS);
-    const char* name = xmpp_stanza_get_name(receipt);
-    if (g_strcmp0(name, "received") != 0) {
-        return;
-    }
+    if (receipt) {
+        const char* name = xmpp_stanza_get_name(receipt);
+        if (g_strcmp0(name, "received") != 0) {
+            return;
+        }
 
-    const char* id = xmpp_stanza_get_id(receipt);
-    if (!id) {
-        return;
-    }
+        const char* id = xmpp_stanza_get_id(receipt);
+        if (!id) {
+            return;
+        }
 
-    const char* fulljid = xmpp_stanza_get_from(stanza);
-    if (!fulljid) {
-        return;
-    }
+        const char* fulljid = xmpp_stanza_get_from(stanza);
+        if (!fulljid) {
+            return;
+        }
 
-    Jid* jidp = jid_create(fulljid);
-    sv_ev_message_receipt(jidp->barejid, id);
-    jid_destroy(jidp);
+        Jid* jidp = jid_create(fulljid);
+        sv_ev_message_receipt(jidp->barejid, id);
+        jid_destroy(jidp);
+    }
 }
 
 static void

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -116,14 +116,12 @@ _handled_by_plugin(xmpp_stanza_t* const stanza)
 static void
 _handle_headline(xmpp_stanza_t* const stanza)
 {
-    xmpp_ctx_t* ctx = connection_get_ctx();
-    char* text = NULL;
     xmpp_stanza_t* body = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_BODY);
     if (body) {
-        text = xmpp_stanza_get_text(body);
+        char *text = xmpp_stanza_get_text(body);
         if (text) {
             cons_show("Headline: %s", text);
-            xmpp_free(ctx, text);
+            xmpp_free(connection_get_ctx(), text);
         }
     }
 }

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1425,22 +1425,38 @@ _handle_ox_chat(xmpp_stanza_t* const stanza, ProfMessage* message, gboolean is_m
     message->enc = PROF_MSG_ENC_OX;
 
 #ifdef HAVE_LIBGPGME
+    xmpp_ctx_t* const ctx = connection_get_ctx();
+
     xmpp_stanza_t* ox = xmpp_stanza_get_child_by_name_and_ns(stanza, "openpgp", STANZA_NS_OPENPGP_0);
-    message->plain = p_ox_gpg_decrypt(xmpp_stanza_get_text(ox));
+    if (!ox) {
+        return;
+    }
 
-    xmpp_stanza_t *x =  xmpp_stanza_new_from_string(connection_get_ctx(), message->plain);
+    char* ox_text = xmpp_stanza_get_text(ox);
+    if (!ox_text) {
+        return;
+    }
+
+    message->plain = p_ox_gpg_decrypt(ox_text);
+    xmpp_free(ctx, ox_text);
+
+    xmpp_stanza_t *x =  xmpp_stanza_new_from_string(ctx, message->plain);
     xmpp_stanza_t *p =  xmpp_stanza_get_child_by_name(x, "payload");
-    xmpp_stanza_t *b =  xmpp_stanza_get_child_by_name(p, "body");
-    message->plain = xmpp_stanza_get_text(b);
-    if(message->plain == NULL ) {
-        message->plain = xmpp_stanza_get_text(stanza);
-    }
-	message->encrypted = xmpp_stanza_get_text(ox);
+    if (p) {
+        xmpp_stanza_t *b =  xmpp_stanza_get_child_by_name(p, "body");
+        if (b) {
+            message->plain = xmpp_stanza_get_text(b);
+            if(message->plain == NULL ) {
+                message->plain = xmpp_stanza_get_text(stanza);
+            }
+            message->encrypted = xmpp_stanza_get_text(ox);
 
-    if (message->plain == NULL) {
-        message->plain = xmpp_stanza_get_text(stanza);
+            if (message->plain == NULL) {
+                message->plain = xmpp_stanza_get_text(stanza);
+            }
+            message->encrypted = xmpp_stanza_get_text(ox);
+        }
     }
-    message->encrypted = xmpp_stanza_get_text(ox);
 #endif // HAVE_LIBGPGME
 }
 

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -877,6 +877,10 @@ _handle_muc_user(xmpp_stanza_t* const stanza)
     xmpp_stanza_t* xns_muc_user = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_MUC_USER);
     const char* room = xmpp_stanza_get_from(stanza);
 
+    if (!xns_muc_user) {
+        return;
+    }
+
     if (!room) {
         log_warning("Message received with no from attribute, ignoring");
         return;

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -990,7 +990,13 @@ _handle_groupchat(xmpp_stanza_t* const stanza)
     xmpp_ctx_t* ctx = connection_get_ctx();
 
     const char* room_jid = xmpp_stanza_get_from(stanza);
+    if(!room_jid) {
+        return;
+    }
     Jid* from_jid = jid_create(room_jid);
+    if(!from_jid) {
+        return;
+    }
 
     // handle room subject
     xmpp_stanza_t* subject = xmpp_stanza_get_child_by_name(stanza, STANZA_NAME_SUBJECT);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -937,6 +937,11 @@ _handle_conference(xmpp_stanza_t* const stanza)
     xmpp_stanza_t* xns_conference = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_CONFERENCE);
 
     if (xns_conference) {
+        // XEP-0249
+        const char* room = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_JID);
+        if (!room) {
+            return;
+        }
 
         const char* from = xmpp_stanza_get_from(stanza);
         if (!from) {
@@ -946,13 +951,6 @@ _handle_conference(xmpp_stanza_t* const stanza)
 
         Jid* jidp = jid_create(from);
         if (!jidp) {
-            return;
-        }
-
-        // XEP-0249
-        const char* room = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_JID);
-        if (!room) {
-            jid_destroy(jidp);
             return;
         }
 

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1193,7 +1193,14 @@ _handle_muc_private_message(xmpp_stanza_t* const stanza)
     message->type = PROF_MSG_TYPE_MUCPM;
 
     const gchar* from = xmpp_stanza_get_from(stanza);
+    if (!from) {
+        goto out;
+    }
+
     message->from_jid = jid_create(from);
+    if (!message->from_jid) {
+        goto out;
+    }
 
     // message stanza id
     const char* id = xmpp_stanza_get_id(stanza);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -276,6 +276,9 @@ _handle_form(xmpp_stanza_t* const stanza)
     }
 
     const char* const stanza_from = xmpp_stanza_get_from(stanza);
+    if (!stanza_from) {
+        return FALSE;
+    }
 
     DataForm* form = form_create(result);
     ProfConfWin* confwin = (ProfConfWin*)wins_new_config(stanza_from, form, message_muc_submit_voice_approve, NULL, NULL);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1184,7 +1184,7 @@ _receipt_request_handler(xmpp_stanza_t* const stanza)
     }
 
     const char* receipts_name = xmpp_stanza_get_name(receipts);
-    if (g_strcmp0(receipts_name, "request") != 0) {
+    if ((receipts_name == NULL) || (g_strcmp0(receipts_name, "request") != 0)) {
         return;
     }
 

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -226,13 +226,15 @@ _message_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* con
             char* mybarejid = connection_get_barejid();
             const char* const stanza_from = xmpp_stanza_get_from(stanza);
 
-            if (g_strcmp0(mybarejid, stanza_from) != 0) {
-                log_warning("Invalid carbon received, from: %s", stanza_from);
-                msg_stanza = NULL;
-            } else {
-                is_carbon = TRUE;
-                // returns NULL if it was a carbon that was invalid, so that we dont parse later
-                msg_stanza = _handle_carbons(carbons);
+            if (stanza_from) {
+                if (g_strcmp0(mybarejid, stanza_from) != 0) {
+                    log_warning("Invalid carbon received, from: %s", stanza_from);
+                    msg_stanza = NULL;
+                } else {
+                    is_carbon = TRUE;
+                    // returns NULL if it was a carbon that was invalid, so that we dont parse later
+                    msg_stanza = _handle_carbons(carbons);
+                }
             }
 
             free(mybarejid);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -931,29 +931,33 @@ _handle_conference(xmpp_stanza_t* const stanza)
 {
     xmpp_stanza_t* xns_conference = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_CONFERENCE);
 
-    const char* from = xmpp_stanza_get_from(stanza);
-    if (!from) {
-        log_warning("Message received with no from attribute, ignoring");
-        return;
-    }
+    if (xns_conference) {
 
-    Jid* jidp = jid_create(from);
-    if (!jidp) {
-        return;
-    }
+        const char* from = xmpp_stanza_get_from(stanza);
+        if (!from) {
+            log_warning("Message received with no from attribute, ignoring");
+            return;
+        }
 
-    // XEP-0249
-    const char* room = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_JID);
-    if (!room) {
+        Jid* jidp = jid_create(from);
+        if (!jidp) {
+            return;
+        }
+
+        // XEP-0249
+        const char* room = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_JID);
+        if (!room) {
+            jid_destroy(jidp);
+            return;
+        }
+
+        // reason and password are both optional
+        const char* reason = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_REASON);
+        const char* password = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_PASSWORD);
+
+        sv_ev_room_invite(INVITE_DIRECT, jidp->barejid, room, reason, password);
         jid_destroy(jidp);
-        return;
     }
-
-    const char* reason = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_REASON);
-    const char* password = xmpp_stanza_get_attribute(xns_conference, STANZA_ATTR_PASSWORD);
-
-    sv_ev_room_invite(INVITE_DIRECT, jidp->barejid, room, reason, password);
-    jid_destroy(jidp);
 }
 
 static void

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -864,8 +864,10 @@ _handle_error(xmpp_stanza_t* const stanza)
     } else {
         if (type && (strcmp(type, "cancel") == 0)) {
             Jid* jidp = jid_create(jid);
-            chat_session_remove(jidp->barejid);
-            jid_destroy(jidp);
+            if (jidp) {
+                chat_session_remove(jidp->barejid);
+                jid_destroy(jidp);
+            }
         }
         ui_handle_recipient_error(jid, err_msg);
     }

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1176,9 +1176,13 @@ _receipt_request_handler(xmpp_stanza_t* const stanza)
     }
 
     const gchar* from = xmpp_stanza_get_from(stanza);
-    Jid* jid = jid_create(from);
-    _message_send_receipt(jid->fulljid, id);
-    jid_destroy(jid);
+    if (from) {
+        Jid* jid = jid_create(from);
+        if (jid) {
+            _message_send_receipt(jid->fulljid, id);
+            jid_destroy(jid);
+        }
+    }
 }
 
 static void

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -118,7 +118,9 @@ ox_announce_public_key(const char* const filename)
 
         xmpp_stanza_t* item = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(item, STANZA_NAME_ITEM);
-        xmpp_stanza_set_attribute(item, STANZA_ATTR_ID, _gettimestamp());
+        char *timestamp = _gettimestamp();
+        xmpp_stanza_set_attribute(item, STANZA_ATTR_ID, timestamp);
+        free(timestamp);
 
         xmpp_stanza_t* pubkey = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(pubkey, STANZA_NAME_PUPKEY);

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -87,7 +87,7 @@ ox_announce_public_key(const char* const filename)
     assert(filename);
 
     cons_show("Annonuce OpenPGP Key for OX %s ...", filename);
-    log_info("Annonuce OpenPGP Key of OX: %s", filename);
+    log_info("[OX] Annonuce OpenPGP Key of OX: %s", filename);
 
     // key the key and the fingerprint via GnuPG from file
     char* key = NULL;
@@ -98,7 +98,7 @@ ox_announce_public_key(const char* const filename)
         cons_show("Error during OpenPGP OX announce. See log file for more information");
         return FALSE;
     } else {
-        log_info("Annonuce OpenPGP Key for Fingerprint: %s", fp);
+        log_info("[OX] Annonuce OpenPGP Key for Fingerprint: %s", fp);
         xmpp_ctx_t* const ctx = connection_get_ctx();
         char* id = xmpp_uuid_gen(ctx);
         xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, id);
@@ -262,34 +262,34 @@ _ox_metadata_node__public_key(const char* const fingerprint)
 static int
 _ox_metadata_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata)
 {
-    log_debug("OX: Processing result %s's metadata.", (char*)userdata);
+    log_debug("[OX] Processing result %s's metadata.", (char*)userdata);
 
     if (g_strcmp0(xmpp_stanza_get_type(stanza), "result") != 0) {
-        cons_show("OX: Error:");
+        cons_show("[OX] Error:");
         return FALSE;
     }
     // pubsub
     xmpp_stanza_t* pubsub = xmpp_stanza_get_child_by_name_and_ns(stanza, STANZA_NAME_PUBSUB, XMPP_FEATURE_PUBSUB);
     if (!pubsub) {
-        cons_show("OX: Error: No pubsub");
+        cons_show("[OX] Error: No pubsub");
         return FALSE;
     }
 
     xmpp_stanza_t* items = xmpp_stanza_get_child_by_name(pubsub, STANZA_NAME_ITEMS);
     if (!items) {
-        cons_show("OX: Error: No items");
+        cons_show("[OX] Error: No items");
         return FALSE;
     }
 
     xmpp_stanza_t* item = xmpp_stanza_get_child_by_name(items, STANZA_NAME_ITEM);
     if (!item) {
-        cons_show("OX: Error: No item");
+        cons_show("[OX] Error: No item");
         return FALSE;
     }
 
     xmpp_stanza_t* publickeyslist = xmpp_stanza_get_child_by_name_and_ns(item, STANZA_NAME_PUBLIC_KEYS_LIST, STANZA_NS_OPENPGP_0);
     if (!publickeyslist) {
-        cons_show("OX: Error: No publickeyslist");
+        cons_show("[OX] Error: No publickeyslist");
         return FALSE;
     }
 
@@ -328,7 +328,7 @@ _ox_request_public_key(const char* const jid, const char* const fingerprint)
     assert(fingerprint);
     assert(strlen(fingerprint) == 40);
     cons_show("Requesting Public Key %s for %s", fingerprint, jid);
-    log_info("OX: Request %s's public key %s.", jid, fingerprint);
+    log_info("[OX] Request %s's public key %s.", jid, fingerprint);
     // iq
     xmpp_ctx_t* const ctx = connection_get_ctx();
     char* id = xmpp_uuid_gen(ctx);
@@ -384,39 +384,39 @@ _ox_request_public_key(const char* const jid, const char* const fingerprint)
 int
 _ox_public_key_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata)
 {
-    log_debug("OX: Processing result public key");
+    log_debug("[OX] Processing result public key");
 
     if (g_strcmp0(xmpp_stanza_get_type(stanza), "result") != 0) {
         cons_show("Public Key import failed. Check log for details.");
-        log_error("OX: Public Key response type is wrong");
+        log_error("[OX] Public Key response type is wrong");
         return FALSE;
     }
     // pubsub
     xmpp_stanza_t* pubsub = xmpp_stanza_get_child_by_name_and_ns(stanza, STANZA_NAME_PUBSUB, XMPP_FEATURE_PUBSUB);
     if (!pubsub) {
         cons_show("Public Key import failed. Check log for details.");
-        log_error("OX: Public key request response failed: No <pubsub/>");
+        log_error("[OX] Public key request response failed: No <pubsub/>");
         return FALSE;
     }
 
     xmpp_stanza_t* items = xmpp_stanza_get_child_by_name(pubsub, STANZA_NAME_ITEMS);
     if (!items) {
         cons_show("Public Key import failed. Check log for details.");
-        log_error("OX: Public key request response failed: No <items/>");
+        log_error("[OX] Public key request response failed: No <items/>");
         return FALSE;
     }
 
     xmpp_stanza_t* item = xmpp_stanza_get_child_by_name(items, STANZA_NAME_ITEM);
     if (!item) {
         cons_show("Public Key import failed. Check log for details.");
-        log_error("OX: Public key request response failed: No <item/>");
+        log_error("[OX] Public key request response failed: No <item/>");
         return FALSE;
     }
 
     xmpp_stanza_t* pubkey = xmpp_stanza_get_child_by_name_and_ns(item, STANZA_NAME_PUPKEY, STANZA_NS_OPENPGP_0);
     if (!pubkey) {
         cons_show("Public Key import failed. Check log for details.");
-        log_error("OX: Public key request response failed: No <pubkey/>");
+        log_error("[OX] Public key request response failed: No <pubkey/>");
         return FALSE;
     }
     xmpp_stanza_t* data = xmpp_stanza_get_child_by_name(pubkey, STANZA_NAME_DATA);

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -265,7 +265,7 @@ _ox_metadata_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* 
     log_debug("[OX] Processing result %s's metadata.", (char*)userdata);
 
     if (g_strcmp0(xmpp_stanza_get_type(stanza), "result") != 0) {
-        cons_show("[OX] Error:");
+        log_debug("[OX] Error: No result");
         return FALSE;
     }
     // pubsub

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -297,7 +297,9 @@ _ox_metadata_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* 
 
     while (pubkeymetadata) {
         const char* fingerprint = xmpp_stanza_get_attribute(pubkeymetadata, STANZA_ATTR_V4_FINGERPRINT);
-        cons_show(fingerprint);
+        if (fingerprint) {
+            cons_show(fingerprint);
+        }
         pubkeymetadata = xmpp_stanza_get_next(pubkeymetadata);
     }
 

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -421,13 +421,23 @@ _ox_public_key_result(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void
         log_error("[OX] Public key request response failed: No <pubkey/>");
         return FALSE;
     }
+
     xmpp_stanza_t* data = xmpp_stanza_get_child_by_name(pubkey, STANZA_NAME_DATA);
+    if (!data) {
+        log_error("[OX] No data");
+    }
+
     char* base64_data = xmpp_stanza_get_text(data);
-    log_debug("Key data: %s", base64_data);
-    if (p_ox_gpg_import(base64_data)) {
-        cons_show("Public Key imported");
-    } else {
-        cons_show("Public Key import failed. Check log for details.");
+    if (base64_data) {
+        log_debug("Key data: %s", base64_data);
+
+        if (p_ox_gpg_import(base64_data)) {
+            cons_show("Public Key imported");
+        } else {
+            cons_show("Public Key import failed. Check log for details.");
+        }
+
+        free(base64_data);
     }
 
     return FALSE;

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -1507,11 +1507,8 @@ stanza_get_muc_destroy_alternative_room(xmpp_stanza_t* stanza)
     }
 
     const char* jid = xmpp_stanza_get_attribute(destroy, STANZA_ATTR_JID);
-    if (jid) {
-        return jid;
-    }
 
-    return NULL;
+    return jid;
 }
 
 char*

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -986,7 +986,7 @@ stanza_create_caps_query_element(xmpp_ctx_t* ctx)
 
     GString* name_str = g_string_new("Profanity ");
     g_string_append(name_str, PACKAGE_VERSION);
-    if (strcmp(PACKAGE_STATUS, "development") == 0) {
+    if (g_strcmp0(PACKAGE_STATUS, "development") == 0) {
 #ifdef HAVE_GIT_VERSION
         g_string_append(name_str, "dev.");
         g_string_append(name_str, PROF_GIT_BRANCH);
@@ -1074,16 +1074,16 @@ stanza_create_caps_sha1_from_query(xmpp_stanza_t* const query)
                 g_string_append(identity_str, name);
             }
             g_string_append(identity_str, "<");
-            identities = g_slist_insert_sorted(identities, g_strdup(identity_str->str), (GCompareFunc)strcmp);
+            identities = g_slist_insert_sorted(identities, g_strdup(identity_str->str), (GCompareFunc)g_strcmp0);
             g_string_free(identity_str, TRUE);
         } else if (g_strcmp0(xmpp_stanza_get_name(child), STANZA_NAME_FEATURE) == 0) {
             const char* feature_str = xmpp_stanza_get_attribute(child, "var");
-            features = g_slist_insert_sorted(features, g_strdup(feature_str), (GCompareFunc)strcmp);
+            features = g_slist_insert_sorted(features, g_strdup(feature_str), (GCompareFunc)g_strcmp0);
         } else if (g_strcmp0(xmpp_stanza_get_name(child), STANZA_NAME_X) == 0) {
             if (g_strcmp0(xmpp_stanza_get_ns(child), STANZA_NS_DATA) == 0) {
                 DataForm* form = form_create(child);
                 char* form_type = form_get_form_type_field(form);
-                form_names = g_slist_insert_sorted(form_names, g_strdup(form_type), (GCompareFunc)strcmp);
+                form_names = g_slist_insert_sorted(form_names, g_strdup(form_type), (GCompareFunc)g_strcmp0);
                 g_hash_table_insert(forms, g_strdup(form_type), form);
             }
         }
@@ -1154,9 +1154,9 @@ stanza_get_child_by_name_and_from(xmpp_stanza_t* const stanza, const char* const
 
     for (child = xmpp_stanza_get_children(stanza); child; child = xmpp_stanza_get_next(child)) {
         child_name = xmpp_stanza_get_name(child);
-        if (child_name && strcmp(name, child_name) == 0) {
+        if (child_name && g_strcmp0(name, child_name) == 0) {
             child_from = xmpp_stanza_get_attribute(child, STANZA_ATTR_FROM);
-            if (child_from && strcmp(from, child_from) == 0) {
+            if (child_from && g_strcmp0(from, child_from) == 0) {
                 break;
             }
         }
@@ -1177,7 +1177,7 @@ _stanza_get_delay_timestamp_xep0203(xmpp_stanza_t* const delay_stanza)
     GTimeVal utc_stamp;
     const char* xmlns = xmpp_stanza_get_attribute(delay_stanza, STANZA_ATTR_XMLNS);
 
-    if (xmlns && (strcmp(xmlns, "urn:xmpp:delay") == 0)) {
+    if (xmlns && (g_strcmp0(xmlns, "urn:xmpp:delay") == 0)) {
         const char* stamp = xmpp_stanza_get_attribute(delay_stanza, STANZA_ATTR_STAMP);
 
         if (stamp && (g_time_val_from_iso8601(stamp, &utc_stamp))) {
@@ -1199,7 +1199,7 @@ _stanza_get_delay_timestamp_xep0091(xmpp_stanza_t* const x_stanza)
     GTimeVal utc_stamp;
     const char* xmlns = xmpp_stanza_get_attribute(x_stanza, STANZA_ATTR_XMLNS);
 
-    if (xmlns && (strcmp(xmlns, "jabber:x:delay") == 0)) {
+    if (xmlns && (g_strcmp0(xmlns, "jabber:x:delay") == 0)) {
         const char* stamp = xmpp_stanza_get_attribute(x_stanza, STANZA_ATTR_STAMP);
         if (stamp && (g_time_val_from_iso8601(stamp, &utc_stamp))) {
 
@@ -1256,7 +1256,7 @@ stanza_get_oldest_delay(xmpp_stanza_t* const stanza)
 
         child_name = xmpp_stanza_get_name(child);
 
-        if (child_name && strcmp(child_name, STANZA_NAME_DELAY) == 0) {
+        if (child_name && g_strcmp0(child_name, STANZA_NAME_DELAY) == 0) {
             GDateTime* tmp = _stanza_get_delay_timestamp_xep0203(child);
 
             if (oldest == NULL) {
@@ -1269,7 +1269,7 @@ stanza_get_oldest_delay(xmpp_stanza_t* const stanza)
             }
         }
 
-        if (child_name && strcmp(child_name, STANZA_NAME_X) == 0) {
+        if (child_name && g_strcmp0(child_name, STANZA_NAME_X) == 0) {
             GDateTime* tmp = _stanza_get_delay_timestamp_xep0091(child);
 
             if (oldest == NULL) {
@@ -1320,7 +1320,7 @@ stanza_is_muc_presence(xmpp_stanza_t* const stanza)
     if (stanza == NULL) {
         return FALSE;
     }
-    if (strcmp(xmpp_stanza_get_name(stanza), STANZA_NAME_PRESENCE) != 0) {
+    if (g_strcmp0(xmpp_stanza_get_name(stanza), STANZA_NAME_PRESENCE) != 0) {
         return FALSE;
     }
 
@@ -1668,7 +1668,7 @@ stanza_get_new_nick(xmpp_stanza_t* const stanza)
     xmpp_stanza_t* x_children = xmpp_stanza_get_children(x);
 
     while (x_children) {
-        if (strcmp(xmpp_stanza_get_name(x_children), STANZA_NAME_ITEM) == 0) {
+        if (g_strcmp0(xmpp_stanza_get_name(x_children), STANZA_NAME_ITEM) == 0) {
             const char* nick = xmpp_stanza_get_attribute(x_children, STANZA_ATTR_NICK);
             if (nick) {
                 return nick;
@@ -1694,7 +1694,7 @@ stanza_get_idle_time(xmpp_stanza_t* const stanza)
         return 0;
     }
 
-    if (strcmp(ns, STANZA_NS_LASTACTIVITY) != 0) {
+    if (g_strcmp0(ns, STANZA_NS_LASTACTIVITY) != 0) {
         return 0;
     }
 
@@ -1756,19 +1756,19 @@ stanza_create_caps_from_query_element(xmpp_stanza_t* query)
             while (field) {
                 formField = field->data;
                 if (formField->values) {
-                    if (strcmp(formField->var, "software") == 0) {
+                    if (g_strcmp0(formField->var, "software") == 0) {
                         if (software == NULL) {
                             software = strdup(formField->values->data);
                         }
-                    } else if (strcmp(formField->var, "software_version") == 0) {
+                    } else if (g_strcmp0(formField->var, "software_version") == 0) {
                         if (software_version == NULL) {
                             software_version = strdup(formField->values->data);
                         }
-                    } else if (strcmp(formField->var, "os") == 0) {
+                    } else if (g_strcmp0(formField->var, "os") == 0) {
                         if (os == NULL) {
                             os = strdup(formField->values->data);
                         }
-                    } else if (strcmp(formField->var, "os_version") == 0) {
+                    } else if (g_strcmp0(formField->var, "os_version") == 0) {
                         if (os_version == NULL) {
                             os_version = strdup(formField->values->data);
                         }


### PR DESCRIPTION
Inspired by https://github.com/profanity-im/profanity/issues/1509 I started something which I have on my TODO list since a long time. Looking for places where profanity could crash when we can malformed stanzas. Things were we expect the sending entity to follow the spec and would so far crash if they don't.