### PR TITLE
fix path where logs are stored

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -679,8 +679,10 @@ _get_log_filename(const char* const other, const char* const login, GDateTime* d
 {
     gchar* chatlogs_dir = files_file_in_account_data_path(DIR_CHATLOGS, login, is_room ? "rooms" : NULL);
     gchar* logfile_name = g_date_time_format(dt, "%Y_%m_%d.log");
-    gchar* logfile_path = files_file_in_account_data_path(chatlogs_dir, other, logfile_name);
+    gchar* other_ = str_replace(other, "@", "_at_");
+    gchar* logfile_path = g_strdup_printf("%s/%s/%s", chatlogs_dir, other_, logfile_name);
 
+    g_free(other_);
     g_free(logfile_name);
     g_free(chatlogs_dir);
 


### PR DESCRIPTION
Reported by @akawolf in profanity@rooms.dismail.de

Logs created while this bug was active were stored in `/home/<user>/.local/share/profanity//home/<user>/.local/share/profanity/chatlogs/`