### PR TITLE
Add quote autocompletion for previous messages

### DIFF
--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -323,6 +323,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
     }
 
     wins_add_urls_ac(window, message);
+    wins_add_quotes_ac(window, message->plain);
 
     if (prefs_get_boolean(PREF_BEEP)) {
         beep();
@@ -345,6 +346,9 @@ chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, 
                      gboolean request_receipt, const char* const replace_id)
 {
     assert(chatwin != NULL);
+
+    ProfWin* window = (ProfWin*)chatwin;
+    wins_add_quotes_ac(window, message);
 
     char* enc_char;
     if (chatwin->outgoing_char) {

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -558,6 +558,10 @@ _inp_rl_getc(FILE* stream)
     if (_inp_edited(ch)) {
         ProfWin* window = wins_get_current();
         cmd_ac_reset(window);
+
+        if ((window->type == WIN_CHAT || window->type == WIN_MUC || window->type == WIN_PRIVATE) && window->quotes_ac != NULL) {
+            autocomplete_reset(window->quotes_ac);
+        }
     }
     return ch;
 }
@@ -597,6 +601,17 @@ _inp_rl_tab_handler(int count, int key)
         }
     }
 
+    if (strncmp(rl_line_buffer, ">", 1) == 0) {
+        ProfWin* window = wins_get_current();
+        char* result = win_quote_autocomplete(window, rl_line_buffer, FALSE);
+        if (result) {
+            rl_replace_line(result, 1);
+            rl_point = rl_end;
+            free(result);
+            return 0;
+        }
+    }
+
     ProfWin* current = wins_get_current();
     if (current->type == WIN_MUC) {
         char* result = muc_autocomplete(current, rl_line_buffer, FALSE);
@@ -606,7 +621,6 @@ _inp_rl_tab_handler(int count, int key)
             free(result);
         }
     }
-
 
     return 0;
 }
@@ -621,6 +635,17 @@ _inp_rl_shift_tab_handler(int count, int key)
     if (strncmp(rl_line_buffer, "/", 1) == 0) {
         ProfWin* window = wins_get_current();
         char* result = cmd_ac_complete(window, rl_line_buffer, TRUE);
+        if (result) {
+            rl_replace_line(result, 1);
+            rl_point = rl_end;
+            free(result);
+            return 0;
+        }
+    }
+
+    if (strncmp(rl_line_buffer, ">", 1) == 0) {
+        ProfWin* window = wins_get_current();
+        char* result = win_quote_autocomplete(window, rl_line_buffer, TRUE);
         if (result) {
             rl_replace_line(result, 1);
             rl_point = rl_end;

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -541,6 +541,8 @@ mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* c
     if (id) {
         _mucwin_set_last_message(mucwin, id, message);
     }
+
+    wins_add_quotes_ac(window, message);
 }
 
 void
@@ -576,6 +578,7 @@ mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList
 
     win_insert_last_read_position_marker((ProfWin*)mucwin, mucwin->roomjid);
     wins_add_urls_ac(window, message);
+    wins_add_quotes_ac(window, message->plain);
 
     if (g_slist_length(mentions) > 0) {
         _mucwin_print_mention(window, message->plain, message->from_jid->resourcepart, mynick, mentions, ch, flags);

--- a/src/ui/privwin.c
+++ b/src/ui/privwin.c
@@ -82,6 +82,7 @@ privwin_incoming_msg(ProfPrivateWin* privatewin, ProfMessage* message)
     }
 
     wins_add_urls_ac(window, message);
+    wins_add_quotes_ac(window, message->plain);
 
     if (prefs_get_boolean(PREF_BEEP)) {
         beep();
@@ -99,6 +100,8 @@ privwin_outgoing_msg(ProfPrivateWin* privwin, const char* const message)
 {
     assert(privwin != NULL);
 
+    ProfWin* window = (ProfWin*)privwin;
+    wins_add_quotes_ac(window, message);
     win_print_outgoing((ProfWin*)privwin, "-", NULL, NULL, message);
 }
 

--- a/src/ui/win_types.h
+++ b/src/ui/win_types.h
@@ -148,6 +148,7 @@ typedef struct prof_win_t
     win_type_t type;
     ProfLayout* layout;
     Autocomplete urls_ac;
+    Autocomplete quotes_ac;
 } ProfWin;
 
 typedef struct prof_console_win_t

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -2020,3 +2020,26 @@ win_insert_last_read_position_marker(ProfWin* window, char* id)
 
     g_date_time_unref(time);
 }
+
+char*
+win_quote_autocomplete(ProfWin* window, const char* const input, gboolean previous)
+{
+    if (window->type != WIN_CHAT && window->type != WIN_MUC && window->type != WIN_PRIVATE) {
+        return NULL;
+    }
+
+    char* result = autocomplete_complete(window->quotes_ac, input + 1, FALSE, previous);
+    if (result == NULL) {
+        return NULL;
+    }
+
+    GString* replace_with = g_string_new("> ");
+    g_string_append(replace_with, result);
+    g_string_replace(replace_with, "\n", "\n> ", 0);
+    g_string_append(replace_with, "\n");
+
+    g_free(result);
+    result = replace_with->str;
+    g_string_free(replace_with, FALSE);
+    return result;
+}

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -93,4 +93,6 @@ void win_sub_page_up(ProfWin* window);
 void win_insert_last_read_position_marker(ProfWin* window, char* id);
 void win_remove_entry_message(ProfWin* window, const char* const id);
 
