### PR TITLE
fix theme load

### DIFF
--- a/src/config/theme.c
+++ b/src/config/theme.c
@@ -184,6 +184,9 @@ theme_exists(const char* const theme_name)
 gboolean
 theme_load(const char* const theme_name, gboolean load_theme_prefs)
 {
+    if (!theme_exists(theme_name))
+        return FALSE;
+
     color_pair_cache_reset();
 
     if (_theme_load_file(theme_name)) {


### PR DESCRIPTION
disable execution of colors-changing code when call for theme load and it doesn't exist

