### PR TITLE
Fix OMEMO devicelist access model by reconfiguring it

### DIFF
--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -386,12 +386,11 @@ omemo_publish_crypto_materials(void)
 
     char* barejid = connection_get_barejid();
 
-    /* Ensure device list is properly configured */
-    omemo_devicelist_configure_and_request();
 
     /* Ensure we get our current device list, and it gets updated with our
      * device_id */
     g_hash_table_insert(omemo_ctx.device_list_handler, strdup(barejid), _handle_own_device_list);
+    omemo_devicelist_request(barejid);
 
     omemo_bundle_publish(true);
 

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -386,10 +386,12 @@ omemo_publish_crypto_materials(void)
 
     char* barejid = connection_get_barejid();
 
+    /* Ensure device list is properly configured */
+    omemo_devicelist_configure_and_request();
+
     /* Ensure we get our current device list, and it gets updated with our
      * device_id */
     g_hash_table_insert(omemo_ctx.device_list_handler, strdup(barejid), _handle_own_device_list);
-    omemo_devicelist_request(barejid);
 
     omemo_bundle_publish(true);
 

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -386,7 +386,6 @@ omemo_publish_crypto_materials(void)
 
     char* barejid = connection_get_barejid();
 
-
     /* Ensure we get our current device list, and it gets updated with our
      * device_id */
     g_hash_table_insert(omemo_ctx.device_list_handler, strdup(barejid), _handle_own_device_list);

--- a/src/xmpp/omemo.c
+++ b/src/xmpp/omemo.c
@@ -563,7 +563,8 @@ _omemo_devicelist_publish_result(xmpp_stanza_t* const stanza, void* const userda
 
         xmpp_stanza_t *pubsub_error = xmpp_stanza_get_child_by_ns(error, STANZA_NS_PUBSUB_ERROR);
         if (!pubsub_error) {
-            // TODO
+            log_error("[OMEMO] Unknown error while publishing our own device list");
+            cons_show_error("Unknown error while publishing our own device list");
             return 0;
         }
 

--- a/src/xmpp/omemo.c
+++ b/src/xmpp/omemo.c
@@ -639,6 +639,8 @@ _omemo_devicelist_configure_result(xmpp_stanza_t* const stanza, void* const user
     char* barejid = connection_get_barejid();
     omemo_devicelist_request(barejid);
 
+    free(barejid);
+
     return 0;
 }
 

--- a/src/xmpp/omemo.c
+++ b/src/xmpp/omemo.c
@@ -47,11 +47,12 @@
 #include "omemo/omemo.h"
 
 static int _omemo_receive_devicelist(xmpp_stanza_t* const stanza, void* const userdata);
+static int _omemo_devicelist_publish_result(xmpp_stanza_t* const stanza, void* const userdata);
+static int _omemo_devicelist_configure(xmpp_stanza_t* const stanza, void* const userdata);
+static int _omemo_devicelist_configure_result(xmpp_stanza_t* const stanza, void* const userdata);
 static int _omemo_bundle_publish_result(xmpp_stanza_t* const stanza, void* const userdata);
 static int _omemo_bundle_publish_configure(xmpp_stanza_t* const stanza, void* const userdata);
 static int _omemo_bundle_publish_configure_result(xmpp_stanza_t* const stanza, void* const userdata);
-
-static int _omemo_device_list_publish_result(xmpp_stanza_t* const stanza, void* const userdata);
 
 void
 omemo_devicelist_subscribe(void)
@@ -69,14 +70,28 @@ omemo_devicelist_publish(GList* device_list)
 
     log_debug("[OMEMO] publish device list");
 
-    if (connection_supports(XMPP_FEATURE_PUBSUB_PUBLISH_OPTIONS)) {
-        stanza_attach_publish_options(ctx, iq, "pubsub#access_model", "open");
-    }
-
-    iq_id_handler_add(xmpp_stanza_get_id(iq), _omemo_device_list_publish_result, NULL, NULL);
+    iq_id_handler_add(xmpp_stanza_get_id(iq), _omemo_devicelist_publish_result, NULL, NULL);
 
     iq_send_stanza(iq);
     xmpp_stanza_release(iq);
+}
+
+void
+omemo_devicelist_configure_and_request(void)
+{
+    xmpp_ctx_t* const ctx = connection_get_ctx();
+    char* id = connection_create_stanza_id();
+    Jid* jid = jid_create(connection_get_fulljid());
+
+    xmpp_stanza_t* iq = stanza_create_pubsub_configure_request(ctx, id, jid->barejid, STANZA_NS_OMEMO_DEVICELIST);
+
+    iq_id_handler_add(id, _omemo_devicelist_configure, NULL, NULL);
+
+    iq_send_stanza(iq);
+
+    xmpp_stanza_release(iq);
+    free(id);
+    jid_destroy(jid);
 }
 
 void
@@ -512,6 +527,76 @@ _omemo_receive_devicelist(xmpp_stanza_t* const stanza, void* const userdata)
     return 1;
 }
 
