### PR TITLE
Input window: handle invalid multibyte

### DIFF
--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -373,6 +373,10 @@ _inp_offset_to_col(char* str, int offset)
     while (i < offset && str[i] != '\0') {
         gunichar uni = g_utf8_get_char(&str[i]);
         size_t ch_len = mbrlen(&str[i], MB_CUR_MAX, NULL);
+        if ((ch_len == (size_t)-2) || (ch_len == (size_t)-1)) {
+            i++;
+            continue;
+        }
         i += ch_len;
         col++;
         if (g_unichar_iswide(uni)) {


### PR DESCRIPTION
The current code enters an infinite loop if the input string happens
to get an invalid utf-8 sequence somehow. For me it was reproducible
by running profanity in a Screen session and pressing Alt-т (cyrillic
letter).

Fix it the way borrowed from 0501e49623f68aa39508e4e622924c1dd8147588
where mbrlen is used for the same purposes.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
