### PR TITLE
Add `/avatar set` command to publish avatar

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -26,7 +26,8 @@ RUN pacman -Syu --noconfirm && pacman -S --needed --noconfirm \
   pkg-config \
   python \
   wget \
-  sqlite
+  sqlite \
+  gdk-pixbuf2
 
 RUN mkdir -p /usr/src/{stabber,profanity}
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   pkg-config \
   python3-dev \
   python-dev-is-python3 \
-  libsqlite3-dev
+  libsqlite3-dev \
+  libgdk-pixbuf-2.0-dev
 
 RUN mkdir -p /usr/src/{stabber,libstrophe,profanity}
 WORKDIR /usr/src

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -34,7 +34,8 @@ RUN dnf install -y \
   python3-devel \
   readline-devel \
   openssl-devel \
-  sqlite-devel
+  sqlite-devel \
+  gdk-pixbuf2-devel
 
 # https://github.com/openSUSE/docker-containers-build/issues/26
 ENV LANG en_US.UTF-8

--- a/Dockerfile.tumbleweed
+++ b/Dockerfile.tumbleweed
@@ -34,7 +34,8 @@ RUN zypper --non-interactive in --no-recommends \
   python38 \
   python38-devel \
   readline-devel \
-  sqlite3-devel
+  sqlite3-devel \
+  gdk-pixbuf-devel
 
 # https://github.com/openSUSE/docker-containers-build/issues/26
 ENV LANG en_US.UTF-8

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   pkg-config \
   python3-dev \
   python-dev-is-python3 \
-  libsqlite3-dev
+  libsqlite3-dev \
+  libgdk-pixbuf-2.0-dev
 
 RUN mkdir -p /usr/src/{stabber,libstrophe,profanity}
 WORKDIR /usr/src

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -44,7 +44,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
         tests=(
         "--enable-notifications --enable-icons-and-clipboard --enable-otr --enable-pgp
         --enable-omemo --enable-plugins --enable-c-plugins
-        --enable-python-plugins --with-xscreensaver"
+        --enable-python-plugins --with-xscreensaver --enable-gdk-pixbuf"
         "--disable-notifications --disable-icons-and-clipboard --disable-otr --disable-pgp
         --disable-omemo --disable-plugins --disable-c-plugins
         --disable-python-plugins --without-xscreensaver"
@@ -60,6 +60,7 @@ case $(uname | tr '[:upper:]' '[:lower:]') in
         "--disable-c-plugins"
         "--disable-c-plugins --disable-python-plugins"
         "--without-xscreensaver"
+        "--disable-gdk-pixbuf"
         "")
         ;;
     darwin*)

--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ AC_ARG_WITH([themes],
 AC_ARG_ENABLE([icons-and-clipboard],
     [AS_HELP_STRING([--enable-icons-and-clipboard], [enable GTK tray icons and clipboard paste support])])
 AC_ARG_ENABLE([gdk-pixbuf],
-    [AS_HELP_STRING([--enable-gdk-pixbuf], [enable GDK Pixbuf support])])
+    [AS_HELP_STRING([--enable-gdk-pixbuf], [enable GDK Pixbuf support to scale avatars before uploading])])
 
 # Required dependencies
 
@@ -308,14 +308,13 @@ if test "x$enable_otr" != xno; then
    AM_COND_IF([BUILD_OTR], [AC_DEFINE([HAVE_LIBOTR], [1], [Have libotr])])
 fi
 
-dnl feature: pixbuf
+dnl feature: pixbuf / used for scaling avatars before uploading via `/avatar set`
 AS_IF([test "x$enable_pixbuf" != xno],
     [PKG_CHECK_MODULES([gdk_pixbuf], [gdk-pixbuf-2.0 >= 2.4],
         [AC_DEFINE([HAVE_PIXBUF], [1], [gdk-pixbuf module])],
         [AS_IF([test "x$enable_pixbuf" = xyes],
-               [AC_MSG_ERROR([gdk-pixbuf-2.0 >= 2.4 is required for GDK Pixbuf support])],
+               [AC_MSG_ERROR([gdk-pixbuf-2.0 >= 2.4 is required to scale avatars before uploading])],
                [AC_MSG_NOTICE([gdk-pixbuf-2.0 >= 2.4 not found, GDK Pixbuf support not enabled])])])])
