### PR TITLE
OMEMO headline

### DIFF
--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -541,6 +541,27 @@ omemo_set_device_list(const char* const from, GList* device_list)
         jid = jid_create(connection_get_fulljid());
     }
 
+    // Check the incoming list of device, if there is a new unknown device.
+    // The user will be informed about JID and Device ID of new devices.
+    GHashTable* known_identities = g_hash_table_lookup(omemo_ctx.known_devices, jid->barejid);
+    if (known_identities) {
+        GList* device_id;
+        for (device_id = device_list; device_id != NULL; device_id = device_id->next) {
+            gboolean found = FALSE;
+            GList* fp = NULL;
+            for (fp = g_hash_table_get_keys(known_identities); fp != NULL; fp = fp->next) {
+                if (device_id->data == g_hash_table_lookup(known_identities, fp->data)) {
+                    found = TRUE;
+                    break;
+                }
+            }
+            if(!found) {
+                cons_show("Found new OMEMO device for %s (Device id %d)",
+                    jid->barejid, device_id->data);
+            }
+        }
+    }
+
     g_hash_table_insert(omemo_ctx.device_list, strdup(jid->barejid), device_list);
 
     OmemoDeviceListHandler handler = g_hash_table_lookup(omemo_ctx.device_list_handler, jid->barejid);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -123,6 +123,7 @@ _handle_headline(xmpp_stanza_t* const stanza)
         if (text) {
             cons_show("Headline: %s", text);
             xmpp_free(connection_get_ctx(), text);
+            return;
         }
     }
 }
@@ -166,8 +167,6 @@ _message_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* con
     } else if (type && g_strcmp0(type, STANZA_TYPE_GROUPCHAT) == 0) {
         // XEP-0045: Multi-User Chat
         _handle_groupchat(stanza);
-    } else if (type && g_strcmp0(type, STANZA_TYPE_HEADLINE) == 0) {
-        _handle_headline(stanza);
     } else if (type == NULL || g_strcmp0(type, STANZA_TYPE_CHAT) == 0 || g_strcmp0(type, STANZA_TYPE_NORMAL) == 0) {
         // type: chat, normal (==NULL)
 
@@ -247,6 +246,15 @@ _message_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* con
         if (msg_stanza) {
             _handle_chat(msg_stanza, FALSE, is_carbon, NULL, NULL);
         }
+    } else if (type && g_strcmp0(type, STANZA_TYPE_HEADLINE) == 0) {
+        // XEP-0060: Publish-Subscribe headline event
+        xmpp_stanza_t* event = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_PUBSUB_EVENT);
+        if (event) {
+            log_info("Received Publish-Subscribee headline event from %s", xmpp_stanza_get_from(stanza));
+            _handle_pubsub(stanza, event);
+            return 1;
+        }
+        _handle_headline(stanza);
     } else {
         // none of the allowed types
         char* text;

--- a/src/xmpp/omemo.c
+++ b/src/xmpp/omemo.c
@@ -458,7 +458,7 @@ _omemo_receive_devicelist(xmpp_stanza_t* const stanza, void* const userdata)
         return 1;
     }
 
-    xmpp_stanza_t* items = xmpp_stanza_get_child_by_name(root, "items");
+    xmpp_stanza_t* items = xmpp_stanza_get_child_by_name(root, STANZA_NAME_ITEMS);
     if (!items) {
         return 1;
     }


### PR DESCRIPTION
Online users will send a list of devices via PubSub `headline`. We will get this just after connection from the online users, but also when a user generates a key for a new device, we will be informed.

Bugfix: This pull request fix the handling of messages to be able to get the `event` messages for the device list.

Feature: Inform the user (console) when a new device as been found. 
#1551 