### PR TITLE
Fix invalid reads on mentions in MUC

### DIFF
--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -389,7 +389,7 @@ _mucwin_print_mention(ProfWin* window, const char* const message, const char* co
     while (curr) {
         pos = GPOINTER_TO_INT(curr->data);
 
-        char *before_str = g_utf8_substring(message, last_pos, last_pos + pos - last_pos);
+        char *before_str = g_utf8_substring(message, last_pos, pos);
 
         if (strncmp(before_str, "/me ", 4) == 0) {
             win_print_them(window, THEME_ROOMMENTION, ch, flags, "");
@@ -416,9 +416,9 @@ _mucwin_print_mention(ProfWin* window, const char* const message, const char* co
 
     glong message_len = g_utf8_strlen(message, -1);
     if (last_pos < message_len) {
-        char* rest = g_utf8_substring(message, last_pos, last_pos + message_len);
+        // get tail without allocating a new string
+        char* rest = g_utf8_offset_to_pointer(message, last_pos);
         win_appendln_highlight(window, THEME_ROOMMENTION, "%s", rest);
-        g_free(rest);
     } else {
         win_appendln_highlight(window, THEME_ROOMMENTION, "");
     }

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -386,12 +386,14 @@ _mucwin_print_mention(ProfWin* window, const char* const message, const char* co
     int last_pos = 0;
     int pos;
     GSList* curr = mentions;
+    glong mynick_len = g_utf8_strlen(mynick, -1);
+
     while (curr) {
         pos = GPOINTER_TO_INT(curr->data);
 
         char *before_str = g_utf8_substring(message, last_pos, pos);
 
-        if (strncmp(before_str, "/me ", 4) == 0) {
+        if (last_pos == 0 && strncmp(before_str, "/me ", 4) == 0) {
             win_print_them(window, THEME_ROOMMENTION, ch, flags, "");
             win_append_highlight(window, THEME_ROOMMENTION, "*%s ", from);
             win_append_highlight(window, THEME_ROOMMENTION, "%s", before_str + 4);
@@ -404,7 +406,6 @@ _mucwin_print_mention(ProfWin* window, const char* const message, const char* co
         }
         g_free(before_str);
 
-        glong mynick_len = g_utf8_strlen(mynick, -1);
         char* mynick_str = g_utf8_substring(message, pos, pos + mynick_len);
         win_append_highlight(window, THEME_ROOMMENTION_TERM, "%s", mynick_str);
         g_free(mynick_str);


### PR DESCRIPTION
_mucwin_print_mention() leads to invalid reads:
```
==18478== Invalid read of size 1
==18478==    at 0x4B7D840: g_utf8_offset_to_pointer (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x4B7D8DF: g_utf8_substring (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x16C29A: mucwin_incoming_msg (in /usr/bin/profanity)
==18478==    by 0x1524F7: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478==  Address 0xb6864ff is 0 bytes after a block of size 63 alloc'd
==18478==    at 0x483879F: malloc (vg_replace_malloc.c:307)
==18478==    by 0x51CFB2A: strdup (in /lib64/libc-2.32.so)
==18478==    by 0x19681B: plugins_pre_room_message_display (in /usr/bin/profanity)
==18478==    by 0x152469: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478== 
==18478== Invalid read of size 1
==18478==    at 0x4B7D854: g_utf8_offset_to_pointer (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x4B7D8DF: g_utf8_substring (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x16C29A: mucwin_incoming_msg (in /usr/bin/profanity)
==18478==    by 0x1524F7: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478==  Address 0xb686500 is 1 bytes after a block of size 63 alloc'd
==18478==    at 0x483879F: malloc (vg_replace_malloc.c:307)
==18478==    by 0x51CFB2A: strdup (in /lib64/libc-2.32.so)
==18478==    by 0x19681B: plugins_pre_room_message_display (in /usr/bin/profanity)
==18478==    by 0x152469: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478== 
==18478== Invalid read of size 2
==18478==    at 0x483F8B7: memmove (vg_replace_strmem.c:1270)
==18478==    by 0x4B7D8FC: g_utf8_substring (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x16C29A: mucwin_incoming_msg (in /usr/bin/profanity)
==18478==    by 0x1524F7: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478==  Address 0xb6864fe is 62 bytes inside a block of size 63 alloc'd
==18478==    at 0x483879F: malloc (vg_replace_malloc.c:307)
==18478==    by 0x51CFB2A: strdup (in /lib64/libc-2.32.so)
==18478==    by 0x19681B: plugins_pre_room_message_display (in /usr/bin/profanity)
==18478==    by 0x152469: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478== 
==18478== Invalid read of size 2
==18478==    at 0x483F8A8: memmove (vg_replace_strmem.c:1270)
==18478==    by 0x4B7D8FC: g_utf8_substring (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x16C29A: mucwin_incoming_msg (in /usr/bin/profanity)
==18478==    by 0x1524F7: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478==  Address 0xb686500 is 1 bytes after a block of size 63 alloc'd
==18478==    at 0x483879F: malloc (vg_replace_malloc.c:307)
==18478==    by 0x51CFB2A: strdup (in /lib64/libc-2.32.so)
==18478==    by 0x19681B: plugins_pre_room_message_display (in /usr/bin/profanity)
==18478==    by 0x152469: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478== 
==18478== Invalid read of size 1
==18478==    at 0x483F8D8: memmove (vg_replace_strmem.c:1270)
==18478==    by 0x4B7D8FC: g_utf8_substring (in /usr/lib64/libglib-2.0.so.0.6600.4)
==18478==    by 0x16C29A: mucwin_incoming_msg (in /usr/bin/profanity)
==18478==    by 0x1524F7: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
==18478==  Address 0x8c1b7c6 is 5 bytes after a block of size 17 alloc'd
==18478==    at 0x483879F: malloc (vg_replace_malloc.c:307)
==18478==    by 0x51CFB2A: strdup (in /lib64/libc-2.32.so)
==18478==    by 0x19681B: plugins_pre_room_message_display (in /usr/bin/profanity)
==18478==    by 0x152469: sv_ev_room_message (in /usr/bin/profanity)
==18478==    by 0x146F4F: _message_handler (in /usr/bin/profanity)
==18478==    by 0x511175C: handler_fire_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x510DECA: _handle_stream_stanza (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x511CAEE: _end_element (in /usr/lib64/libstrophe.so.0.0.0)
==18478==    by 0x5812982: doContent (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x581364B: contentProcessor (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x5815C3B: XML_ParseBuffer (in /usr/lib64/libexpat.so.1.6.12)
==18478==    by 0x51110A3: xmpp_run_once (in /usr/lib64/libstrophe.so.0.0.0)
```

This is likely because of the 3rd `g_utf8_substring()` with wrong end position. Simplify this 3rd case by just getting pointer to the tail.

The 2nd commit fixes situation when `mentions` contains multiple items and there is `/me` substring after a mention.

Please, test this PR before merging. How to test:
1. Build profanity with `--disable-python-plugins`
2. `valgrind --leak-check=full ./profanity 2>valgrind.txt`
2. Ask someone to type a message in MUC with a mention
3. Quit profanity and inspect valgrind.txt for invalid reads and other errors