### PR TITLE
Fix segfault on `/ox discover`

### DIFF
--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -325,11 +325,14 @@ _ox_metadata_result(xmpp_stanza_t* const stanza, void* const userdata)
 
     while (pubkeymetadata) {
         const char* fingerprint = xmpp_stanza_get_attribute(pubkeymetadata, STANZA_ATTR_V4_FINGERPRINT);
-        if (strlen(fingerprint) == KEYID_LENGTH) {
-            cons_show(fingerprint);
-        } else {
-            cons_show("OX: Wrong char size of public key");
-            log_error("[OX] Wrong chat size of public key %s", fingerprint);
+
+        if (fingerprint) {
+            if (strlen(fingerprint) == KEYID_LENGTH) {
+                cons_show(fingerprint);
+            } else {
+                cons_show("OX: Wrong char size of public key");
+                log_error("[OX] Wrong chat size of public key %s", fingerprint);
+            }
         }
         pubkeymetadata = xmpp_stanza_get_next(pubkeymetadata);
     }


### PR DESCRIPTION
`/ox discover` segfaults on some misconfigured? nodes because there are
newlines before and after some pubkey-metadata stanzas so the newlines
get treated as seperate stanzas. This commit just skips each stanza in
public-keys-list that doesn't have a fingerprint.

Fixes https://github.com/profanity-im/profanity/issues/1713
