### PR TITLE
 [OMEMO] Fix sending messages

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -2151,22 +2151,21 @@ cmd_msg(ProfWin* window, const char* const command, gchar** args)
 
         ProfChatWin* chatwin = wins_get_chat(barejid);
         if (!chatwin) {
-            // NOTE: This will also start the new OMEMO session
-            // and send a MAM request.
+            // NOTE: This will also start the new OMEMO session and send a MAM request.
             chatwin = chatwin_new(barejid);
         }
         ui_focus_win((ProfWin*)chatwin);
 
         if (msg) {
-            // FIXME [OMEMO] We can't be sure whether the
-            // bundles have already been receieved. Thus, it is
-            // possible (and probable) that the recipent can't
-            // encrypt the message.
+            // NOTE: In case the message is OMEMO encrypted, we can't be sure
+            // whether the key bundles of the recipient have already been
+            // received. In the case that *no* bundles have been received yet,
+            // the message won't be sent, and an error is shown to the user.
+            // Other cases are not handled here.
             cl_ev_send_msg(chatwin, msg, NULL);
         } else {
 #ifdef HAVE_LIBOTR
-            // Start the OTR session after this (i.e. the
-            // first) message was sent
+            // Start the OTR session after this (i.e. the first) message was sent
             if (otr_is_secure(barejid)) {
                 chatwin_otr_secured(chatwin, otr_is_trusted(barejid));
             }

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -2151,30 +2151,22 @@ cmd_msg(ProfWin* window, const char* const command, gchar** args)
 
         ProfChatWin* chatwin = wins_get_chat(barejid);
         if (!chatwin) {
+            // NOTE: This will also start the new OMEMO session
+            // and send a MAM request.
             chatwin = chatwin_new(barejid);
         }
         ui_focus_win((ProfWin*)chatwin);
 
-#ifdef HAVE_OMEMO
-        gboolean is_otr_secure = FALSE;
-
-#ifdef HAVE_LIBOTR
-        is_otr_secure = otr_is_secure(barejid);
-#endif // HAVE_LIBOTR
-
-        if (omemo_automatic_start(barejid) && is_otr_secure) {
-            win_println(window, THEME_DEFAULT, "!", "Chat could be either OMEMO or OTR encrypted. Use '/omemo start %s' or '/otr start %s' to start a session.", usr, usr);
-            return TRUE;
-        } else if (omemo_automatic_start(barejid)) {
-            omemo_start_session(barejid);
-            chatwin->is_omemo = TRUE;
-        }
-#endif // HAVE_OMEMO
-
         if (msg) {
+            // FIXME [OMEMO] We can't be sure whether the
+            // bundles have already been receieved. Thus, it is
+            // possible (and probable) that the recipent can't
+            // encrypt the message.
             cl_ev_send_msg(chatwin, msg, NULL);
         } else {
 #ifdef HAVE_LIBOTR
+            // Start the OTR session after this (i.e. the
+            // first) message was sent
             if (otr_is_secure(barejid)) {
                 chatwin_otr_secured(chatwin, otr_is_trusted(barejid));
             }

--- a/src/event/client_events.c
+++ b/src/event/client_events.c
@@ -134,27 +134,33 @@ cl_ev_send_msg_correct(ProfChatWin* chatwin, const char* const msg, const char* 
     if (chatwin->is_omemo) {
 #ifdef HAVE_OMEMO
         char* id = omemo_on_message_send((ProfWin*)chatwin, plugin_msg, request_receipt, FALSE, replace_id);
-        chat_log_omemo_msg_out(chatwin->barejid, plugin_msg, NULL);
-        log_database_add_outgoing_chat(id, chatwin->barejid, plugin_msg, replace_id, PROF_MSG_ENC_OMEMO);
-        chatwin_outgoing_msg(chatwin, plugin_msg, id, PROF_MSG_ENC_OMEMO, request_receipt, replace_id);
-        free(id);
+        if (id != NULL) {
+            chat_log_omemo_msg_out(chatwin->barejid, plugin_msg, NULL);
+            log_database_add_outgoing_chat(id, chatwin->barejid, plugin_msg, replace_id, PROF_MSG_ENC_OMEMO);
+            chatwin_outgoing_msg(chatwin, plugin_msg, id, PROF_MSG_ENC_OMEMO, request_receipt, replace_id);
+            free(id);
+        }
 #endif
     } else if (chatwin->is_ox) {
 #ifdef HAVE_LIBGPGME
         // XEP-0373: OpenPGP for XMPP
         char* id = message_send_chat_ox(chatwin->barejid, plugin_msg, request_receipt, replace_id);
-        chat_log_pgp_msg_out(chatwin->barejid, plugin_msg, NULL);
-        log_database_add_outgoing_chat(id, chatwin->barejid, plugin_msg, replace_id, PROF_MSG_ENC_OX);
-        chatwin_outgoing_msg(chatwin, plugin_msg, id, PROF_MSG_ENC_OX, request_receipt, replace_id);
-        free(id);
+        if (id != NULL) {
+            chat_log_pgp_msg_out(chatwin->barejid, plugin_msg, NULL);
+            log_database_add_outgoing_chat(id, chatwin->barejid, plugin_msg, replace_id, PROF_MSG_ENC_OX);
+            chatwin_outgoing_msg(chatwin, plugin_msg, id, PROF_MSG_ENC_OX, request_receipt, replace_id);
+            free(id);
+        }
 #endif
     } else if (chatwin->pgp_send) {
 #ifdef HAVE_LIBGPGME
         char* id = message_send_chat_pgp(chatwin->barejid, plugin_msg, request_receipt, replace_id);
-        chat_log_pgp_msg_out(chatwin->barejid, plugin_msg, NULL);
-        log_database_add_outgoing_chat(id, chatwin->barejid, plugin_msg, replace_id, PROF_MSG_ENC_PGP);
-        chatwin_outgoing_msg(chatwin, plugin_msg, id, PROF_MSG_ENC_PGP, request_receipt, replace_id);
-        free(id);
+        if (id != NULL) {
+            chat_log_pgp_msg_out(chatwin->barejid, plugin_msg, NULL);
+            log_database_add_outgoing_chat(id, chatwin->barejid, plugin_msg, replace_id, PROF_MSG_ENC_PGP);
+            chatwin_outgoing_msg(chatwin, plugin_msg, id, PROF_MSG_ENC_PGP, request_receipt, replace_id);
+            free(id);
+        }
 #endif
     } else {
         gboolean handled = FALSE;


### PR DESCRIPTION
Fix #1436

- [x] Fix the race condition (don't start two sessions in parallel)
- [x] Warn the user in the chat window (not only in the log file) if there where errors when encrypting the messages (related: #1185)
- [x] Don't encrypt to own device
