### PR TITLE
Add option to only allow messages from jids in roster

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -1672,7 +1672,8 @@ _cmd_ac_complete_params(ProfWin* window, const char* const input, gboolean previ
 
     // autocomplete boolean settings
     gchar* boolean_choices[] = { "/beep", "/states", "/outtype", "/flash", "/splash",
-                                 "/history", "/vercheck", "/privileges", "/wrap", "/carbons", "/os", "/slashguard", "/mam" };
+                                 "/history", "/vercheck", "/privileges", "/wrap",
+                                 "/carbons", "/os", "/slashguard", "/mam", "/silence" };
 
     for (int i = 0; i < ARRAY_SIZE(boolean_choices); i++) {
         result = autocomplete_param_with_func(input, boolean_choices[i], prefs_autocomplete_boolean_choice, previous, NULL);

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2622,6 +2622,20 @@ static struct cmd_t command_defs[] = {
       CMD_NOEXAMPLES
     },
 
+    { "/silence",
+      parse_args, 1, 1, &cons_silence_setting,
+      CMD_NOSUBFUNCS
+      CMD_MAINFUNC(cmd_silence)
+      CMD_TAGS(
+              CMD_TAG_CHAT)
+      CMD_SYN(
+              "/silence on|off")
+      CMD_DESC(
+              "Let's you silence all message attempts from people who are not in your roster.")
+      CMD_NOARGS
+      CMD_NOEXAMPLES
+    },
+
     // NEXT-COMMAND (search helper)
 };
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9505,3 +9505,11 @@ cmd_editor(ProfWin* window, const char* const command, gchar** args)
     }
     return TRUE;
 }
+
+gboolean
+cmd_silence(ProfWin* window, const char* const command, gchar** args)
+{
+    _cmd_set_boolean_preference(args[0], command, "Block all messages from JIDs that are not in the roster", PREF_SILENCE_NON_ROSTER);
+
+    return TRUE;
+}

--- a/src/command/cmd_funcs.h
+++ b/src/command/cmd_funcs.h
@@ -246,5 +246,6 @@ gboolean cmd_executable_urlsave(ProfWin* window, const char* const command, gcha
 gboolean cmd_executable_editor(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_mam(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_editor(ProfWin* window, const char* const command, gchar** args);
+gboolean cmd_silence(ProfWin* window, const char* const command, gchar** args);
 
 #endif

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -1916,6 +1916,7 @@ _get_group(preference_t pref)
     case PREF_TLS_CERTPATH:
     case PREF_CORRECTION_ALLOW:
     case PREF_MAM:
+    case PREF_SILENCE_NON_ROSTER:
         return PREF_GROUP_CONNECTION;
     case PREF_OTR_LOG:
     case PREF_OTR_POLICY:
@@ -2198,6 +2199,8 @@ _get_key(preference_t pref)
         return "url.save.cmd";
     case PREF_COMPOSE_EDITOR:
         return "compose.editor";
+    case PREF_SILENCE_NON_ROSTER:
+        return "silence.incoming.nonroster";
     default:
         return NULL;
     }

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -176,6 +176,7 @@ typedef enum {
     PREF_URL_OPEN_CMD,
     PREF_URL_SAVE_CMD,
     PREF_COMPOSE_EDITOR,
+    PREF_SILENCE_NON_ROSTER,
 } preference_t;
 
 typedef struct prof_alias_t

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2179,6 +2179,16 @@ cons_mam_setting(void)
 }
 
 void
+cons_silence_setting(void)
+{
+    if (prefs_get_boolean(PREF_SILENCE_NON_ROSTER)) {
+        cons_show("Block all messages from JIDs that are not in the roster (/silence)    : ON");
+    } else {
+        cons_show("Block all messages from JIDs that are not in the roster (/silence)    : OFF");
+    }
+}
+
+void
 cons_show_connection_prefs(void)
 {
     cons_show("Connection preferences:");

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -328,6 +328,7 @@ void cons_correction_setting(void);
 void cons_executable_setting(void);
 void cons_slashguard_setting(void);
 void cons_mam_setting(void);
+void cons_silence_setting(void);
 void cons_show_contact_online(PContact contact, Resource* resource, GDateTime* last_activity);
 void cons_show_contact_offline(PContact contact, char* resource, char* status);
 void cons_theme_properties(void);

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -1125,6 +1125,12 @@ void
 cons_mam_setting(void)
 {
 }
+
+void
+cons_silence_setting(void)
+{
+}
+
 void
 cons_show_bookmarks_ignore(gchar** list, gsize len)
 {


### PR DESCRIPTION
`/silence on` will throw away all messages (type: chat, normal) that
come from jids that are not in the roster.

Implement https://github.com/profanity-im/profanity/issues/955