### PR TITLE
Add in-band account registration

### DIFF
--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2638,6 +2638,32 @@ static struct cmd_t command_defs[] = {
       CMD_NOEXAMPLES
     },
 
+    { "/register",
+      parse_args, 2, 6, NULL,
+      CMD_NOSUBFUNCS
+      CMD_MAINFUNC(cmd_register)
+      CMD_TAGS(
+              CMD_TAG_CONNECTION)
+      CMD_SYN(
+              "/register <host> <username> [port <port>] [tls force|allow|trust|legacy|disable]")
+      CMD_DESC(
+              "Register an account on a server.")
+      CMD_ARGS(
+              { "<host>", "Server to register account on." },
+              { "<username>", "Username to register with." },
+              { "port <port>", "The port to use if different to the default (5222, or 5223 for SSL)." },
+              { "tls force", "Force TLS connection, and fail if one cannot be established. This is the default behavior." },
+              { "tls allow", "Use TLS for the connection if it is available." },
+              { "tls trust", "Force TLS connection and trust server's certificate." },
+              { "tls legacy", "Use legacy TLS for the connection. This forces TLS just after the TCP connection is established. Use when a server doesn't support STARTTLS." },
+              { "tls disable", "Disable TLS for the connection." })
+      CMD_EXAMPLES(
+              "/register valhalla.edda odin",
+              "/register vanaheimr.edda freyr port 5678",
+              "/register 127.0.0.1 me tls disable",
+              "/register my.xmppserv.er someuser port 5443 tls force")
+    },
+
     // NEXT-COMMAND (search helper)
 };
 
@@ -3008,3 +3034,4 @@ command_mangen(void)
     g_free(header);
     g_list_free(cmds);
 }
+

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2645,23 +2645,25 @@ static struct cmd_t command_defs[] = {
       CMD_TAGS(
               CMD_TAG_CONNECTION)
       CMD_SYN(
-              "/register <host> <username> [port <port>] [tls force|allow|trust|legacy|disable]")
+              "/register <username> <server> [port <port>] [tls force|allow|trust|legacy|disable] [auth default|legacy]")
       CMD_DESC(
               "Register an account on a server.")
       CMD_ARGS(
-              { "<host>", "Server to register account on." },
               { "<username>", "Username to register with." },
+              { "<server>", "Server to register account on." },
               { "port <port>", "The port to use if different to the default (5222, or 5223 for SSL)." },
               { "tls force", "Force TLS connection, and fail if one cannot be established. This is the default behavior." },
               { "tls allow", "Use TLS for the connection if it is available." },
-              { "tls trust", "Force TLS connection and trust server's certificate." },
+              { "tls trust", "Force TLS connection and trust the server's certificate." },
               { "tls legacy", "Use legacy TLS for the connection. This forces TLS just after the TCP connection is established. Use when a server doesn't support STARTTLS." },
-              { "tls disable", "Disable TLS for the connection." })
+              { "tls disable", "Disable TLS for the connection." },
+              { "auth default", "Default authentication process." },
+              { "auth legacy", "Allow legacy authentication." })
       CMD_EXAMPLES(
-              "/register valhalla.edda odin",
-              "/register vanaheimr.edda freyr port 5678",
-              "/register 127.0.0.1 me tls disable",
-              "/register my.xmppserv.er someuser port 5443 tls force")
+              "/register odin valhalla.edda ",
+              "/register freyr vanaheimr.edda port 5678",
+              "/register me 127.0.0.1 tls disable",
+              "/register someuser my.xmppserv.er port 5443 tls force")
     },
 
     // NEXT-COMMAND (search helper)

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9588,7 +9588,7 @@ cmd_register(ProfWin* window, const char* const command, gchar** args)
 
     char* server = args[1];
 
-    jabber_conn_status_t conn_status = connection_connect_raw(server, port, tls_policy, auth_policy);
+    jabber_conn_status_t conn_status = cl_ev_connect_raw(server, port, tls_policy, auth_policy);
 
     if (conn_status == JABBER_DISCONNECTED) {
         cons_show_error("Connection attempt to server %s port %d failed.", server, port);
@@ -9597,19 +9597,26 @@ cmd_register(ProfWin* window, const char* const command, gchar** args)
     }
 
     char* username = args[0];
