### PR TITLE
Fix OMEMO /sendfile on non-glibc systems

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -4859,7 +4859,7 @@ _add_omemo_stream(int* fd, FILE** fh, char** err)
         *err = "Unable to create temporary file for encrypted transfer.";
         return NULL;
     }
-    FILE* tmpfh = fdopen(tmpfd, "wb");
+    FILE* tmpfh = fdopen(tmpfd, "w+b");
 
     // The temporary ciphertext file should be removed after it has
     // been closed.


### PR DESCRIPTION
On non-glibc systems, libcurl fails to read the OMEMO encrypted file when it is opened in `"wb"` mode (as is expected). Changing it to `"w+b"` allows `profanity` to `/sendfile` in OMEMO encrypted chats on BSDs and musl based Linux distributions.

Fixes #1478