### PR TITLE
Use EDITOR environment variable

### DIFF
--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -2277,8 +2277,10 @@ _get_default_string(preference_t pref)
         return "xdg-open";
     case PREF_URL_OPEN_CMD:
         return "xdg-open %u";
-    case PREF_COMPOSE_EDITOR:
-        return "vim";
+    case PREF_COMPOSE_EDITOR: {
+        gchar* editor = getenv("EDITOR");
+        return editor ? editor : "vim";
+    }
     case PREF_URL_SAVE_CMD:
         return NULL; // Default to built-in method.
     default:


### PR DESCRIPTION
When preferences do not specify a program to be used for /editor
command, try getting it from EDITOR (which POSIX.1-2017 calls one of
"variables that are frequently exported by widely used command
interpreters and applications"), fall back to "vim" if not set.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
