### PR TITLE
use wildcard for man pages in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,7 +220,7 @@ icons_sources = $(top_srcdir)/icons/*
 
 script_sources = bootstrap.sh
 
-man_sources = docs/profanity*.1
+man_sources = $(wildcard docs/profanity*.1)
 
 if BUILD_PGP
 core_sources += $(pgp_sources)


### PR DESCRIPTION
use wildcard for man pages in Makefile.am

otherwise it did not build on Debian, see https://salsa.debian.org/xmpp-team/profanity/-/blob/debian/master/debian/patches/fix-make-globbing.patch