### PR TITLE
Upgrade to OpenBSD 7.0 in CI

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -1,14 +1,15 @@
-image: openbsd/6.8
+image: openbsd/7.0
 
 packages:
+  - gcc-11.2.0p0
   - cmake
   - gmake
   - cmocka
   - libtool
-  - automake-1.16.2
+  - automake-1.16.3
   - pkgconf
   - readline
-  - python-3.8.6p0
+  - python-3.8.12
   - autoconf-2.69p3
   - autoconf-archive
   - curl

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -89,7 +89,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
         # `-std=gnu99 -fexec-charset=UTF-8` to silence:
         # src/event/server_events.c:1453:19: error: universal character names are only valid in C++ and C99
         # src/event/server_events.c:1454:19: error: universal character names are only valid in C++ and C99
-        CC="gcc -std=gnu99 -fexec-charset=UTF-8"
+        CC="egcc -std=gnu99 -fexec-charset=UTF-8"
 
         tests=(
         "--enable-notifications --enable-icons-and-clipboard --enable-otr --enable-pgp


### PR DESCRIPTION
GCC is disabled in 7.0, so instead we install it explicitly and point the CC variable to egcc (which is the binary of the gcc package installed with pkg_add).