### PR TITLE
Fix xscreensaver detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,7 +270,8 @@ AS_IF([test "x$PLATFORM" = xosx],
 dnl feature: xscreensaver
 AS_IF([test "x$enable_xscreensaver" != xno],
     [PKG_CHECK_MODULES([xscrnsaver], [xscrnsaver],
-        [AC_MSG_NOTICE([xscreensaver support is enabled])],
+        [AC_MSG_NOTICE([xscreensaver support is enabled]);
+         LIBS="$xscrnsaver_LIBS $LIBS" CFLAGS="$CFLAGS $xscrnsaver_CFLAGS"],
         [AS_IF([test "x$enable_xscreensaver" = xyes],
             [AC_MSG_ERROR([xscreensaver is required but does not exist])],
             [AC_MSG_NOTICE([xscreensaver support is disabled])])])])


### PR DESCRIPTION
Using pkg-config to find libraries requires explicit mention of the
relevant _CFLAGS and _LIBS variables.

Fixes #1695.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