+static int
+_omemo_devicelist_publish_result(xmpp_stanza_t* const stanza, void* const userdata)
+{
+    const char* type = xmpp_stanza_get_type(stanza);
+    if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
+        cons_show_error("Unable to publish own OMEMO device list");
+        log_error("[OMEMO] Publishing device list failed");
+        return 0;
+    }
+    return 0;
+}
+
+static int
+_omemo_devicelist_configure(xmpp_stanza_t* const stanza, void* const userdata)
+{
+    log_debug("[OMEMO] _omemo_devicelist_configure()");
+
+    xmpp_stanza_t* pubsub = xmpp_stanza_get_child_by_name(stanza, "pubsub");
+    if (!pubsub) {
+        log_error("[OMEMO] The stanza doesn't contain a 'pubsub' child");
+        return 0;
+    }
+    xmpp_stanza_t* configure = xmpp_stanza_get_child_by_name(pubsub, STANZA_NAME_CONFIGURE);
+    if (!configure) {
+        log_error("[OMEMO] The stanza doesn't contain a 'configure' child");
+        return 0;
+    }
+    xmpp_stanza_t* x = xmpp_stanza_get_child_by_name(configure, "x");
+    if (!x) {
+        log_error("[OMEMO] The stanza doesn't contain an 'x' child");
+        return 0;
+    }
+
+    DataForm* form = form_create(x);
+    form_set_value(form,  "pubsub#access_model", "open");
+
+    xmpp_ctx_t* const ctx = connection_get_ctx();
+    Jid* jid = jid_create(connection_get_fulljid());
+    char* id = connection_create_stanza_id();
+    xmpp_stanza_t* iq = stanza_create_pubsub_configure_submit(ctx, id, jid->barejid, STANZA_NS_OMEMO_DEVICELIST, form);
+
+    iq_id_handler_add(id, _omemo_devicelist_configure_result, NULL, NULL);
+
+    iq_send_stanza(iq);
+
+    xmpp_stanza_release(iq);
+    free(id);
+    jid_destroy(jid);
+    return 0;
+}
+
+static int
+_omemo_devicelist_configure_result(xmpp_stanza_t* const stanza, void* const userdata)
+{
+    const char* type = xmpp_stanza_get_type(stanza);
+
+    if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
+        log_error("[OMEMO] cannot configure device list to an open access model: Result error");
+        return 0;
+    }
+
+    log_debug("[OMEMO] node configured");
+
+    // Try to publish
+    char* barejid = connection_get_barejid();
+    omemo_devicelist_request(barejid);
+
+    return 0;
+}
+
 
 static int
 _omemo_bundle_publish_result(xmpp_stanza_t* const stanza, void* const userdata)
@@ -572,11 +657,7 @@ _omemo_bundle_publish_configure(xmpp_stanza_t* const stanza, void* const userdat
     }
 
     DataForm* form = form_create(x);
-    char* tag = g_hash_table_lookup(form->var_to_tag, "pubsub#access_model");
-    if (!tag) {
-        log_error("[OMEMO] cannot configure bundle to an open access model");
-        return 0;
-    }
+    form_set_value(form,  "pubsub#access_model", "open");
 
     xmpp_ctx_t* const ctx = connection_get_ctx();
     Jid* jid = jid_create(connection_get_fulljid());
@@ -610,17 +691,5 @@ _omemo_bundle_publish_configure_result(xmpp_stanza_t* const stanza, void* const 
     // Try to publish again
     omemo_bundle_publish(TRUE);
 
-    return 0;
-}
-
-static int
-_omemo_device_list_publish_result(xmpp_stanza_t* const stanza, void* const userdata)
-{
-    const char* type = xmpp_stanza_get_type(stanza);
-    if (g_strcmp0(type, STANZA_TYPE_ERROR) == 0) {
-        cons_show_error("Unable to publish own OMEMO device list");
-        log_error("[OMEMO] Publishing device list failed");
-        return 0;
-    }
     return 0;
 }

--- a/src/xmpp/omemo.h
+++ b/src/xmpp/omemo.h
@@ -38,6 +38,7 @@
 #include "xmpp/iq.h"
 
 void omemo_devicelist_subscribe(void);
+void omemo_devicelist_configure_and_request(void);
 void omemo_devicelist_publish(GList* device_list);
 void omemo_devicelist_request(const char* const jid);
 void omemo_bundle_publish(gboolean first);

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -216,6 +216,7 @@
 #define STANZA_NS_PUBSUB       "http://jabber.org/protocol/pubsub"
 #define STANZA_NS_PUBSUB_OWNER "http://jabber.org/protocol/pubsub#owner"
 #define STANZA_NS_PUBSUB_EVENT "http://jabber.org/protocol/pubsub#event"
+#define STANZA_NS_PUBSUB_ERROR "http://jabber.org/protocol/pubsub#error"
 #define STANZA_NS_CARBONS      "urn:xmpp:carbons:2"
 #define STANZA_NS_HINTS        "urn:xmpp:hints"
 #define STANZA_NS_FORWARD      "urn:xmpp:forward:0"

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -216,7 +216,7 @@
 #define STANZA_NS_PUBSUB       "http://jabber.org/protocol/pubsub"
 #define STANZA_NS_PUBSUB_OWNER "http://jabber.org/protocol/pubsub#owner"
 #define STANZA_NS_PUBSUB_EVENT "http://jabber.org/protocol/pubsub#event"
-#define STANZA_NS_PUBSUB_ERROR "http://jabber.org/protocol/pubsub#error"
+#define STANZA_NS_PUBSUB_ERROR "http://jabber.org/protocol/pubsub#errors"
 #define STANZA_NS_CARBONS      "urn:xmpp:carbons:2"
 #define STANZA_NS_HINTS        "urn:xmpp:hints"
 #define STANZA_NS_FORWARD      "urn:xmpp:forward:0"


### PR DESCRIPTION
Fix #1538

Handle precondition-not-met returned when inserting our device in the device list. Try to reconfigure it properly and give up if it fails again.

Also add support for missing device list node. It rely on auto-create. We should ensure this feature is enabled and fallback to a proper create with config otherwise.