### PR TITLE
Access roster from plugins

### DIFF
--- a/apidocs/c/profapi.h
+++ b/apidocs/c/profapi.h
@@ -142,7 +142,7 @@ char* prof_get_current_nick(void);
 Retrieve the nickname for a given barejid if it is in the roster.
 @return the users nickname e.g. "eddie", or NULLL if the barejid is not in the roster.
 */
-char* prof_get_nick_from_roster(const char *barejid);
+char* prof_get_name_from_roster(const char *barejid);
 
 /**
 Retrieve nicknames of all occupants in a chat room, when in a chat room window.

--- a/apidocs/c/profapi.h
+++ b/apidocs/c/profapi.h
@@ -140,7 +140,7 @@ char* prof_get_current_nick(void);
 
 /**
 Retrieve the nickname for a given barejid if it is in the roster.
-@return the users nickname e.g. "eddie", or NULLL if the barejid is not in the roster.
+@return the users nickname e.g. "eddie", or the input barejid if it is not in the roster.
 */
 char* prof_get_name_from_roster(const char *barejid);
 

--- a/apidocs/c/profapi.h
+++ b/apidocs/c/profapi.h
@@ -145,6 +145,12 @@ Retrieve the nickname for a given barejid if it is in the roster.
 char* prof_get_name_from_roster(const char *barejid);
 
 /**
+Retrieve the barejid for a given nickname if it is in the roster.
+@return the users barejid e.g. "eddie@server.tld", or NULLL if the nickname is not in the roster.
+*/
+char* prof_get_barejid_from_roster(const char *name);
+
+/**
 Retrieve nicknames of all occupants in a chat room, when in a chat room window.
 @return nicknames of all occupants in the current room or an empty list if not in a chat room window.
 */

--- a/apidocs/c/profapi.h
+++ b/apidocs/c/profapi.h
@@ -139,6 +139,12 @@ Retrieve the users nickname in a chat room, when in a chat room window.
 char* prof_get_current_nick(void);
 
 /**
+Retrieve the nickname for a given barejid if it is in the roster.
+@return the users nickname e.g. "eddie", or NULLL if the barejid is not in the roster.
+*/
+char* prof_get_nick_from_roster(const char *barejid);
+
+/**
 Retrieve nicknames of all occupants in a chat room, when in a chat room window.
 @return nicknames of all occupants in the current room or an empty list if not in a chat room window.
 */

--- a/apidocs/python/src/prof.py
+++ b/apidocs/python/src/prof.py
@@ -253,6 +253,15 @@ def get_current_nick():
     pass
 
 
+def get_nick_from_roster(barejid):
+    """Retrieve a nickname from a barejid if it is in the roster.
+
+    :return: the users nickname e.g. ``"eddie"``, or ``None`` if the barejid is not in the roster.
+    :rtype: str
+    """
+    pass
+
+
 def get_current_occupants(): 
     """Retrieve nicknames of all occupants in a chat room, when in a chat room window.
 

--- a/apidocs/python/src/prof.py
+++ b/apidocs/python/src/prof.py
@@ -256,7 +256,7 @@ def get_current_nick():
 def get_name_from_roster(barejid):
     """Retrieve a nickname from a barejid if it is in the roster.
 
-    :return: the users nickname e.g. ``"eddie"``, or ``None`` if the barejid is not in the roster.
+    :return: the users nickname e.g. "eddie", or the input barejid if it is not in the roster.
     :rtype: str
     """
     pass

--- a/apidocs/python/src/prof.py
+++ b/apidocs/python/src/prof.py
@@ -253,7 +253,7 @@ def get_current_nick():
     pass
 
 
-def get_nick_from_roster(barejid):
+def get_name_from_roster(barejid):
     """Retrieve a nickname from a barejid if it is in the roster.
 
     :return: the users nickname e.g. ``"eddie"``, or ``None`` if the barejid is not in the roster.