-
 
 dnl feature: omemo
 AM_CONDITIONAL([BUILD_OMEMO], [false])

--- a/configure.ac
+++ b/configure.ac
@@ -311,7 +311,8 @@ fi
 dnl feature: pixbuf / used for scaling avatars before uploading via `/avatar set`
 AS_IF([test "x$enable_pixbuf" != xno],
     [PKG_CHECK_MODULES([gdk_pixbuf], [gdk-pixbuf-2.0 >= 2.4],
-        [AC_DEFINE([HAVE_PIXBUF], [1], [gdk-pixbuf module])],
+        [AC_DEFINE([HAVE_PIXBUF], [1], [gdk-pixbuf module])
+         LIBS="$gdk_pixbuf_LIBS $LIBS" CFLAGS="$gdk_pixbuf_CFLAGS $CFLAGS"],
         [AS_IF([test "x$enable_pixbuf" = xyes],
                [AC_MSG_ERROR([gdk-pixbuf-2.0 >= 2.4 is required to scale avatars before uploading])],
                [AC_MSG_NOTICE([gdk-pixbuf-2.0 >= 2.4 not found, GDK Pixbuf support not enabled])])])])

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,8 @@ AC_ARG_WITH([themes],
     [AS_HELP_STRING([--with-themes[[=PATH]]], [install themes (default yes)])])
 AC_ARG_ENABLE([icons-and-clipboard],
     [AS_HELP_STRING([--enable-icons-and-clipboard], [enable GTK tray icons and clipboard paste support])])
+AC_ARG_ENABLE([gdk-pixbuf],
+    [AS_HELP_STRING([--enable-gdk-pixbuf], [enable GDK Pixbuf support])])
 
 # Required dependencies
 
@@ -305,6 +307,15 @@ if test "x$enable_otr" != xno; then
 
    AM_COND_IF([BUILD_OTR], [AC_DEFINE([HAVE_LIBOTR], [1], [Have libotr])])
 fi
+
+dnl feature: pixbuf
+AS_IF([test "x$enable_pixbuf" != xno],
+    [PKG_CHECK_MODULES([gdk_pixbuf], [gdk-pixbuf-2.0 >= 2.4],
+        [AC_DEFINE([HAVE_PIXBUF], [1], [gdk-pixbuf module])],
+        [AS_IF([test "x$enable_pixbuf" = xyes],
+               [AC_MSG_ERROR([gdk-pixbuf-2.0 >= 2.4 is required for GDK Pixbuf support])],
+               [AC_MSG_NOTICE([gdk-pixbuf-2.0 >= 2.4 not found, GDK Pixbuf support not enabled])])])])
+
 
 dnl feature: omemo
 AM_CONDITIONAL([BUILD_OMEMO], [false])

--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -1057,6 +1057,7 @@ cmd_ac_init(void)
     autocomplete_add(correction_ac, "char");
 
     avatar_ac = autocomplete_new();
+    autocomplete_add(avatar_ac, "set");
     autocomplete_add(avatar_ac, "get");
     autocomplete_add(avatar_ac, "open");
 
