### PR TITLE
Add none option for /who

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -627,6 +627,7 @@ cmd_ac_init(void)
     autocomplete_add(who_room_ac, "owner");
     autocomplete_add(who_room_ac, "admin");
     autocomplete_add(who_room_ac, "member");
+    autocomplete_add(who_room_ac, "none");
 
     bookmark_ac = autocomplete_new();
     autocomplete_add(bookmark_ac, "list");

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1049,7 +1049,7 @@ static struct cmd_t command_defs[] = {
               "/who",
               "/who online|offline|away|dnd|xa|chat|available|unavailable|any [<group>]",
               "/who moderator|participant|visitor",
-              "/who owner|admin|member")
+              "/who owner|admin|member|none")
       CMD_DESC(
               "Show contacts or room occupants with chosen status, role or affiliation.")
       CMD_ARGS(
@@ -1060,7 +1060,7 @@ static struct cmd_t command_defs[] = {
               { "any", "Contacts with any status (same as calling with no argument)." },
               { "<group>", "Filter the results by the specified roster group, not applicable in chat rooms." },
               { "moderator|participant|visitor", "Room occupants with the specified role." },
-              { "owner|admin|member", "Room occupants with the specified affiliation." })
+              { "owner|admin|member|none", "Room occupants with the specified affiliation." })
       CMD_EXAMPLES(
               "/who",
               "/who xa",

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -1763,7 +1763,7 @@ _who_room(ProfWin* window, const char* const command, gchar** args)
     }
 
     // bad arg
-    if (args[0] && (g_strcmp0(args[0], "online") != 0) && (g_strcmp0(args[0], "available") != 0) && (g_strcmp0(args[0], "unavailable") != 0) && (g_strcmp0(args[0], "away") != 0) && (g_strcmp0(args[0], "chat") != 0) && (g_strcmp0(args[0], "xa") != 0) && (g_strcmp0(args[0], "dnd") != 0) && (g_strcmp0(args[0], "any") != 0) && (g_strcmp0(args[0], "moderator") != 0) && (g_strcmp0(args[0], "participant") != 0) && (g_strcmp0(args[0], "visitor") != 0) && (g_strcmp0(args[0], "owner") != 0) && (g_strcmp0(args[0], "admin") != 0) && (g_strcmp0(args[0], "member") != 0) && (g_strcmp0(args[0], "outcast") != 0)) {
+    if (args[0] && (g_strcmp0(args[0], "online") != 0) && (g_strcmp0(args[0], "available") != 0) && (g_strcmp0(args[0], "unavailable") != 0) && (g_strcmp0(args[0], "away") != 0) && (g_strcmp0(args[0], "chat") != 0) && (g_strcmp0(args[0], "xa") != 0) && (g_strcmp0(args[0], "dnd") != 0) && (g_strcmp0(args[0], "any") != 0) && (g_strcmp0(args[0], "moderator") != 0) && (g_strcmp0(args[0], "participant") != 0) && (g_strcmp0(args[0], "visitor") != 0) && (g_strcmp0(args[0], "owner") != 0) && (g_strcmp0(args[0], "admin") != 0) && (g_strcmp0(args[0], "member") != 0) && (g_strcmp0(args[0], "outcast") != 0) && (g_strcmp0(args[0], "none") != 0)) {
         cons_bad_cmd_usage(command);
         return;
     }
@@ -1856,6 +1856,10 @@ _who_room(ProfWin* window, const char* const command, gchar** args)
         }
         if (g_strcmp0(args[0], "outcast") == 0) {
             mucwin_show_affiliation_list(mucwin, MUC_AFFILIATION_OUTCAST);
+            return;
+        }
+        if (g_strcmp0(args[0], "none") == 0) {
+            mucwin_show_affiliation_list(mucwin, MUC_AFFILIATION_NONE);
             return;
         }
     }

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -723,6 +723,9 @@ mucwin_show_affiliation_list(ProfMucWin* mucwin, muc_affiliation_t affiliation)
         case MUC_AFFILIATION_OUTCAST:
             win_println(window, THEME_DEFAULT, "!", "No outcasts found.");
             break;
+        case MUC_AFFILIATION_NONE:
+            win_println(window, THEME_DEFAULT, "!", "No nones found.");
+            break;
         default:
             break;
         }
@@ -740,6 +743,9 @@ mucwin_show_affiliation_list(ProfMucWin* mucwin, muc_affiliation_t affiliation)
             break;
         case MUC_AFFILIATION_OUTCAST:
             win_println(window, THEME_DEFAULT, "!", "Outcasts:");
+            break;
+        case MUC_AFFILIATION_NONE:
+            win_println(window, THEME_DEFAULT, "!", "Nones:");
             break;
         default:
             break;


### PR DESCRIPTION
Fixes https://github.com/profanity-im/profanity/issues/1425
`/who none` now displays all users in an muc without an affiliation