-    char* passwd = ui_ask_password(false);
-    char* confirm_passwd = ui_ask_password(true);
+    if (connection_get_status() != JABBER_RAW_CONNECTED) { // FIXME: this is ALWAYS the case, as the connection doesn't finish by this time.
+        cons_show_error("Raw connection attempt failed or not yet completed.");
+        log_info("Raw connection attempt failed or not yet completed.");
+    } //else {
+        char* passwd = ui_ask_password(false);
+        char* confirm_passwd = ui_ask_password(true);
 
-    if (g_strcmp0(passwd, confirm_passwd) == 0) {
-        iq_register_new_account(username, passwd);
-    } else {
-        cons_show("The two passwords do not match.");
-    }
+        if (g_strcmp0(passwd, confirm_passwd) == 0) {
+            log_info("Attempting to register account %s on server %s.", username, server);
+            iq_register_new_account(username, passwd);
+        } else {
+            cons_show("The two passwords do not match.");
+        }
+        free(passwd);
+        free(confirm_passwd);
+    //}
 
-    free(username);
-    free(passwd);
-    free(confirm_passwd);
+    options_destroy(options);
 
+    log_info("we are leaving the registration process");
     return TRUE;
 }
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9540,3 +9540,68 @@ cmd_silence(ProfWin* window, const char* const command, gchar** args)
 
     return TRUE;
 }