@@ -4101,6 +4102,11 @@ _avatar_autocomplete(ProfWin* window, const char* const input, gboolean previous
 
     jabber_conn_status_t conn_status = connection_get_status();
     if (conn_status == JABBER_CONNECTED) {
+        result = cmd_ac_complete_filepath(input, "/avatar set", previous);
+        if (result) {
+            return result;
+        }
+
         result = autocomplete_param_with_func(input, "/avatar get", roster_barejid_autocomplete, previous, NULL);
         if (result) {
             return result;

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2452,7 +2452,7 @@ static struct cmd_t command_defs[] = {
               "If nothing happens after using this command the user either doesn't have an avatar set at all "
               "or doesn't use XEP-0084 to publish it.")
       CMD_ARGS(
-              { "set <path>", "Set avatar to the img at <path>." },
+              { "set <path>", "Set avatar to the image at <path>." },
               { "get <barejid>", "Download the avatar. barejid is the JID to download avatar from." },
               { "open <barejid>", "Download avatar and open it with command." })
       CMD_EXAMPLES(

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2443,16 +2443,20 @@ static struct cmd_t command_defs[] = {
       CMD_TAGS(
               CMD_TAG_CHAT)
       CMD_SYN(
+              "/avatar set <path>",
               "/avatar get <barejid>",
               "/avatar open <barejid>")
       CMD_DESC(
+              "Upload avatar for oneself (XEP-0084). "
               "Download avatar (XEP-0084) for a certain contact. "
               "If nothing happens after using this command the user either doesn't have an avatar set at all "
               "or doesn't use XEP-0084 to publish it.")
       CMD_ARGS(
+              { "set <path>", "Set avatar to the img at <path>." },
               { "get <barejid>", "Download the avatar. barejid is the JID to download avatar from." },
               { "open <barejid>", "Download avatar and open it with command." })
       CMD_EXAMPLES(
+              "/avatar set ~/images/avatar.png",
               "/avatar get thor@valhalla.edda",
               "/avatar open freyja@vanaheimr.edda") },
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9196,9 +9196,13 @@ cmd_avatar(ProfWin* window, const char* const command, gchar** args)
     }
 
     if (g_strcmp0(args[0], "set") == 0) {
+#ifdef HAVE_PIXBUF
         if (avatar_set(args[1])) {
             cons_show("Avatar updated successfully");
         }
+#else
+        cons_show("This version of Profanity has not been built with GDK Pixbuf support enabled");
+#endif
     } else if (g_strcmp0(args[0], "get") == 0) {
         avatar_get_by_nick(args[1], false);
     } else if (g_strcmp0(args[0], "open") == 0) {

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9195,7 +9195,11 @@ cmd_avatar(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
-    if (g_strcmp0(args[0], "get") == 0) {
+    if (g_strcmp0(args[0], "set") == 0) {
+        if (avatar_set(args[1])) {
+            cons_show("Avatar updated successfully");
+        }
+    } else if (g_strcmp0(args[0], "get") == 0) {
         avatar_get_by_nick(args[1], false);
     } else if (g_strcmp0(args[0], "open") == 0) {
         avatar_get_by_nick(args[1], true);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9201,7 +9201,7 @@ cmd_avatar(ProfWin* window, const char* const command, gchar** args)
             cons_show("Avatar updated successfully");
         }
 #else
-        cons_show("This version of Profanity has not been built with GDK Pixbuf support enabled");
+        cons_show("Profanity has not been built with GDK Pixbuf support enabled which is needed to scale the avatar when uploading.");
 #endif
     } else if (g_strcmp0(args[0], "get") == 0) {
         avatar_get_by_nick(args[1], false);

--- a/src/main.c
+++ b/src/main.c
@@ -173,6 +173,12 @@ main(int argc, char** argv)
         g_print("GTK icons/clipboard: Disabled\n");
 #endif
 
+#ifdef HAVE_PIXBUF
+        g_print("GDK Pixbuf: Enabled\n");
+#else
+        g_print("GDK Pixbuf: Disabled\n");
+#endif
+
         return 0;
     }
 

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -95,6 +95,7 @@ avatar_pep_subscribe(void)
     shall_open = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 }
 
+#ifdef HAVE_PIXBUF
 gboolean
 avatar_set(const char* path)
 {
@@ -104,7 +105,7 @@ avatar_set(const char* path)
     GdkPixbuf* pixbuf = gdk_pixbuf_new_from_file(expanded_path, &err);
 
     if (pixbuf == NULL) {
-        cons_show("An error occurred while opening %s: %s.", expanded_path, err ? err->message : "No error message given");
+        cons_show_error("An error occurred while opening %s: %s.", expanded_path, err ? err->message : "No error message given");
         return FALSE;
     }
     free(expanded_path);
@@ -129,7 +130,7 @@ avatar_set(const char* path)
     gsize len = -1;
 
     if (!gdk_pixbuf_save_to_buffer(pixbuf, &img_data, &len, "png", &err, NULL)) {
-        cons_show("Unable to scale and convert avatar.");
+        cons_show_error("Unable to scale and convert avatar.");
         return FALSE;
     }
 
@@ -146,6 +147,7 @@ avatar_set(const char* path)
 
     return TRUE;
 }
+#endif
 
 gboolean
 avatar_get_by_nick(const char* nick, gboolean open)

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -36,12 +36,13 @@
 #include "config.h"
 
 #include <glib.h>
+#ifdef HAVE_PIXBUF
 #include <gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf.h>
+#endif
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <assert.h>
 #include <sys/stat.h>
 
 #include "log.h"
@@ -61,7 +62,7 @@ typedef struct avatar_metadata
 
 static GHashTable* looking_for = NULL; // contains nicks/barejids from who we want to get the avatar
 static GHashTable* shall_open = NULL;  // contains a list of nicks that shall not just downloaded but also opened
-const int MAX_PIXEL = 192;
+const int MAX_PIXEL = 192;             // max pixel width/height for an avatar
 
 static void _avatar_request_item_by_id(const char* jid, avatar_metadata* data);
 static int _avatar_metadata_handler(xmpp_stanza_t* const stanza, void* const userdata);

--- a/src/xmpp/avatar.h
+++ b/src/xmpp/avatar.h
@@ -40,6 +40,8 @@
 
 void avatar_pep_subscribe(void);
 gboolean avatar_get_by_nick(const char* nick, gboolean open);
+#ifdef HAVE_PIXBUF
 gboolean avatar_set(const char* path);
+#endif
 
 #endif

--- a/src/xmpp/avatar.h
+++ b/src/xmpp/avatar.h
@@ -40,5 +40,6 @@
 
 void avatar_pep_subscribe(void);
 gboolean avatar_get_by_nick(const char* nick, gboolean open);
+gboolean avatar_set(const char* path);
 
 #endif

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -62,6 +62,8 @@
 #define STANZA_NAME_PUBLIC_KEYS_LIST "public-keys-list"
 #define STANZA_NAME_PUBKEY_METADATA  "pubkey-metadata"
 #define STANZA_NAME_DATA             "data"
+#define STANZA_NAME_METADATA         "metadata"
+#define STANZA_NAME_INFO             "info"
 #define STANZA_NAME_SHOW             "show"
 #define STANZA_NAME_STATUS           "status"
 #define STANZA_NAME_IQ               "iq"
@@ -409,6 +411,8 @@ XMPPCaps* stanza_parse_caps(xmpp_stanza_t* const stanza);
 void stanza_free_caps(XMPPCaps* caps);
 
 xmpp_stanza_t* stanza_create_avatar_retrieve_data_request(xmpp_ctx_t* ctx, const char* stanza_id, const char* const item_id, const char* const jid);
+xmpp_stanza_t* stanza_create_avatar_data_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len);
+xmpp_stanza_t* stanza_create_avatar_metadata_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len, int height, int width);
 xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const lastid);
 xmpp_stanza_t* stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* const password);
 xmpp_stanza_t* stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char* const password);

