### PR TITLE
Fix carbons criteria

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -223,7 +223,13 @@ _message_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* con
         gboolean is_carbon = FALSE;
 
         // XEP-0280: Message Carbons
-        xmpp_stanza_t* carbons = xmpp_stanza_get_child_by_ns(stanza, STANZA_NS_CARBONS);
+        // Only allow `<sent xmlns='urn:xmpp:carbons:2'>` and `<received xmlns='urn:xmpp:carbons:2'>` carbons
+        // Thus ignoring `<private xmlns="urn:xmpp:carbons:2"/>`
+        xmpp_stanza_t* carbons = xmpp_stanza_get_child_by_name_and_ns(stanza, STANZA_NAME_SENT, STANZA_NS_CARBONS);
+        if (!carbons) {
+            carbons = xmpp_stanza_get_child_by_name_and_ns(stanza, STANZA_NAME_RECEIVED, STANZA_NS_CARBONS);
+        }
+
         if (carbons) {
 
             // carbon must come from ourselves
@@ -1283,7 +1289,7 @@ _handle_carbons(xmpp_stanza_t* const stanza)
     }
     */
 
-    if ((g_strcmp0(name, "received") != 0) && (g_strcmp0(name, "sent") != 0)) {
+    if ((g_strcmp0(name, STANZA_NAME_RECEIVED) != 0) && (g_strcmp0(name, STANZA_NAME_SENT) != 0)) {
         log_warning("Carbon received with unrecognised stanza name: %s", name);
         return NULL;
     }

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -117,6 +117,8 @@
 #define STANZA_NAME_USERNAME         "username"
 #define STANZA_NAME_PROPOSE          "propose"
 #define STANZA_NAME_REPORT           "report"
+#define STANZA_NAME_RECEIVED         "received"
+#define STANZA_NAME_SENT             "sent"
 
 // error conditions
 #define STANZA_NAME_BAD_REQUEST             "bad-request"


### PR DESCRIPTION
We came into the carbons checking code when we received `<private
xmlns="urn:xmpp:carbons:2"/>`. Which actually marks a message to _not_
be a carbon.

In this code we also make sure that carbons only come from us.
If not we don't call the message handler code.

So we should actually only check for `<sent xmlns='urn:xmpp:carbons:2'>`
and `<received xmlns='urn:xmpp:carbons:2'>`.

Thanks pukkamustard and Holger.

Fixes https://github.com/profanity-im/profanity/issues/1614