### PR TITLE
make OMEMO respect resource settings

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -619,12 +619,13 @@ message_send_chat_otr(const char* const barejid, const char* const msg, gboolean
 
 #ifdef HAVE_OMEMO
 char*
-message_send_chat_omemo(const char* const jid, uint32_t sid, GList* keys,
+message_send_chat_omemo(const char* const barejid, uint32_t sid, GList* keys,
                         const unsigned char* const iv, size_t iv_len,
                         const unsigned char* const ciphertext, size_t ciphertext_len,
                         gboolean request_receipt, gboolean muc, const char* const replace_id)
 {
-    char* state = chat_session_get_state(jid);
+    char* state = chat_session_get_state(barejid);
+    char* jid = chat_session_get_jid(barejid);
     xmpp_ctx_t* const ctx = connection_get_ctx();
     char* id;
     xmpp_stanza_t* message;

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -208,7 +208,7 @@ char* message_send_chat_otr(const char* const barejid, const char* const msg, gb
 char* message_send_chat_pgp(const char* const barejid, const char* const msg, gboolean request_receipt, const char* const replace_id);
 // XEP-0373: OpenPGP for XMPP
 char* message_send_chat_ox(const char* const barejid, const char* const msg, gboolean request_receipt, const char* const replace_id);
-char* message_send_chat_omemo(const char* const jid, uint32_t sid, GList* keys, const unsigned char* const iv, size_t iv_len, const unsigned char* const ciphertext, size_t ciphertext_len, gboolean request_receipt, gboolean muc, const char* const replace_id);
+char* message_send_chat_omemo(const char* const barejid, uint32_t sid, GList* keys, const unsigned char* const iv, size_t iv_len, const unsigned char* const ciphertext, size_t ciphertext_len, gboolean request_receipt, gboolean muc, const char* const replace_id);
 char* message_send_private(const char* const fulljid, const char* const msg, const char* const oob_url);
 char* message_send_groupchat(const char* const roomjid, const char* const msg, const char* const oob_url, const char* const replace_id);
 void message_send_groupchat_subject(const char* const roomjid, const char* const subject);


### PR DESCRIPTION
non-encrypted messages sending respecting «/resource set» setting
omemo-encrypted messages uses default resource (ignoring that setting)
this PR make behavior of both cases consistent