### PR TITLE
Update capabilities of muc on available presence

### DIFF
--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -892,13 +892,6 @@ _caps_response_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
             log_debug("Capabilities not cached: %s, storing", given_sha1);
             EntityCapabilities* capabilities = stanza_create_caps_from_query_element(query);
 
-            // Update window name
-            ProfMucWin* win = wins_get_muc(from);
-            if (win != NULL) {
-                free(win->room_name);
-                win->room_name = strdup(capabilities->identity->name);
-            }
-
             caps_add_by_ver(given_sha1, capabilities);
             caps_destroy(capabilities);
         }


### PR DESCRIPTION
Updates whether the muc is members only and its anonymity type.
Problem: the caps request is not always sent, it is always sent when name of muc is changed but not if the members only or anonymity type is changed. Any tips?

Should fix 1347 when completed