### PR TITLE
Improved OMEMO logging

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -624,6 +624,7 @@ message_send_chat_omemo(const char* const jid, uint32_t sid, GList* keys,
     xmpp_stanza_t* header = xmpp_stanza_new(ctx);
     xmpp_stanza_set_name(header, "header");
     char* sid_text = g_strdup_printf("%d", sid);
+    log_debug("[OMEMO] Sending from device sid %s", sid_text);
     xmpp_stanza_set_attribute(header, "sid", sid_text);
     g_free(sid_text);
 
@@ -634,6 +635,7 @@ message_send_chat_omemo(const char* const jid, uint32_t sid, GList* keys,
         xmpp_stanza_t* key_stanza = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(key_stanza, "key");
         char* rid = g_strdup_printf("%d", key->device_id);
+        log_debug("[OMEMO] Sending to device rid %s", rid == NULL ? "NULL" : rid );
         xmpp_stanza_set_attribute(key_stanza, "rid", rid);
         g_free(rid);
         if (key->prekey) {


### PR DESCRIPTION
The most loggings has been set to debug. Just in case of error / problem the
logging should be done with log-level ERROR or WARNING.

We will see later, which loggings should be switched to log-level INFO.

This improvement has been done to find OMEMO bugs.

See also: #1070 #1530 #1538