--- a/tests/unittests/xmpp/stub_avatar.c
+++ b/tests/unittests/xmpp/stub_avatar.c
@@ -8,8 +8,11 @@ avatar_get_by_nick(const char* nick)
 {
     return TRUE;
 }
+
+#ifdef HAVE_PIXBUF
 gboolean
 avatar_set(const char* path)
 {
-    return FALSE;
+    return TRUE;
 }
+#endif

--- a/tests/unittests/xmpp/stub_avatar.c
+++ b/tests/unittests/xmpp/stub_avatar.c
@@ -9,10 +9,8 @@ avatar_get_by_nick(const char* nick)
     return TRUE;
 }
 
-#ifdef HAVE_PIXBUF
 gboolean
 avatar_set(const char* path)
 {
     return TRUE;
 }
-#endif

--- a/tests/unittests/xmpp/stub_avatar.c
+++ b/tests/unittests/xmpp/stub_avatar.c
@@ -8,3 +8,8 @@ avatar_get_by_nick(const char* nick)
 {
     return TRUE;
 }
+gboolean
+avatar_set(const char* path)
+{
+    return FALSE;
+}


### PR DESCRIPTION
Use `/avatar set <path>` where <path> is an image file to upload a new
avatar for the current user. When the avatar is too big it gets scaled
down. Scaling code copied from dino.

Not so sure about using `gdk_pixbuf_save_to_buffer` because it's available after 2.4

Fixes https://github.com/profanity-im/profanity/issues/1687

