### PR TITLE
Fix log rotation

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -246,18 +246,12 @@ _rotate_log_file(void)
             break;
     }
 
-    char* lf = strdup(mainlogfile);
-    char* start = strrchr(lf, '/') + 1;
-    char* end = strstr(start, ".log");
-    *end = '\0';
-
     log_close();
 
     rename(log_file, log_file_new);
 
-    log_init(log_get_filter(), start);
+    log_init(log_get_filter(), log_file);
 
-    free(lf);
     free(log_file_new);
     free(log_file);
     log_info("Log has been rotated");


### PR DESCRIPTION
See https://github.com/profanity-im/profanity/issues/1518
It has a good explanation of what happened:

```
Apparently, the _rotate_log_file function tried to extract user-provided
name from currently used mainlogfile and restart logging to the same
place after rotation, but currently this is interpreted as a full path
instead. As I understand, the log rotation is no longer done with
user-provided paths at all so this should be simply skipped altogether
now as passing any non-NULL value is interpreted as user-provided.
Replacing start with NULL appears to fix it for me.
```

In log_msg() we only rotate the log if not user_provided_log.

https://github.com/profanity-im/profanity/pull/1455 changed the
behaviour from user defined filename in the log dir to using full path.