### PR TITLE
OMEMO: Don't encrypt to yourself (MUC)

### DIFF
--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -794,15 +794,15 @@ omemo_on_message_send(ProfWin* win, const char* const message, gboolean request_
             // Don't encrypt for this device (according to
             // <https://xmpp.org/extensions/xep-0384.html#encrypt>).
             // Yourself as recipients in case of MUC
-            Jid* me = jid_create(connection_get_fulljid());
-            if ( !g_strcmp0(me->barejid, recipients_iter->data) ) {
+            char* mybarejid = connection_get_barejid();
+            if ( !g_strcmp0(mybarejid, recipients_iter->data) ) {
                 if (GPOINTER_TO_INT(device_ids_iter->data) == omemo_ctx.device_id) {
-                    jid_destroy(me);
+                    free(mybarejid);
                     log_debug("[OMEMO][SEND] Skipping %d (my device) ", GPOINTER_TO_INT(device_ids_iter->data));
                     continue;
                 }
             }
-            jid_destroy(me);
+            free(mybarejid);
 
             log_debug("[OMEMO][SEND] recipients with device id %d for %s", GPOINTER_TO_INT(device_ids_iter->data), recipients_iter->data);
             res = session_cipher_create(&cipher, omemo_ctx.store, &address, omemo_ctx.signal);


### PR DESCRIPTION
As defined in XEP-0384 the application should not encrypt the message to own
devices. Within a groupchat, yourself are a recipients as well.

We will check the recipients and filter out the own device of the own jid.

This Pull Request will fix Issue: #1541