### PR TITLE
database.c: fix inserting messages to chat logs if archive_id is empty

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -328,7 +328,7 @@ _add_to_db(ProfMessage* message, char* type, const Jid* const from_jid, const Ji
         type = (char*)_get_message_type_str(message->type);
     }
 
-    query = sqlite3_mprintf("INSERT INTO `ChatLogs` (`from_jid`, `from_resource`, `to_jid`, `to_resource`, `message`, `timestamp`, `stanza_id`, `archive_id`, `replace_id`, `type`, `encryption`) SELECT '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q' WHERE NOT EXISTS (SELECT 1 FROM `ChatLogs` WHERE `archive_id` = '%q')",
+    query = sqlite3_mprintf("INSERT INTO `ChatLogs` (`from_jid`, `from_resource`, `to_jid`, `to_resource`, `message`, `timestamp`, `stanza_id`, `archive_id`, `replace_id`, `type`, `encryption`) SELECT '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q' WHERE NOT EXISTS (SELECT 1 FROM `ChatLogs` WHERE `archive_id` = '%q' AND `archive_id` != '')",
                             from_jid->barejid,
                             from_jid->resourcepart ? from_jid->resourcepart : "",
                             to_jid->barejid,


### PR DESCRIPTION
The original intention of the code was that in case archive_id is not set, NULL should be inserted. What is
inserted however is an empty string. This causes the condition to not insert messages with non-unique
archive_id insert only one message in total and ignore all further ones (if NULL was there, the condition
would work properly). And this in turn causes chat history not work properly.

This commit makes the SQL condition work properly and therefore fixes chat history.

Fixes #1589.

See https://github.com/profanity-im/profanity/issues/1589#issuecomment-1002290945 for longer explanation.