### PR TITLE
Apply pre_chat_message_display hook to history

### DIFF
--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -519,6 +519,7 @@ _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 
         while (curr) {
             ProfMessage* msg = curr->data;
+            msg->plain = plugins_pre_chat_message_display(msg->from_jid->barejid, msg->from_jid->resourcepart, msg->plain);
             win_print_history((ProfWin*)chatwin, msg);
             curr = g_slist_next(curr);
         }


### PR DESCRIPTION
I find it helpful to have the plugin hook pre_chat_message_display apply to messages shown in a chat's history (via _chatwin_history) and not just for new incoming messages (in chatwin_incoming_msg). There is just one line here but I can try and add some tests or anything else if someone thinks it would be useful.

Could this break any current plugins?

On a related note, a similar change could be made to pre_room_msg_display