### PR TITLE
fix handling of connection errors

### DIFF
--- a/src/xmpp/session.c
+++ b/src/xmpp/session.c
@@ -549,8 +549,6 @@ session_reconnect(gchar* altdomain, unsigned short altport)
 {
     reconnect.altdomain = altdomain;
     reconnect.altport = altport;
-    assert(reconnect_timer == NULL);
-    reconnect_timer = g_timer_new();
 }
 
 static void
@@ -583,7 +581,8 @@ _session_reconnect(void)
     connection_connect(jid, saved_account.passwd, server, port, account->tls_policy, account->auth_policy);
     free(jid);
     account_free(account);
-    g_timer_start(reconnect_timer);
+    if (reconnect_timer)
+        g_timer_start(reconnect_timer);
 }
 
 static void


### PR DESCRIPTION
When a `see-other-host` stream-error is received we try to re-connect to
the other host. Erroneously this also started the `reconnect_timer`.
This lead to the behavior that in cases where e.g. the login failed
we try to reconnect instead of bailing out with an error.

This commit fixes the wrong behavior by not starting the `reconnect_timer`.

Fix 0e58509c161ae8409c9accabb9606e0c7006b880 

Related to #1628 #1631