### PR TITLE
Reset url autocompletion after open/save

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9292,6 +9292,8 @@ cmd_url_open(ProfWin* window, const char* const command, gchar** args)
     _url_external_method(cmd_template, url, NULL);
 
 out:
+    // reset autocompletion to start from latest url and not where we left of
+    autocomplete_reset(window->urls_ac);
 
     free(cmd_template);
     free(filename);
@@ -9348,6 +9350,8 @@ cmd_url_save(ProfWin* window, const char* const command, gchar** args)
     }
 
 out:
+    // reset autocompletion to start from latest url and not where we left of
+    autocomplete_reset(window->urls_ac);
 
     free(filename);
     free(cmd_template);


### PR DESCRIPTION
I guess we should reset the position after we ran `/url open|save`.
So that next time `/url open <tab>` starts with the latest entry.

Fix https://github.com/profanity-im/profanity/issues/1654

@MarcoPolo-PasTonMolo I guess this is what we want?