### PR TITLE
Fix race condition on resize

### DIFF
--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -144,10 +144,8 @@ ui_update(void)
     doupdate();
 
     if (perform_resize) {
-        signal(SIGWINCH, SIG_IGN);
-        ui_resize();
         perform_resize = FALSE;
-        signal(SIGWINCH, ui_sigwinch_handler);
+        ui_resize();
     }
 }
 


### PR DESCRIPTION
The current code is inherently racy: if screen update takes
considerable time (e.g. when working over network) and a user
performed a series of resizes the final event might get ignored and
the display will be left in inconsistent state.

Fix the race by unsetting the flag first so if the next WINCH signal
is received while display is resizing it'll be processed on the next
iteration.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