+
+gboolean
+cmd_register(ProfWin* window, const char* const command, gchar** args)
+{
+    gchar* opt_keys[] = { "port", "tls", NULL };
+    gboolean parsed;
+
+    GHashTable* options = parse_options(&args[2], opt_keys, &parsed);
+    if (!parsed) {
+        cons_bad_cmd_usage(command);
+        cons_show("");
+        options_destroy(options);
+        return TRUE;
+    }
+
+    char* tls_policy = g_hash_table_lookup(options, "tls");
+    if (tls_policy && (g_strcmp0(tls_policy, "force") != 0) && (g_strcmp0(tls_policy, "allow") != 0) && (g_strcmp0(tls_policy, "trust") != 0) && (g_strcmp0(tls_policy, "disable") != 0) && (g_strcmp0(tls_policy, "legacy") != 0)) {
+        cons_bad_cmd_usage(command);
+        cons_show("");
+        options_destroy(options);
+        return TRUE;
+    }
+
+    int port = 0;
+    if (g_hash_table_contains(options, "port")) {
+        char* port_str = g_hash_table_lookup(options, "port");
+        char* err_msg = NULL;
+        gboolean res = strtoi_range(port_str, &port, 1, 65535, &err_msg);
+        if (!res) {
+            cons_show(err_msg);
+            cons_show("");
+            free(err_msg);
+            port = 0;
+            options_destroy(options);
+            return TRUE;
+        }
+    }
+
+    char* host = args[0];
+
+    jabber_conn_status_t conn_status = connection_connect_raw(host, port, tls_policy, "default");
+
+    if (conn_status == JABBER_DISCONNECTED) {
+        cons_show_error("Connection attempt to server %s port %d failed.", host, port);
+        log_info("Connection attempt to server %s port %d failed.", host, port);
+        return TRUE;
+    }
+
+    char* username = args[1];
+    char* passwd = ui_ask_password(false);
+    char* confirm_passwd = ui_ask_password(true);
+
+    if (g_strcmp0(passwd, confirm_passwd) == 0) {
+        iq_register_new_account(username, passwd);
+    } else {
+        cons_show("The two passwords do not match.");
+    }
+
+    free(username);
+    free(passwd);
+    free(confirm_passwd);
+
+    return TRUE;
+}
+

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -3050,14 +3050,15 @@ cmd_blocked(ProfWin* window, const char* const command, gchar** args)
     }
 
     if (strncmp(args[0], "report-", 7) == 0) {
-        char *jid;
-        char *msg = NULL;
+        char* jid = NULL;
+        char* msg = NULL;
         guint argn = g_strv_length(args);
 
         if (argn >= 2) {
             jid = args[1];
         } else {
             cons_bad_cmd_usage(command);
+            return TRUE;
         }
 
         if (argn >= 3) {
@@ -9586,32 +9587,29 @@ cmd_register(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
+    char* username = args[0];
     char* server = args[1];
 
-    jabber_conn_status_t conn_status = cl_ev_connect_raw(server, port, tls_policy, auth_policy);
+    char* passwd = ui_ask_password(false);
+    char* confirm_passwd = ui_ask_password(true);
 
-    if (conn_status == JABBER_DISCONNECTED) {
+    if (g_strcmp0(passwd, confirm_passwd) == 0) {
+        log_info("Attempting to register account %s on server %s.", username, server);
+        connection_register((server), port, tls_policy, auth_policy, username, passwd);
+            //iq_register_new_account(username, passwd);
+    } else {
+        cons_show("The two passwords do not match.");
+    }
+    //jabber_conn_status_t conn_status = cl_ev_connect_raw(server, port, tls_policy, auth_policy);
+
+    if (connection_get_status() == JABBER_DISCONNECTED) {
         cons_show_error("Connection attempt to server %s port %d failed.", server, port);
         log_info("Connection attempt to server %s port %d failed.", server, port);
         return TRUE;
     }
 
-    char* username = args[0];
-    if (connection_get_status() != JABBER_RAW_CONNECTED) { // FIXME: this is ALWAYS the case, as the connection doesn't finish by this time.
-        cons_show_error("Raw connection attempt failed or not yet completed.");
-        log_info("Raw connection attempt failed or not yet completed.");
-    } //else {
-        char* passwd = ui_ask_password(false);
-        char* confirm_passwd = ui_ask_password(true);
-
-        if (g_strcmp0(passwd, confirm_passwd) == 0) {
-            log_info("Attempting to register account %s on server %s.", username, server);
-            iq_register_new_account(username, passwd);
-        } else {
-            cons_show("The two passwords do not match.");
-        }
-        free(passwd);
-        free(confirm_passwd);
+    free(passwd);
+    free(confirm_passwd);
     //}
 
     options_destroy(options);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9544,7 +9544,7 @@ cmd_silence(ProfWin* window, const char* const command, gchar** args)
 gboolean
 cmd_register(ProfWin* window, const char* const command, gchar** args)
 {
-    gchar* opt_keys[] = { "port", "tls", NULL };
+    gchar* opt_keys[] = { "port", "tls", "auth", NULL };
     gboolean parsed;
 
     GHashTable* options = parse_options(&args[2], opt_keys, &parsed);
@@ -9578,17 +9578,25 @@ cmd_register(ProfWin* window, const char* const command, gchar** args)
         }
     }
 
-    char* host = args[0];
-
-    jabber_conn_status_t conn_status = connection_connect_raw(host, port, tls_policy, "default");
-
-    if (conn_status == JABBER_DISCONNECTED) {
-        cons_show_error("Connection attempt to server %s port %d failed.", host, port);
-        log_info("Connection attempt to server %s port %d failed.", host, port);
+    char* auth_policy = g_hash_table_lookup(options, "auth");
+    if (auth_policy && (g_strcmp0(auth_policy, "default") != 0) && (g_strcmp0(auth_policy, "legacy") != 0)) {
+        cons_bad_cmd_usage(command);
+        cons_show("");
+        options_destroy(options);
         return TRUE;
     }
 
-    char* username = args[1];
+    char* server = args[1];
+
+    jabber_conn_status_t conn_status = connection_connect_raw(server, port, tls_policy, auth_policy);
+
+    if (conn_status == JABBER_DISCONNECTED) {
+        cons_show_error("Connection attempt to server %s port %d failed.", server, port);
+        log_info("Connection attempt to server %s port %d failed.", server, port);
+        return TRUE;
+    }
+
+    char* username = args[0];
     char* passwd = ui_ask_password(false);
     char* confirm_passwd = ui_ask_password(true);
 

--- a/src/command/cmd_funcs.h
+++ b/src/command/cmd_funcs.h
@@ -247,5 +247,7 @@ gboolean cmd_executable_editor(ProfWin* window, const char* const command, gchar
 gboolean cmd_mam(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_editor(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_silence(ProfWin* window, const char* const command, gchar** args);
+gboolean cmd_register(ProfWin* window, const char* const command, gchar** args);
 
 #endif
+

--- a/src/event/client_events.c
+++ b/src/event/client_events.c
@@ -81,6 +81,13 @@ cl_ev_connect_account(ProfAccount* account)
     return session_connect_with_account(account);
 }
 
+jabber_conn_status_t
+cl_ev_connect_raw(const char* const altdomain, const int port, const char* const tls_policy, const char* const auth_policy)
+{
+    cons_show("Raw connecting to %s", altdomain);
+    return session_connect_raw(altdomain, port, tls_policy, auth_policy);
+}
+
 void
 cl_ev_disconnect(void)
 {
@@ -262,3 +269,4 @@ cl_ev_send_priv_msg(ProfPrivateWin* privwin, const char* const msg, const char* 
         jid_destroy(jidp);
     }
 }
+

--- a/src/event/client_events.h
+++ b/src/event/client_events.h
@@ -40,6 +40,7 @@
 
 jabber_conn_status_t cl_ev_connect_jid(const char* const jid, const char* const passwd, const char* const altdomain, const int port, const char* const tls_policy, const char* const auth_policy);
 jabber_conn_status_t cl_ev_connect_account(ProfAccount* account);
+jabber_conn_status_t cl_ev_connect_raw(const char* const altdomain, const int port, const char* const tls_policy, const char* const auth_policy);
 
 void cl_ev_disconnect(void);
 
@@ -52,3 +53,4 @@ void cl_ev_send_muc_msg(ProfMucWin* mucwin, const char* const msg, const char* c
 void cl_ev_send_priv_msg(ProfPrivateWin* privwin, const char* const msg, const char* const oob_url);
 
 #endif
+

--- a/src/profanity.c
+++ b/src/profanity.c
@@ -268,3 +268,4 @@ _shutdown(void)
     ui_close();
     prefs_close();
 }
+

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -245,6 +245,111 @@ connection_connect(const char* const jid, const char* const passwd, const char* 
     return conn.conn_status;
 }
 
+jabber_conn_status_t
+connection_connect_raw(const char* const altdomain, int port,
+                   const char* const tls_policy, const char* const auth_policy)
+{
+    long flags;
+
+    Jid* jidp = jid_create(altdomain);
+    if (jidp == NULL) {
+        log_error("Malformed JID not able to connect: %s", altdomain);
+        conn.conn_status = JABBER_DISCONNECTED;
+        return conn.conn_status;
+    }
+
+    _compute_identifier(jidp->barejid);
+    jid_destroy(jidp);
+
+    if (conn.xmpp_log) {
+        free(conn.xmpp_log);
+    }
+    conn.xmpp_log = _xmpp_get_file_logger();
+
+    if (conn.xmpp_conn) {
+        xmpp_conn_release(conn.xmpp_conn);
+    }
+    if (conn.xmpp_ctx) {
+        xmpp_ctx_free(conn.xmpp_ctx);
+    }
+    conn.xmpp_ctx = xmpp_ctx_new(NULL, conn.xmpp_log);
+    if (conn.xmpp_ctx == NULL) {
+        log_warning("Failed to get libstrophe ctx during connect");
+        return JABBER_DISCONNECTED;
+    }
+    conn.xmpp_conn = xmpp_conn_new(conn.xmpp_ctx);
+    if (conn.xmpp_conn == NULL) {
+        log_warning("Failed to get libstrophe conn during connect");
+        return JABBER_DISCONNECTED;
+    }
+    xmpp_conn_set_jid(conn.xmpp_conn, altdomain);
+
+    flags = xmpp_conn_get_flags(conn.xmpp_conn);
+
+    if (!tls_policy || (g_strcmp0(tls_policy, "force") == 0)) {
+        flags |= XMPP_CONN_FLAG_MANDATORY_TLS;
+    } else if (g_strcmp0(tls_policy, "trust") == 0) {
+        flags |= XMPP_CONN_FLAG_MANDATORY_TLS;
+        flags |= XMPP_CONN_FLAG_TRUST_TLS;
+    } else if (g_strcmp0(tls_policy, "disable") == 0) {
+        flags |= XMPP_CONN_FLAG_DISABLE_TLS;
+    } else if (g_strcmp0(tls_policy, "legacy") == 0) {
+        flags |= XMPP_CONN_FLAG_LEGACY_SSL;
+    }
+
+    if (auth_policy && (g_strcmp0(auth_policy, "legacy") == 0)) {
+        flags |= XMPP_CONN_FLAG_LEGACY_AUTH;
+    }
+
+    xmpp_conn_set_flags(conn.xmpp_conn, flags);
+
+    /* Print debug logs that can help when users share the logs */
+    if (flags != 0) {
+        log_debug("Connecting with flags (0x%lx):", flags);
+#define LOG_FLAG_IF_SET(name)  \
+    if (flags & name) {        \
+        log_debug("  " #name); \
+    }
+        LOG_FLAG_IF_SET(XMPP_CONN_FLAG_MANDATORY_TLS);
+        LOG_FLAG_IF_SET(XMPP_CONN_FLAG_TRUST_TLS);
+        LOG_FLAG_IF_SET(XMPP_CONN_FLAG_DISABLE_TLS);
+        LOG_FLAG_IF_SET(XMPP_CONN_FLAG_LEGACY_SSL);
+        LOG_FLAG_IF_SET(XMPP_CONN_FLAG_LEGACY_AUTH);
+#undef LOG_FLAG_IF_SET
+    }
+
+#ifdef HAVE_LIBMESODE
+    char* cert_path = prefs_get_tls_certpath();
+    if (cert_path) {
+        xmpp_conn_tlscert_path(conn.xmpp_conn, cert_path);
+        free(cert_path);
+    }
+
+    int connect_status = xmpp_connect_raw(
+        conn.xmpp_conn,
+        altdomain,
+        port,
+        _connection_certfail_cb,
+        _connection_handler,
+        conn.xmpp_ctx);
+#else
+    int connect_status = xmpp_connect_raw(
+        conn.xmpp_conn,
+        altdomain,
+        port,
+        _connection_handler,
+        conn.xmpp_ctx);
+#endif
+
+    if (connect_status == 0) {
+        conn.conn_status = JABBER_CONNECTING;
+    } else {
+        conn.conn_status = JABBER_DISCONNECTED;
+    }
+
+    return conn.conn_status;
+}
+
 void
 connection_disconnect(void)
 {
@@ -755,3 +860,4 @@ connection_get_profanity_identifier(void)
 {
     return prof_identifier;
 }
+

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -342,7 +342,7 @@ connection_connect_raw(const char* const altdomain, int port,
 #endif
 
     if (connect_status == 0) {
-        conn.conn_status = JABBER_CONNECTING;
+        conn.conn_status = JABBER_RAW_CONNECTING;
     } else {
         conn.conn_status = JABBER_DISCONNECTED;
     }
@@ -683,6 +683,21 @@ _connection_handler(xmpp_conn_t* const xmpp_conn, const xmpp_conn_event_t status
         g_hash_table_insert(conn.features_by_jid, strdup(conn.domain), g_hash_table_new_full(g_str_hash, g_str_equal, free, NULL));
 
         session_login_success(connection_is_secured());
+
+        break;
+
+    // raw connection success
+    case XMPP_CONN_RAW_CONNECT:
+        log_debug("Connection handler: XMPP_CONN_RAW_CONNECT");
+        conn.conn_status = JABBER_RAW_CONNECTED;
+
+        Jid* my_raw_jid = jid_create(xmpp_conn_get_jid(conn.xmpp_conn));
+        log_debug("jid: %s", xmpp_conn_get_jid(conn.xmpp_conn));
+        conn.domain = strdup(my_raw_jid->domainpart);
+        jid_destroy(my_raw_jid);
+
+        conn.features_by_jid = g_hash_table_new_full(g_str_hash, g_str_equal, free, (GDestroyNotify)g_hash_table_destroy);
+        g_hash_table_insert(conn.features_by_jid, strdup(conn.domain), g_hash_table_new_full(g_str_hash, g_str_equal, free, NULL));
 
         break;
 

--- a/src/xmpp/connection.h
+++ b/src/xmpp/connection.h
@@ -46,6 +46,8 @@ void connection_check_events(void);
 
 jabber_conn_status_t connection_connect(const char* const fulljid, const char* const passwd, const char* const altdomain, int port,
                                         const char* const tls_policy, const char* const auth_policy);
+jabber_conn_status_t connection_connect_raw(const char* const altdomain, int port,
+                                        const char* const tls_policy, const char* const auth_policy);
 void connection_disconnect(void);
 void connection_set_disconnected(void);
 
@@ -68,3 +70,4 @@ void connection_remove_available_resource(const char* const resource);
 char* connection_create_stanza_id(void);
 
 #endif
+

--- a/src/xmpp/connection.h
+++ b/src/xmpp/connection.h
@@ -48,6 +48,9 @@ jabber_conn_status_t connection_connect(const char* const fulljid, const char* c
                                         const char* const tls_policy, const char* const auth_policy);
 jabber_conn_status_t connection_connect_raw(const char* const altdomain, int port,
                                         const char* const tls_policy, const char* const auth_policy);
+jabber_conn_status_t connection_register(const char* const altdomain, int port,
+                                        const char* const tls_policy, const char* const auth_policy,
+                                        const char* const username, const char* const password);
 void connection_disconnect(void);
 void connection_set_disconnected(void);
 

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2658,14 +2658,15 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
 void
 iq_register_new_account(const char* const user, const char* const password)
 {
-    //char* id = connection_create_stanza_id();
     xmpp_ctx_t* const ctx = connection_get_ctx();
     xmpp_stanza_t* iq = stanza_register_new_account(ctx, user, password);
 
     const char* id = xmpp_stanza_get_id(iq);
-    iq_id_handler_add(id, _register_new_account_result_id_handler, NULL, NULL);
+    iq_id_handler_add(id, _register_new_account_result_id_handler, NULL, NULL); // FIXME: function doesn't seem to ever run?
 
+    log_debug("HI hi sending registration stanza");
     iq_send_stanza(iq);
+    log_debug("registration stanza has been sent");
     xmpp_stanza_release(iq);
 }
 

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -150,6 +150,7 @@ static int _command_list_result_handler(xmpp_stanza_t* const stanza, void* const
 static int _command_exec_response_handler(xmpp_stanza_t* const stanza, void* const userdata);
 static int _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata);
 static int _register_change_password_result_id_handler(xmpp_stanza_t* const stanza, void* const userdata);
+static int _register_new_account_result_id_handler(xmpp_stanza_t* const stanza, void* const userdata);
 
 static void _iq_free_room_data(ProfRoomInfoData* roominfo);
 static void _iq_free_affiliation_set(ProfPrivilegeSet* affiliation_set);
@@ -2655,6 +2656,36 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
 }
 
 void
+iq_register_new_account(const char* const user, const char* const password)
+{
+    //char* id = connection_create_stanza_id();
+    xmpp_ctx_t* const ctx = connection_get_ctx();
+    xmpp_stanza_t* iq = stanza_register_new_account(ctx, user, password);
+
+    const char* id = xmpp_stanza_get_id(iq);
+    iq_id_handler_add(id, _register_new_account_result_id_handler, NULL, NULL);
+
+    iq_send_stanza(iq);
+    xmpp_stanza_release(iq);
+}
+
+static int
+_register_new_account_result_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
+{
+    const char* type = xmpp_stanza_get_type(stanza);
+    if (g_strcmp0(type, "error") == 0) {
+        char* error_message = stanza_get_error_message(stanza);
+        cons_show_error("Server error: %s", error_message);
+        log_debug("Registration error: %s", error_message);
+        free(error_message);
+    } else {
+        cons_show("Registration successful.");
+        log_debug("Registration successful.");
+    }
+    return 0;
+}
+
+void
 iq_register_change_password(const char* const user, const char* const password)
 {
     xmpp_ctx_t* const ctx = connection_get_ctx();
@@ -2807,3 +2838,4 @@ iq_muc_register_nick(const char* const roomjid)
     xmpp_stanza_release(iq);
     xmpp_stanza_release(query);
 }
+

--- a/src/xmpp/session.c
+++ b/src/xmpp/session.c
@@ -204,6 +204,43 @@ session_connect_with_details(const char* const jid, const char* const passwd, co
         saved_details.auth_policy);
 }
 
+jabber_conn_status_t
+session_connect_raw(const char* const altdomain, const int port, const char* const tls_policy,
+                    const char* const auth_policy)
+{
+    assert(altdomain != NULL);
+
+    _session_free_saved_account();
+    _session_free_saved_details();
+
+    // save details for reconnect
+    saved_details.altdomain = strdup(altdomain);
+    if (port != 0) {
+        saved_details.port = port;
+    } else {
+        saved_details.port = 0;
+    }
+    if (tls_policy) {
+        saved_details.tls_policy = strdup(tls_policy);
+    } else {
+        saved_details.tls_policy = NULL;
+    }
+    if (auth_policy) {
+        saved_details.auth_policy = strdup(auth_policy);
+    } else {
+        saved_details.auth_policy = NULL;
+    }
+
+    // raw connect
+    log_info("Raw connecting to server: %s", altdomain);
+
+    return connection_connect_raw(
+        saved_details.altdomain,
+        saved_details.port,
+        saved_details.tls_policy,
+        saved_details.auth_policy);
+}
+
 void
 session_autoping_fail(void)
 {
@@ -261,6 +298,8 @@ session_process_events(void)
     switch (conn_status) {
     case JABBER_CONNECTED:
     case JABBER_CONNECTING:
+    case JABBER_RAW_CONNECTED:
+    case JABBER_RAW_CONNECTING:
     case JABBER_DISCONNECTING:
         connection_check_events();
         break;
@@ -543,3 +582,4 @@ _session_free_saved_details(void)
     FREE_SET_NULL(saved_details.tls_policy);
     FREE_SET_NULL(saved_details.auth_policy);
 }
+

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2755,7 +2755,8 @@ xmpp_stanza_t*
 stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char* const password)
 {
     char* id = connection_create_stanza_id();
-    xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, id);
+    //char* id = "reg2";
+    xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, strdup(id));
     free(id);
 
     xmpp_stanza_t* register_new_account = xmpp_stanza_new(ctx);

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2782,6 +2782,9 @@ stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char*
     xmpp_stanza_add_child(register_new_account, password_st);
     xmpp_stanza_release(password_st);
 
+    xmpp_stanza_add_child(iq, register_new_account);
+    xmpp_stanza_release(register_new_account);
+
     return iq;
 }
 

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2752,6 +2752,40 @@ stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* cons
 }
 
 xmpp_stanza_t*
+stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char* const password)
+{
+    char* id = connection_create_stanza_id();
+    xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, id);
+    free(id);
+
+    xmpp_stanza_t* register_new_account = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(register_new_account, STANZA_NAME_QUERY);
+    xmpp_stanza_set_ns(register_new_account, STANZA_NS_REGISTER);
+
+    xmpp_stanza_t* username_st = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(username_st, STANZA_NAME_USERNAME);
+    xmpp_stanza_t* username_text = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_text(username_text, user);
+    xmpp_stanza_add_child(username_st, username_text);
+    xmpp_stanza_release(username_text);
+
+    xmpp_stanza_t* password_st = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(password_st, STANZA_NAME_PASSWORD);
+    xmpp_stanza_t* password_text = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_text(password_text, password);
+    xmpp_stanza_add_child(password_st, password_text);
+    xmpp_stanza_release(password_text);
+
+    xmpp_stanza_add_child(register_new_account, username_st);
+    xmpp_stanza_release(username_st);
+
+    xmpp_stanza_add_child(register_new_account, password_st);
+    xmpp_stanza_release(password_st);
+
+    return iq;
+}
+
+xmpp_stanza_t*
 stanza_request_voice(xmpp_ctx_t* ctx, const char* const room)
 {
     char* id = connection_create_stanza_id();
@@ -2889,3 +2923,4 @@ stanza_get_service_contact_addresses(xmpp_ctx_t* ctx, xmpp_stanza_t* stanza)
 
     return addresses;
 }
+

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -408,8 +408,10 @@ void stanza_free_caps(XMPPCaps* caps);
 xmpp_stanza_t* stanza_create_avatar_retrieve_data_request(xmpp_ctx_t* ctx, const char* stanza_id, const char* const item_id, const char* const jid);
 xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const lastid);
 xmpp_stanza_t* stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* const password);
+xmpp_stanza_t* stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char* const password);
 xmpp_stanza_t* stanza_request_voice(xmpp_ctx_t* ctx, const char* const room);
 xmpp_stanza_t* stanza_create_approve_voice(xmpp_ctx_t* ctx, const char* const id, const char* const jid, const char* const node, DataForm* form);
 xmpp_stanza_t* stanza_create_muc_register_nick(xmpp_ctx_t* ctx, const char* const id, const char* const jid, const char* const node, DataForm* form);
 
 #endif
