### PR TITLE
Fix memory leak in accounts_get_login_status()

### DIFF
--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -958,6 +958,10 @@ accounts_get_login_status(const char* const account_name)
     if (g_strcmp0(setting, "last") == 0) {
         status = accounts_get_last_status(account_name);
     }
+
+    if (setting) {
+        g_free(setting);
+    }
     return status;
 }
 

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -193,7 +193,8 @@ sv_ev_roster_received(void)
         cl_ev_presence_send(conn_presence, 0);
     }
 
-    free(last_activity_str);
+    g_free(status_message);
+    g_free(last_activity_str);
 
     const char* fulljid = connection_get_fulljid();
     plugins_on_connect(account_name, fulljid);


### PR DESCRIPTION
`g_key_file_get_string()` returns a newly allocated string and must be freed with g_free(). `accounts_get_login_status()` uses this API internally and also for return value.

Also reduce copy-paste in a separated commit. Please, review this part carefully.