+char* win_quote_autocomplete(ProfWin* window, const char* const input, gboolean previous);
+
 #endif

--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -554,6 +554,7 @@ wins_close_by_num(int i)
                     }
                 }
                 autocomplete_free(window->urls_ac);
+                autocomplete_free(window->quotes_ac);
                 break;
             }
             case WIN_MUC:
@@ -566,6 +567,7 @@ wins_close_by_num(int i)
                     g_date_time_unref(mucwin->last_msg_timestamp);
                 }
                 autocomplete_free(window->urls_ac);
+                autocomplete_free(window->quotes_ac);
                 break;
             }
             case WIN_PRIVATE:
@@ -574,6 +576,7 @@ wins_close_by_num(int i)
                 autocomplete_remove(wins_ac, privwin->fulljid);
                 autocomplete_remove(wins_close_ac, privwin->fulljid);
                 autocomplete_free(window->urls_ac);
+                autocomplete_free(window->quotes_ac);
                 break;
             }
             case WIN_XML:
@@ -646,6 +649,7 @@ wins_new_chat(const char* const barejid)
         }
     }
     newwin->urls_ac = autocomplete_new();
+    newwin->quotes_ac = autocomplete_new();
 
     return newwin;
 }
@@ -661,6 +665,7 @@ wins_new_muc(const char* const roomjid)
     autocomplete_add(wins_ac, roomjid);
     autocomplete_add(wins_close_ac, roomjid);
     newwin->urls_ac = autocomplete_new();
+    newwin->quotes_ac = autocomplete_new();
 
     return newwin;
 }
@@ -688,6 +693,7 @@ wins_new_private(const char* const fulljid)
     autocomplete_add(wins_ac, fulljid);
     autocomplete_add(wins_close_ac, fulljid);
     newwin->urls_ac = autocomplete_new();
+    newwin->quotes_ac = autocomplete_new();
 
     return newwin;
 }
@@ -1299,10 +1305,26 @@ wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message)
     g_regex_unref(regex);
 }
 
+void
+wins_add_quotes_ac(const ProfWin* const win, const char* const message)
+{
+    autocomplete_add_reverse(win->quotes_ac, message);
+    // for people who run profanity a long time, we don't want to waste a lot of memory
+    autocomplete_remove_older_than_max_reverse(win->quotes_ac, 20);
+}
+
 char*
 wins_get_url(const char* const search_str, gboolean previous, void* context)
 {
     ProfWin* win = (ProfWin*)context;
 
     return autocomplete_complete(win->urls_ac, search_str, FALSE, previous);
+}
+
+char*
+wins_get_quote(const char* const search_str, gboolean previous, void* context)
+{
+    ProfWin* win = (ProfWin*)context;
+
+    return autocomplete_complete(win->quotes_ac, search_str, FALSE, previous);
 }

--- a/src/ui/window_list.h
+++ b/src/ui/window_list.h
@@ -102,5 +102,7 @@ void win_close_reset_search_attempts(void);
 
 void wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message);
 char* wins_get_url(const char* const search_str, gboolean previous, void* context);
+void wins_add_quotes_ac(const ProfWin* const win, const char* const message);
+char* wins_get_quote(const char* const search_str, gboolean previous, void* context);
 
 #endif

--- a/tests/unittests/test_cmd_otr.c
+++ b/tests/unittests/test_cmd_otr.c
@@ -271,6 +271,7 @@ test_cmd_otr_theirfp_from_wintype(win_type_t wintype)
     window.type = wintype;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
 
     will_return(connection_get_status, JABBER_CONNECTED);
 
@@ -308,6 +309,7 @@ cmd_otr_theirfp_shows_message_when_non_otr_chat_window(void** state)
     window.type = WIN_CHAT;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.memcheck = PROFCHATWIN_MEMCHECK;
@@ -337,6 +339,7 @@ cmd_otr_theirfp_shows_fingerprint(void** state)
     window.type = WIN_CHAT;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;
@@ -365,6 +368,7 @@ test_cmd_otr_start_from_wintype(win_type_t wintype)
     window.type = wintype;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
 
     will_return(connection_get_status, JABBER_CONNECTED);
 
@@ -404,6 +408,7 @@ cmd_otr_start_shows_message_when_already_started(void** state)
     window.type = WIN_CHAT;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;
@@ -430,6 +435,7 @@ cmd_otr_start_shows_message_when_no_key(void** state)
     window.type = WIN_CHAT;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;
@@ -454,6 +460,7 @@ cmd_otr_start_sends_otr_query_message_to_current_recipeint(void** state)
     window.type = WIN_CHAT;
     window.layout = NULL;
     window.urls_ac = NULL;
+    window.quotes_ac = NULL;
     ProfChatWin chatwin;
     chatwin.window = window;
     chatwin.barejid = recipient;


### PR DESCRIPTION
Fixes https://github.com/profanity-im/profanity/issues/1649

Type `>` then press tab or shift tab to autocomplete previous messages,
then type your reply and send message.
Newlines are replaced with newline followed by `> `.
A newline is added at the end so that the user can immediately type a
message without manually adding a new line.

I'm not sure if win_quote_autocomplete is in the correct file. I thought ui/window_list.c might have also been a good place to put it in since there are some other related functions there.