### PR TITLE
Add hotkey for sending readline text to editor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ core_sources = \
 	src/tools/bookmark_ignore.h \
 	src/tools/autocomplete.c src/tools/autocomplete.h \
 	src/tools/clipboard.c src/tools/clipboard.h \
+	src/tools/editor.c src/tools/editor.h \
 	src/config/files.c src/config/files.h \
 	src/config/conflists.c src/config/conflists.h \
 	src/config/accounts.c src/config/accounts.h \
@@ -91,6 +92,7 @@ unittest_sources = \
 	src/tools/parser.h \
 	src/tools/autocomplete.c src/tools/autocomplete.h \
 	src/tools/clipboard.c src/tools/clipboard.h \
+	src/tools/editor.c src/tools/editor.h \
 	src/tools/bookmark_ignore.c \
 	src/tools/bookmark_ignore.h \
 	src/config/accounts.h \

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -122,7 +122,6 @@ static void _who_roster(ProfWin* window, const char* const command, gchar** args
 static gboolean _cmd_execute(ProfWin* window, const char* const command, const char* const inp);
 static gboolean _cmd_execute_default(ProfWin* window, const char* inp);
 static gboolean _cmd_execute_alias(ProfWin* window, const char* const inp, gboolean* ran);
-gboolean _get_message_from_editor(gchar* message, gchar** returned_message);
 
 /*
  * Take a line of input and process it, return TRUE if profanity is to
@@ -4099,7 +4098,7 @@ cmd_subject(ProfWin* window, const char* const command, gchar** args)
         gchar* message = NULL;
         char* subject = muc_subject(mucwin->roomjid);
 
-        if (_get_message_from_editor(subject, &message)) {
+        if (get_message_from_editor(subject, &message)) {
             return TRUE;
         }
 
@@ -9455,7 +9454,7 @@ cmd_change_password(ProfWin* window, const char* const command, gchar** args)
 
 // Returns true if an error occurred
 gboolean
-_get_message_from_editor(gchar* message, gchar** returned_message)
+get_message_from_editor(gchar* message, gchar** returned_message)
 {
     // create editor dir if not present
     char* jid = connection_get_barejid();
@@ -9548,7 +9547,7 @@ cmd_editor(ProfWin* window, const char* const command, gchar** args)
 
     gchar* message = NULL;
 
-    if (_get_message_from_editor(NULL, &message)) {
+    if (get_message_from_editor(NULL, &message)) {
         return TRUE;
     }
 
@@ -9571,7 +9570,7 @@ cmd_correct_editor(ProfWin* window, const char* const command, gchar** args)
     gchar* initial_message = win_get_last_sent_message(window);
 
     gchar* message = NULL;
-    if (_get_message_from_editor(initial_message, &message)) {
+    if (get_message_from_editor(initial_message, &message)) {
         return TRUE;
     }
 

--- a/src/command/cmd_funcs.h
+++ b/src/command/cmd_funcs.h
@@ -250,5 +250,6 @@ gboolean cmd_correct_editor(ProfWin* window, const char* const command, gchar** 
 gboolean cmd_silence(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_register(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_mood(ProfWin* window, const char* const command, gchar** args);
+gboolean get_message_from_editor(gchar* message, gchar** returned_message);
 
 #endif

--- a/src/command/cmd_funcs.h
+++ b/src/command/cmd_funcs.h
@@ -250,6 +250,5 @@ gboolean cmd_correct_editor(ProfWin* window, const char* const command, gchar** 
 gboolean cmd_silence(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_register(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_mood(ProfWin* window, const char* const command, gchar** args);
-gboolean get_message_from_editor(gchar* message, gchar** returned_message);
 
 #endif

--- a/src/tools/editor.c
+++ b/src/tools/editor.c
@@ -1,0 +1,132 @@
+/*
+ * editor.c
+ * vim: expandtab:ts=4:sts=4:sw=4
+ *
+ * Copyright (C) 2022 Michael Vetter <jubalh@iodoru.org>
+ * Copyright (C) 2022 MarcoPolo PasTonMolo  <marcopolopastonmolo@protonmail.com>
+ *
+ * This file is part of Profanity.
+ *
+ * Profanity is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Profanity is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Profanity.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link the code of portions of this program with the OpenSSL library under
+ * certain conditions as described in each individual source file, and
+ * distribute linked combinations including the two.
+ *
+ * You must obey the GNU General Public License in all respects for all of the
+ * code used other than OpenSSL. If you modify file(s) with this exception, you
+ * may extend this exception to your version of the file(s), but you are not
+ * obligated to do so. If you do not wish to do so, delete this exception
+ * statement from your version. If you delete this exception statement from all
+ * source files in the program, then also delete it here.
+ *
+ */
+
+#include <fcntl.h>
+#include <glib.h>
+#include <sys/wait.h>
+#include <gio/gio.h>
+
+#include "config/files.h"
+#include "config/preferences.h"
+#include "ui/ui.h"
+
+// Returns true if an error occurred
+gboolean
+get_message_from_editor(gchar* message, gchar** returned_message)
+{
+    // create editor dir if not present
+    char* jid = connection_get_barejid();
+    gchar* path = files_get_account_data_path(DIR_EDITOR, jid);
+    free(jid);
+    if (g_mkdir_with_parents(path, S_IRWXU) != 0) {
+        cons_show_error("Failed to create directory at '%s' with error '%s'", path, strerror(errno));
+        g_free(path);
+        return TRUE;
+    }
+
+    // build temp file name. Example: /home/user/.local/share/profanity/editor/jid/compose.md
+    char* filename = g_strdup_printf("%s/compose.md", path);
+    g_free(path);
+
+    GError* creation_error = NULL;
+    GFile* file = g_file_new_for_path(filename);
+    GFileOutputStream* fos = g_file_create(file, G_FILE_CREATE_PRIVATE, NULL, &creation_error);
+
+    free(filename);
+
+    if (message != NULL && strlen(message) > 0) {
+        int fd_output_file = open(g_file_get_path(file), O_WRONLY);
+        if (fd_output_file < 0) {
+            cons_show_error("Editor: Could not open file '%s': %s", file, strerror(errno));
+            return TRUE;
+        }
+        if (-1 == write(fd_output_file, message, strlen(message))) {
+            cons_show_error("Editor: failed to write '%s' to file: %s", message, strerror(errno));
+            return TRUE;
+        }
+        close(fd_output_file);
+    }
+
+    if (creation_error) {
+        cons_show_error("Editor: could not create temp file");
+        return TRUE;
+    }
+    g_object_unref(fos);
+
+    char* editor = prefs_get_string(PREF_COMPOSE_EDITOR);
+
+    // Fork / exec
+    pid_t pid = fork();
+    if (pid == 0) {
+        int x = execlp(editor, editor, g_file_get_path(file), (char*)NULL);
+        if (x == -1) {
+            cons_show_error("Editor:Failed to exec %s", editor);
+        }
+        _exit(EXIT_FAILURE);
+    } else {
+        if (pid == -1) {
+            return TRUE;
+        }
+        int status = 0;
+        waitpid(pid, &status, 0);
+        int fd_input_file = open(g_file_get_path(file), O_RDONLY);
+        const size_t COUNT = 8192;
+        char buf[COUNT];
+        ssize_t size_read = read(fd_input_file, buf, COUNT);
+        if (size_read > 0 && size_read <= COUNT) {
+            buf[size_read - 1] = '\0';
+            GString* text = g_string_new(buf);
+            *returned_message = g_strdup(text->str);
+            g_string_free(text, TRUE);
+        } else {
+            *returned_message = g_strdup("");
+        }
+        close(fd_input_file);
+
+        GError* deletion_error = NULL;
+        g_file_delete(file, NULL, &deletion_error);
+        if (deletion_error) {
+            cons_show("Editor: error during file deletion");
+            g_free(*returned_message);
+            return TRUE;
+        }
+        g_object_unref(file);
+    }
+
+    g_free(editor);
+
+    return FALSE;
+}

--- a/src/tools/editor.h
+++ b/src/tools/editor.h
@@ -1,0 +1,44 @@
+/*
+ * editor.h
+ * vim: expandtab:ts=4:sts=4:sw=4
+ *
+ * Copyright (C) 2022 Michael Vetter <jubalh@iodoru.org>
+ * Copyright (C) 2022 MarcoPolo PasTonMolo  <marcopolopastonmolo@protonmail.com>
+ *
+ * This file is part of Profanity.
+ *
+ * Profanity is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Profanity is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Profanity.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link the code of portions of this program with the OpenSSL library under
+ * certain conditions as described in each individual source file, and
+ * distribute linked combinations including the two.
+ *
+ * You must obey the GNU General Public License in all respects for all of the
+ * code used other than OpenSSL. If you modify file(s) with this exception, you
+ * may extend this exception to your version of the file(s), but you are not
+ * obligated to do so. If you do not wish to do so, delete this exception
+ * statement from your version. If you delete this exception statement from all
+ * source files in the program, then also delete it here.
+ *
+ */
+
+#ifndef TOOLS_EDITOR_H
+#define TOOLS_EDITOR_H
+
+#include <glib.h>
+
+gboolean get_message_from_editor(gchar* message, gchar** returned_message);
+
+#endif

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -60,7 +60,6 @@
 #include "log.h"
 #include "common.h"
 #include "command/cmd_ac.h"
-#include "command/cmd_funcs.h"
 #include "config/files.h"
 #include "config/accounts.h"
 #include "config/preferences.h"
@@ -75,6 +74,7 @@
 #include "xmpp/muc.h"
 #include "xmpp/roster_list.h"
 #include "xmpp/chat_state.h"
+#include "tools/editor.h"
 
 static WINDOW* inp_win;
 static int pad_start = 0;
@@ -487,7 +487,7 @@ _inp_rl_startup_hook(void)
     rl_bind_keyseq("\\ea", _inp_rl_win_next_unread_handler);
     rl_bind_keyseq("\\ev", _inp_rl_win_attention_handler);
     rl_bind_keyseq("\\em", _inp_rl_win_attention_next_handler);
-    rl_bind_keyseq("\\ed", _inp_rl_send_to_editor);
+    rl_bind_keyseq("\\ee", _inp_rl_send_to_editor);
 
     rl_bind_keyseq("\\e\\e[5~", _inp_rl_subwin_pageup_handler);
     rl_bind_keyseq("\\e[5;3~", _inp_rl_subwin_pageup_handler);
@@ -885,14 +885,14 @@ _inp_rl_down_arrow_handler(int count, int key)
 static int
 _inp_rl_send_to_editor(int count, int key)
 {
-    if (rl_point != rl_end || !rl_line_buffer) {
+    if (!rl_line_buffer) {
         return 0;
     }
 
     gchar* message = NULL;
 
     if (get_message_from_editor(rl_line_buffer, &message)) {
-        return TRUE;
+        return 0;
     }
 
     rl_replace_line(message, 0);


### PR DESCRIPTION
Add a hotkey for sending text in readline to external text editor.
Should deprecate the need for /command-editor requests like /subject-editor, /correct-editor.

Example workflow:
alt+d to open editor or write something in readline first and then alt+d.

I have a feeling a put the declaration of _get_message_from_editor in a suboptimal header file.