--- a/apidocs/python/src/prof.py
+++ b/apidocs/python/src/prof.py
@@ -262,6 +262,15 @@ def get_name_from_roster(barejid):
     pass
 
 
+def get_barejid_from_roster(name):
+    """Retrieve the barejid for a given nickname if it is in the roster.
+
+    :return: the users barejid e.g. "eddie@server.tld", or ``None`` if the nickname is not in the roster.
+    :rtype: str
+    """
+    pass
+
+
 def get_current_occupants(): 
     """Retrieve nicknames of all occupants in a chat room, when in a chat room window.
 

--- a/src/plugins/api.c
+++ b/src/plugins/api.c
@@ -246,6 +246,12 @@ api_get_name_from_roster(const char* barejid)
     return roster_get_display_name(barejid);
 }
 
+char*
+api_get_barejid_from_roster(const char* name)
+{
+    return roster_barejid_from_name(name);
+}
+
 char**
 api_get_current_occupants(void)
 {

--- a/src/plugins/api.c
+++ b/src/plugins/api.c
@@ -55,6 +55,7 @@
 #include "plugins/disco.h"
 #include "ui/ui.h"
 #include "ui/window_list.h"
+#include "xmpp/roster_list.h"
 
 void
 api_cons_alert(void)
@@ -237,6 +238,12 @@ api_get_current_nick(void)
     } else {
         return NULL;
     }
+}
+
+char*
+api_get_nick_from_roster(const char* barejid)
+{
+    return roster_get_display_name(barejid);
 }
 
 char**

--- a/src/plugins/api.c
+++ b/src/plugins/api.c
@@ -241,7 +241,7 @@ api_get_current_nick(void)
 }
 
 char*
-api_get_nick_from_roster(const char* barejid)
+api_get_name_from_roster(const char* barejid)
 {
     return roster_get_display_name(barejid);
 }

--- a/src/plugins/api.h
+++ b/src/plugins/api.h
@@ -50,6 +50,7 @@ char* api_get_current_muc(void);
 gboolean api_current_win_is_console(void);
 char* api_get_current_nick(void);
 char* api_get_name_from_roster(const char* barejid);
+char* api_get_barejid_from_roster(const char* name);
 char** api_get_current_occupants(void);
 
 char* api_get_room_nick(const char* barejid);

--- a/src/plugins/api.h
+++ b/src/plugins/api.h
@@ -49,7 +49,7 @@ char* api_get_current_recipient(void);
 char* api_get_current_muc(void);
 gboolean api_current_win_is_console(void);
 char* api_get_current_nick(void);
-char* api_get_nick_from_roster(const char* barejid);
+char* api_get_name_from_roster(const char* barejid);
 char** api_get_current_occupants(void);
 
 char* api_get_room_nick(const char* barejid);

--- a/src/plugins/api.h
+++ b/src/plugins/api.h
@@ -49,6 +49,7 @@ char* api_get_current_recipient(void);
 char* api_get_current_muc(void);
 gboolean api_current_win_is_console(void);
 char* api_get_current_nick(void);
+char* api_get_nick_from_roster(const char* barejid);
 char** api_get_current_occupants(void);
 
 char* api_get_room_nick(const char* barejid);

--- a/src/plugins/c_api.c
+++ b/src/plugins/c_api.c
@@ -201,6 +201,12 @@ c_api_get_name_from_roster(const char* barejid)
     return api_get_name_from_roster(barejid);
 }
 
+static char*
+c_api_get_barejid_from_roster(const char* name)
+{
+    return api_get_barejid_from_roster(name);
+}
+
 static char**
 c_api_get_current_occupants(void)
 {
@@ -490,6 +496,7 @@ c_api_init(void)
     prof_current_win_is_console = c_api_current_win_is_console;
     prof_get_current_nick = c_api_get_current_nick;
     prof_get_name_from_roster = c_api_get_name_from_roster;
+    prof_get_barejid_from_roster = c_api_get_barejid_from_roster;
     prof_get_current_occupants = c_api_get_current_occupants;
     prof_get_room_nick = c_api_get_room_nick;
     prof_log_debug = c_api_log_debug;

--- a/src/plugins/c_api.c
+++ b/src/plugins/c_api.c
@@ -196,9 +196,9 @@ c_api_get_current_nick(void)
 }
 
 static char*
-c_api_get_nick_from_roster(const char* barejid)
+c_api_get_name_from_roster(const char* barejid)
 {
-    return api_get_nick_from_roster(barejid);
+    return api_get_name_from_roster(barejid);
 }
 
 static char**
@@ -489,7 +489,7 @@ c_api_init(void)
     prof_get_current_muc = c_api_get_current_muc;
     prof_current_win_is_console = c_api_current_win_is_console;
     prof_get_current_nick = c_api_get_current_nick;
-    prof_get_nick_from_roster = c_api_get_nick_from_roster;
+    prof_get_name_from_roster = c_api_get_name_from_roster;
     prof_get_current_occupants = c_api_get_current_occupants;
     prof_get_room_nick = c_api_get_room_nick;
     prof_log_debug = c_api_log_debug;

--- a/src/plugins/c_api.c
+++ b/src/plugins/c_api.c
@@ -195,6 +195,12 @@ c_api_get_current_nick(void)
     return api_get_current_nick();
 }
 
+static char*
+c_api_get_nick_from_roster(const char* barejid)
+{
+    return api_get_nick_from_roster(barejid);
+}
+
 static char**
 c_api_get_current_occupants(void)
 {
@@ -483,6 +489,7 @@ c_api_init(void)
     prof_get_current_muc = c_api_get_current_muc;
     prof_current_win_is_console = c_api_current_win_is_console;
     prof_get_current_nick = c_api_get_current_nick;
+    prof_get_nick_from_roster = c_api_get_nick_from_roster;
     prof_get_current_occupants = c_api_get_current_occupants;
     prof_get_room_nick = c_api_get_room_nick;
     prof_log_debug = c_api_log_debug;

--- a/src/plugins/profapi.c
+++ b/src/plugins/profapi.c
@@ -64,6 +64,7 @@ char* (*prof_get_current_recipient)(void) = NULL;
 char* (*prof_get_current_muc)(void) = NULL;
 int (*prof_current_win_is_console)(void) = NULL;
 char* (*prof_get_current_nick)(void) = NULL;
+char* (*prof_get_nick_from_roster)(const char *barejid) = NULL;
 char** (*prof_get_current_occupants)(void) = NULL;
 
 char* (*prof_get_room_nick)(const char *barejid) = NULL;

--- a/src/plugins/profapi.c
+++ b/src/plugins/profapi.c
@@ -64,7 +64,7 @@ char* (*prof_get_current_recipient)(void) = NULL;
 char* (*prof_get_current_muc)(void) = NULL;
 int (*prof_current_win_is_console)(void) = NULL;
 char* (*prof_get_current_nick)(void) = NULL;
-char* (*prof_get_nick_from_roster)(const char *barejid) = NULL;
+char* (*prof_get_name_from_roster)(const char *barejid) = NULL;
 char** (*prof_get_current_occupants)(void) = NULL;
 
 char* (*prof_get_room_nick)(const char *barejid) = NULL;

--- a/src/plugins/profapi.c
+++ b/src/plugins/profapi.c
@@ -65,6 +65,7 @@ char* (*prof_get_current_muc)(void) = NULL;
 int (*prof_current_win_is_console)(void) = NULL;
 char* (*prof_get_current_nick)(void) = NULL;
 char* (*prof_get_name_from_roster)(const char *barejid) = NULL;
+char* (*prof_get_barejid_from_roster)(const char *name) = NULL;
 char** (*prof_get_current_occupants)(void) = NULL;
 
 char* (*prof_get_room_nick)(const char *barejid) = NULL;

--- a/src/plugins/profapi.h
+++ b/src/plugins/profapi.h
@@ -74,6 +74,7 @@ char* (*prof_get_current_recipient)(void);
 char* (*prof_get_current_muc)(void);
 int (*prof_current_win_is_console)(void);
 char* (*prof_get_current_nick)(void);
+char* (*prof_get_nick_from_roster)(const char *barejid);
 char** (*prof_get_current_occupants)(void);
 
 char* (*prof_get_room_nick)(const char *barejid);

--- a/src/plugins/profapi.h
+++ b/src/plugins/profapi.h
@@ -74,7 +74,7 @@ char* (*prof_get_current_recipient)(void);
 char* (*prof_get_current_muc)(void);
 int (*prof_current_win_is_console)(void);
 char* (*prof_get_current_nick)(void);
-char* (*prof_get_nick_from_roster)(const char *barejid);
+char* (*prof_get_name_from_roster)(const char *barejid);
 char** (*prof_get_current_occupants)(void);
 
 char* (*prof_get_room_nick)(const char *barejid);

--- a/src/plugins/profapi.h
+++ b/src/plugins/profapi.h
@@ -75,6 +75,7 @@ char* (*prof_get_current_muc)(void);
 int (*prof_current_win_is_console)(void);
 char* (*prof_get_current_nick)(void);
 char* (*prof_get_name_from_roster)(const char *barejid);
+char* (*prof_get_barejid_from_roster)(const char *name);
 char** (*prof_get_current_occupants)(void);
 
 char* (*prof_get_room_nick)(const char *barejid);

--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -46,6 +46,7 @@
 #include "plugins/python_plugins.h"
 #include "plugins/callbacks.h"
 #include "plugins/autocompleters.h"
+#include "xmpp/roster_list.h"
 
 static char* _python_plugin_name(void);
 
@@ -432,6 +433,27 @@ python_api_get_current_nick(PyObject* self, PyObject* args)
 {
     allow_python_threads();
     char* nick = api_get_current_nick();
+    disable_python_threads();
+    if (nick) {
+        return Py_BuildValue("s", nick);
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+static PyObject*
+python_api_get_nick_from_roster(PyObject* self, PyObject* args)
+{
+    PyObject* barejid = NULL;
+    if (!PyArg_ParseTuple(args, "O", &barejid)) {
+        Py_RETURN_NONE;
+    }
+
+    char* barejid_str = python_str_or_unicode_to_string(barejid);
+
+    allow_python_threads();
+    char* nick = roster_get_display_name(barejid_str);
+    free(barejid_str);
     disable_python_threads();
     if (nick) {
         return Py_BuildValue("s", nick);
@@ -1487,6 +1509,7 @@ static PyMethodDef apiMethods[] = {
     { "get_current_recipient", python_api_get_current_recipient, METH_VARARGS, "Return the jid of the recipient of the current window." },
     { "get_current_muc", python_api_get_current_muc, METH_VARARGS, "Return the jid of the room of the current window." },
     { "get_current_nick", python_api_get_current_nick, METH_VARARGS, "Return nickname in current room." },
+    { "get_nick_from_roster", python_api_get_nick_from_roster, METH_VARARGS, "Return nickname in roster of barejid." },
     { "get_current_occupants", python_api_get_current_occupants, METH_VARARGS, "Return list of occupants in current room." },
     { "current_win_is_console", python_api_current_win_is_console, METH_VARARGS, "Returns whether the current window is the console." },
     { "get_room_nick", python_api_get_room_nick, METH_VARARGS, "Return the nickname used in the specified room, or None if not in the room." },

--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -463,6 +463,27 @@ python_api_get_name_from_roster(PyObject* self, PyObject* args)
 }
 
 static PyObject*
+python_api_get_barejid_from_roster(PyObject* self, PyObject* args)
+{
+    PyObject* name = NULL;
+    if (!PyArg_ParseTuple(args, "O", &name)) {
+        Py_RETURN_NONE;
+    }
+
+    char* name_str = python_str_or_unicode_to_string(name);
+
+    allow_python_threads();
+    char* barejid = roster_barejid_from_name(name_str);
+    free(name_str);
+    disable_python_threads();
+    if (barejid) {
+        return Py_BuildValue("s", barejid);
+    } else {
+        Py_RETURN_NONE;
+    }
+}
+
+static PyObject*
 python_api_get_current_occupants(PyObject* self, PyObject* args)
 {
     allow_python_threads();
@@ -1510,6 +1531,7 @@ static PyMethodDef apiMethods[] = {
     { "get_current_muc", python_api_get_current_muc, METH_VARARGS, "Return the jid of the room of the current window." },
     { "get_current_nick", python_api_get_current_nick, METH_VARARGS, "Return nickname in current room." },
     { "get_name_from_roster", python_api_get_name_from_roster, METH_VARARGS, "Return nickname in roster of barejid." },
+    { "get_barejid_from_roster", python_api_get_barejid_from_roster, METH_VARARGS, "Return nickname in roster of barejid." },
     { "get_current_occupants", python_api_get_current_occupants, METH_VARARGS, "Return list of occupants in current room." },
     { "current_win_is_console", python_api_current_win_is_console, METH_VARARGS, "Returns whether the current window is the console." },
     { "get_room_nick", python_api_get_room_nick, METH_VARARGS, "Return the nickname used in the specified room, or None if not in the room." },

--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -442,7 +442,7 @@ python_api_get_current_nick(PyObject* self, PyObject* args)
 }
 
 static PyObject*
-python_api_get_nick_from_roster(PyObject* self, PyObject* args)
+python_api_get_name_from_roster(PyObject* self, PyObject* args)
 {
     PyObject* barejid = NULL;
     if (!PyArg_ParseTuple(args, "O", &barejid)) {
@@ -452,11 +452,11 @@ python_api_get_nick_from_roster(PyObject* self, PyObject* args)
     char* barejid_str = python_str_or_unicode_to_string(barejid);
 
     allow_python_threads();
-    char* nick = roster_get_display_name(barejid_str);
+    char* name = roster_get_display_name(barejid_str);
     free(barejid_str);
     disable_python_threads();
-    if (nick) {
-        return Py_BuildValue("s", nick);
+    if (name) {
+        return Py_BuildValue("s", name);
     } else {
         Py_RETURN_NONE;
     }
@@ -1509,7 +1509,7 @@ static PyMethodDef apiMethods[] = {
     { "get_current_recipient", python_api_get_current_recipient, METH_VARARGS, "Return the jid of the recipient of the current window." },
     { "get_current_muc", python_api_get_current_muc, METH_VARARGS, "Return the jid of the room of the current window." },
     { "get_current_nick", python_api_get_current_nick, METH_VARARGS, "Return nickname in current room." },
-    { "get_nick_from_roster", python_api_get_nick_from_roster, METH_VARARGS, "Return nickname in roster of barejid." },
+    { "get_name_from_roster", python_api_get_name_from_roster, METH_VARARGS, "Return nickname in roster of barejid." },
     { "get_current_occupants", python_api_get_current_occupants, METH_VARARGS, "Return list of occupants in current room." },
     { "current_win_is_console", python_api_current_win_is_console, METH_VARARGS, "Returns whether the current window is the console." },
     { "get_room_nick", python_api_get_room_nick, METH_VARARGS, "Return the nickname used in the specified room, or None if not in the room." },

--- a/src/xmpp/roster_list.c
+++ b/src/xmpp/roster_list.c
@@ -171,6 +171,30 @@ roster_get_contact(const char* const barejid)
 }
 
 char*
+roster_get_display_name(const char* const barejid)
+{
+    assert(roster != NULL);
+
+    GString* result = g_string_new("");
+
+    PContact contact = roster_get_contact(barejid);
+    if (contact) {
+        if (p_contact_name(contact)) {
+            g_string_append(result, p_contact_name(contact));
+        } else {
+            g_string_append(result, barejid);
+        }
+    } else {
+        g_string_append(result, barejid);
+    }
+
+    char* result_str = result->str;
+    g_string_free(result, FALSE);
+
+    return result_str;
+}
+
+char*
 roster_get_msg_display_name(const char* const barejid, const char* const resource)
 {
     assert(roster != NULL);

--- a/src/xmpp/roster_list.h
+++ b/src/xmpp/roster_list.h
@@ -70,6 +70,7 @@ GList* roster_get_groups(void);
 char* roster_group_autocomplete(const char* const search_str, gboolean previous, void* context);
 char* roster_barejid_autocomplete(const char* const search_str, gboolean previous, void* context);
 GSList* roster_get_contacts_by_presence(const char* const presence);
+char* roster_get_display_name(const char* const barejid);
 char* roster_get_msg_display_name(const char* const barejid, const char* const resource);
 gint roster_compare_name(PContact a, PContact b);
 gint roster_compare_presence(PContact a, PContact b);

--- a/tests/unittests/test_roster_list.c
+++ b/tests/unittests/test_roster_list.c
@@ -689,3 +689,35 @@ remove_contact_with_remaining_in_group(void** state)
     g_list_free_full(groups_res, free);
     roster_destroy();
 }
+
+void
+get_contact_display_name(void** state)
+{
+    roster_create();
+    roster_add("person@server.org", "nickname", NULL, NULL, FALSE);
+
+    assert_string_equal("nickname", roster_get_display_name("person@server.org"));
+
+    roster_destroy();
+}
+
+void
+get_contact_display_name_is_barejid_if_name_is_empty(void** state)
+{
+    roster_create();
+    roster_add("person@server.org", NULL, NULL, NULL, FALSE);
+
+    assert_string_equal("person@server.org", roster_get_display_name("person@server.org"));
+
+    roster_destroy();
+}
+
+void
+get_contact_display_name_is_passed_barejid_if_contact_does_not_exist(void** state)
+{
+    roster_create();
+
+    assert_string_equal("person@server.org", roster_get_display_name("person@server.org"));
+
+    roster_destroy();
+}

--- a/tests/unittests/test_roster_list.h
+++ b/tests/unittests/test_roster_list.h
@@ -30,3 +30,6 @@ void add_contacts_with_different_groups(void** state);
 void add_contacts_with_same_groups(void** state);
 void add_contacts_with_overlapping_groups(void** state);
 void remove_contact_with_remaining_in_group(void** state);
+void get_contact_display_name(void** state);
+void get_contact_display_name_is_barejid_if_name_is_empty(void** state);
+void get_contact_display_name_is_passed_barejid_if_contact_does_not_exist(void** state);

--- a/tests/unittests/unittests.c
+++ b/tests/unittests/unittests.c
@@ -219,6 +219,9 @@ main(int argc, char* argv[])
         unit_test(add_contacts_with_same_groups),
         unit_test(add_contacts_with_overlapping_groups),
         unit_test(remove_contact_with_remaining_in_group),
+        unit_test(get_contact_display_name),
+        unit_test(get_contact_display_name_is_barejid_if_name_is_empty),
+        unit_test(get_contact_display_name_is_passed_barejid_if_contact_does_not_exist),
 
         unit_test_setup_teardown(returns_false_when_chat_session_does_not_exist,
                                  init_chat_sessions,


### PR DESCRIPTION
This adds two functions to the "prof" plugin API:
```c
char* prof_get_name_from_roster(const char *barejid);
```
and
```c
char* prof_get_barejid_from_roster(const char *name);
```
as well as the equivalent functions for the Python API.

I can add some tests if this functionality is otherwise mergable and of course fix anything else too!

There is a potential inconsistency here because these functions inherit the convention of the `xmpp/roster_list.c` functions that they call. `prof_get_name_from_roster` returns the input barejid if it is not found in the roster, but `prof_get_barejid_from_roster` returns NULL if the name is not in the roster. This makes sense to me but is potentially confusing.
