### PR TITLE
Fix SIGABRT when using wrong argument order for receiving ox key

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7503,11 +7503,6 @@ cmd_pgp(ProfWin* window, const char* const command, gchar** args)
 
 #ifdef HAVE_LIBGPGME
 
-/*!
- * \brief Command for XEP-0373: OpenPGP for XMPP
- *
- */
-
 gboolean
 cmd_ox(ProfWin* window, const char* const command, gchar** args)
 {

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7695,7 +7695,7 @@ cmd_ox(ProfWin* window, const char* const command, gchar** args)
             cons_show("JID and OpenPGP Key ID are required");
         }
     } else {
-        cons_show("OX not implemented");
+        cons_bad_cmd_usage(command);
     }
     return TRUE;
 }

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -340,7 +340,11 @@ _ox_request_public_key(const char* const jid, const char* const fingerprint)
 {
     assert(jid);
     assert(fingerprint);
-    assert(strlen(fingerprint) == KEYID_LENGTH);
+
+    if (strlen(fingerprint) != KEYID_LENGTH) {
+        cons_show_error("Invalid fingerprint length for: %s", fingerprint);
+    }
+
     cons_show("Requesting Public Key %s for %s", fingerprint, jid);
     log_info("[OX] Request %s's public key %s.", jid, fingerprint);
     // iq


### PR DESCRIPTION
Fix https://github.com/profanity-im/profanity/issues/1698