### PR TITLE
Fix room name not updating.

### DIFF
--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -891,6 +891,14 @@ _caps_response_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
         } else {
             log_debug("Capabilities not cached: %s, storing", given_sha1);
             EntityCapabilities* capabilities = stanza_create_caps_from_query_element(query);
+
+            // Update window name
+            ProfMucWin* win = wins_get_muc(from);
+            if (win != NULL) {
+                free(win->room_name);
+                win->room_name = strdup(capabilities->identity->name);
+            }
+
             caps_add_by_ver(given_sha1, capabilities);
             caps_destroy(capabilities);
         }


### PR DESCRIPTION
Now whenever the name of a room changes, either in profanity or another
client, it gets updated inside profanity.

Fixes https://github.com/profanity-im/profanity/issues/1710
