### PR TITLE
Add debug information to binary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,6 +349,7 @@ AC_CHECK_LIB([expect], [exp_expectl], [AM_CONDITIONAL([HAVE_EXPECT], [true])],
 
 ## Default parameters
 AM_CFLAGS="$AM_CFLAGS -Wall -Wno-deprecated-declarations -std=gnu99"
+AM_CFLAGS="$AM_CFLAGS -Wall -Wno-deprecated-declarations -std=gnu99 -ggdb3"
 AM_LDFLAGS="$AM_LDFLAGS -export-dynamic"
 
 AS_IF([test "x$PACKAGE_STATUS" = xdevelopment],


### PR DESCRIPTION
Option -ggdb3 (same as -g3) doesn't affect code-generation, just adds
to the binary size of an executable. Automake strips installed
binaries automatically when "make install-strip" is run so enabling
this option permanently doesn't affect the end result while allowing
for hassle-free interactive debugging.

If one is running a stripped binary it's still possible to attach GDB
by process PID and then use "file /path/to/unstripped/profanity" to
get all symbols and lines data.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