+

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -266,6 +266,7 @@ void iq_command_list(const char* const target);
 void iq_command_exec(const char* const target, const char* const command);
 void iq_mam_request(ProfChatWin* win);
 void iq_register_change_password(const char* const user, const char* const password);
+void iq_register_new_account(const char* const user, const char* const password);
 void iq_muc_register_nick(const char* const roomjid);
 
 EntityCapabilities* caps_lookup(const char* const jid);
@@ -313,3 +314,4 @@ Autocomplete form_get_value_ac(DataForm* form, const char* const tag);
 void form_reset_autocompleters(DataForm* form);
 
 #endif
+

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -76,7 +76,9 @@ typedef enum {
     JABBER_CONNECTING,
     JABBER_CONNECTED,
     JABBER_DISCONNECTING,
-    JABBER_DISCONNECTED
+    JABBER_DISCONNECTED,
+    JABBER_RAW_CONNECTING,
+    JABBER_RAW_CONNECTED
 } jabber_conn_status_t;
 
 typedef enum {
@@ -183,6 +185,8 @@ void session_init(void);
 jabber_conn_status_t session_connect_with_details(const char* const jid, const char* const passwd,
                                                   const char* const altdomain, const int port, const char* const tls_policy, const char* const auth_policy);
 jabber_conn_status_t session_connect_with_account(const ProfAccount* const account);
+
+jabber_conn_status_t session_connect_raw(const char* const altdomain, const int port, const char* const tls_policy, const char* const auth_policy);
 void session_disconnect(void);
 void session_shutdown(void);
 void session_process_events(void);


### PR DESCRIPTION
Closes #199

currently broken but making PR anyway because i dont feel like doing this anymore for now

checklist:
- [x] Add `auth` param like `/connect` does
- [x] Switch `host` and `user` positions?
- [ ] support for forms
- [ ] Feature & error checking -- ensure in-band registration is enabled
- [ ] Support for simple JID registration; `/register user@xmpp.serv.er` instead of `/register user xmpp.serv.er`
- [ ] Possibly remove the `auth` parameter actually, because there's no authentication occuring

bugs:
- [x] SIGABRT after confirming password, in `xmpp_run_once` (caused by accidental freeing of one of the args in `cmd_register`)
- [ ] The raw connection to the server finishes AFTER the registration process (!!)
- [ ] Does not actually register at all - caused by the previous issue
- [ ] Connection is left in a `JABBER_RAW_CONNECTED` state afterwards--must be set to `JABBER_DISCONNECTED` (and, well, it should be disconnected) after registration has finished, but it's not possible to do this unless bug 2 is fixed. 
- [ ] After the register command has been run once, if it is run again, a segfault occurs, in `xmpp_conn_release(conn.xmpp_conn)` -> `conn_disconnect(conn)` -> `conn->ctx, "xmpp", "Closing socket.")` -> `xmpp_log(ctx, XMPP_LEVEL_DEBUG, area, fmt, ap)` -> `ctx->log->handler(ctx->log->userdata, level, area, buf)`

OTHER STUFF/NOTES
- added a `connection_connect_raw` function for connecting to a server without authenticating as a user, as well as corresponding `session_connect_raw` and `cl_ev_connect_raw` functions
  * `JABBER_RAW_CONNECTING` and `JABBER_RAW_CONNECTED` states were also added, self explanatory as they indicate a raw, non-authenticated connection was made
- some added functions are very similar to other already existing ones--maybe possible to merge them?