### PR TITLE
Include useful aliases in profrc example

### DIFF
--- a/profrc.example
+++ b/profrc.example
@@ -37,6 +37,8 @@ message.text=true
 room.text=true
 
 [alias]
+colour=/color
+topic=/subject
 friends=/who online friends
 bob=/msg bob@server.org hey wassup?
 


### PR DESCRIPTION
Since some other commands are using british spelling for colour it
makes sense to have it available for /color command as well.

IRC users will feel more at home having /topic command equivalent to
/subject (which seems to be a MUC-specific terminology).

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
