### PR TITLE
Draft: Add support for gMainLoop

### DIFF
--- a/src/profanity.c
+++ b/src/profanity.c
@@ -64,6 +64,7 @@
 #include "command/cmd_defs.h"
 #include "plugins/plugins.h"
 #include "event/client_events.h"
+#include "ui/inputwin.h"
 #include "ui/ui.h"
 #include "ui/window_list.h"
 #include "xmpp/resource.h"
@@ -94,7 +95,7 @@ static gboolean _main_update(gpointer data);
 
 pthread_mutex_t lock;
 static gboolean force_quit = FALSE;
-static GMainLoop* main_loop = NULL;
+GMainLoop* mainloop = NULL;
 
 void
 prof_run(char* log_level, char* account_name, char* config_file, char* log_file, char* theme_name)
@@ -109,9 +110,10 @@ prof_run(char* log_level, char* account_name, char* config_file, char* log_file,
 
     session_init_activity();
 
-    main_loop = g_main_loop_new(NULL, TRUE);
+    mainloop = g_main_loop_new(NULL, TRUE);
     g_timeout_add(1000/60, _main_update, NULL);
-    g_main_loop_run(main_loop);
+    inp_add_watch();
+    g_main_loop_run(mainloop);
 }
 
 void
@@ -126,15 +128,6 @@ _main_update(gpointer data)
     log_stderr_handler();
     session_check_autoaway();
 
-    gboolean cont = TRUE;
-    char *line = inp_readline();
-    if (line) {
-        ProfWin* window = wins_get_current();
-        cont = cmd_process_input(window, line);
-        free(line);
-        line = NULL;
-    }
-
 #ifdef HAVE_LIBOTR
     otr_poll();
 #endif
@@ -146,9 +139,6 @@ _main_update(gpointer data)
 #ifdef HAVE_GTK
     tray_update();
 #endif
-
-    if (!cont)
-        g_main_loop_quit(main_loop);
 
     // Always repeat
     return TRUE;

--- a/src/profanity.h
+++ b/src/profanity.h
@@ -44,5 +44,6 @@ void prof_run(char* log_level, char* account_name, char* config_file, char* log_
 void prof_set_quit(void);
 
 extern pthread_mutex_t lock;
+extern GMainLoop* mainloop;
 
 #endif

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -159,6 +159,44 @@ create_input_window(void)
     _inp_win_update_virtual();
 }
 
+static gboolean
+_inp_callback(GIOChannel *source, GIOCondition condition, gpointer data)
+{
+    rl_callback_read_char();
+
+    ui_reset_idle_time();
+    if (!get_password) {
+        // Update the input buffer on screen
+        _inp_write(rl_line_buffer, rl_point);
+    }
+    // TODO set idle or activity with a timeout
+    //chat_state_idle();
+    //chat_state_activity();
+
+    if (inp_line) {
+        ProfWin* window = wins_get_current();
+
+        if (!cmd_process_input(window, inp_line))
+            g_main_loop_quit(mainloop);
+
+        free(inp_line);
+        inp_line = NULL;
+    }
+
+    return TRUE;
+}
+
+void
+inp_add_watch(void)
+{
+    GIOChannel* channel = g_io_channel_unix_new(fileno(rl_instream));
+    if (g_io_channel_set_encoding(channel, NULL, NULL) != G_IO_STATUS_NORMAL) {
+        log_error("cannot set NULL encoding");
+    }
+
+    g_io_add_watch(channel, G_IO_IN, _inp_callback, NULL);
+}
+
 char*
 inp_readline(void)
 {

--- a/src/ui/inputwin.h
+++ b/src/ui/inputwin.h
@@ -46,5 +46,6 @@ void inp_win_resize(void);
 void inp_put_back(void);
 char* inp_get_password(void);
 char* inp_get_line(void);
+void inp_add_watch(void);
 
 #endif


### PR DESCRIPTION
This PR attempts to fix the performance issues observed in #1246 by using the glib event loop to avoid interrupting the main loop with `select()` and using a polling approach instead.