### PR TITLE
Display OMEMO device ID

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -8415,7 +8415,7 @@ cmd_omemo_gen(ProfWin* window, const char* const command, gchar** args)
     ui_update();
     ProfAccount* account = accounts_get_account(session_get_account_name());
     omemo_generate_crypto_materials(account);
-    cons_show("OMEMO crytographic materials generated.");
+    cons_show("OMEMO crytographic materials generated. Your Device ID is %d.", omemo_device_id());
     return TRUE;
 #else
     cons_show("This version of Profanity has not been built with OMEMO support enabled");

--- a/tests/unittests/omemo/stub_omemo.c
+++ b/tests/unittests/omemo/stub_omemo.c
@@ -114,3 +114,8 @@ omemo_encrypt_file(FILE* in, FILE* out, off_t file_size, int* gcry_res)
     return NULL;
 };
 void omemo_free(void* a){};
+
+uint32_t
+omemo_device_id() {
+	return 123;
+}


### PR DESCRIPTION
Display the OMEMO device ID which has been generated, when the user generated
OMEMO crytographic materials via /omemo gen.