### PR TITLE
Add command to show single bookmark details

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -2206,6 +2206,10 @@ _bookmark_autocomplete(ProfWin* window, const char* const input, gboolean previo
     if (found) {
         return found;
     }
+    found = autocomplete_param_with_func(input, "/bookmark list", bookmark_find, previous, NULL);
+    if (found) {
+        return found;
+    }
 
     found = autocomplete_param_with_ac(input, "/bookmark", bookmark_ac, TRUE, previous);
     return found;

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -822,7 +822,7 @@ static struct cmd_t command_defs[] = {
               CMD_TAG_GROUPCHAT)
       CMD_SYN(
               "/bookmark",
-              "/bookmark list",
+              "/bookmark list [<jid>]",
               "/bookmark add [<room>] [nick <nick>] [password <password>] [name <roomname>] [autojoin on|off]",
               "/bookmark update <room> [nick <nick>] [password <password>] [name <roomname>] [autojoin on|off]",
               "/bookmark remove [<room>]",
@@ -836,7 +836,7 @@ static struct cmd_t command_defs[] = {
               "If you are in a chat room and no arguments are supplied to `/bookmark add`, autojoin is set to \"on\". "
               "There is also an autojoin ignore list in case you want to autojoin in many clients but not on Profanity. ")
       CMD_ARGS(
-              { "list", "List all bookmarks." },
+              { "list [<jid>]", "List all bookmarks. Or the details of one." },
               { "add [<room>]", "Add a bookmark, passing no room will bookmark the current room, setting autojoin to \"on\"." },
               { "remove [<room>]", "Remove a bookmark, passing no room will remove the bookmark for the current room, if one exists." },
               { "update <room>", "Update the properties associated with a bookmark." },
@@ -853,6 +853,8 @@ static struct cmd_t command_defs[] = {
               "/bookmark join room@example.com",
               "/bookmark update room@example.com nick NEWNICK autojoin on",
               "/bookmark ignore room@example.com",
+              "/bookmark list",
+              "/bookmark list room@example.com",
               "/bookmark remove room@example.com")
     },
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -4661,9 +4661,18 @@ cmd_bookmark(ProfWin* window, const char* const command, gchar** args)
     }
 
     if (strcmp(cmd, "list") == 0) {
-        GList* bookmarks = bookmark_get_list();
-        cons_show_bookmarks(bookmarks);
-        g_list_free(bookmarks);
+        char* bookmark_jid = args[1];
+        if (bookmark_jid == NULL) {
+            // list all bookmarks
+            GList* bookmarks = bookmark_get_list();
+            cons_show_bookmarks(bookmarks);
+            g_list_free(bookmarks);
+        } else {
+             // list one bookmark
+            Bookmark *bookmark = bookmark_get_by_jid(bookmark_jid);
+            cons_show_bookmark(bookmark);
+        }
+
         return TRUE;
     }
 

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -745,6 +745,34 @@ cons_show_bookmarks(const GList* list)
 }
 
 void
+cons_show_bookmark(Bookmark* item)
+{
+    cons_show("");
+    if (!item) {
+        cons_show("No such bookmark");
+    } else {
+        cons_show("Bookmark details:");
+        cons_show("Room jid           : %s", item->barejid);
+        if (item->name) {
+            cons_show("name               : %s", item->name);
+        }
+        if (item->nick) {
+            cons_show("nick               : %s", item->nick);
+        }
+        if (item->password) {
+            cons_show("password           : %s", item->password);
+        }
+        if (item->autojoin) {
+            cons_show("autojoin           : ON");
+        } else {
+            cons_show("autojoin           : OFF");
+        }
+    }
+
+    cons_alert(NULL);
+}
+
+void
 cons_show_disco_info(const char* jid, GSList* identities, GSList* features)
 {
     if ((identities && (g_slist_length(identities) > 0)) || (features && (g_slist_length(features) > 0))) {

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -271,6 +271,7 @@ void cons_show_aliases(GList* aliases);
 void cons_show_login_success(ProfAccount* account, gboolean secured);
 void cons_show_account_list(gchar** accounts);
 void cons_show_room_list(GSList* room, const char* const conference_node);
+void cons_show_bookmark(Bookmark* item);
 void cons_show_bookmarks(const GList* list);
 void cons_show_bookmarks_ignore(gchar** list, gsize len);
 void cons_show_disco_items(GSList* items, const char* const jid);

--- a/src/xmpp/bookmark.c
+++ b/src/xmpp/bookmark.c
@@ -225,6 +225,13 @@ bookmark_remove(const char* jid)
     return TRUE;
 }
 
+Bookmark*
+bookmark_get_by_jid(const char* jid)
+{
+    Bookmark* bookmark = g_hash_table_lookup(bookmarks, jid);
+    return bookmark;
+}
+
 GList*
 bookmark_get_list(void)
 {

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -274,6 +274,7 @@ gboolean bookmark_update(const char* jid, const char* nick, const char* password
 gboolean bookmark_remove(const char* jid);
 gboolean bookmark_join(const char* jid);
 GList* bookmark_get_list(void);
+Bookmark* bookmark_get_by_jid(const char* jid);
 char* bookmark_find(const char* const search_str, gboolean previous, void* context);
 void bookmark_autocomplete_reset(void);
 gboolean bookmark_exists(const char* const room);

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -908,6 +908,11 @@ cons_show_bookmarks(const GList* list)
 }
 
 void
+cons_show_bookmark(Bookmark* item)
+{
+}
+
+void
 cons_show_disco_items(GSList* items, const char* const jid)
 {
 }

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -487,6 +487,12 @@ bookmark_get_list(void)
     return mock_ptr_type(GList*);
 }
 
+Bookmark*
+bookmark_get_by_jid(const char* jid)
+{
+    return NULL;
+}
+
 char*
 bookmark_find(const char* const search_str, gboolean previous, void* context)
 {


### PR DESCRIPTION
`/bookmark list` lists all bookmarks with its details.
`/bookmark list <jid>` shows the details of a single bookmark.

Implement https://github.com/profanity-im/profanity/issues/1558