### PR TITLE
Respect silent nick change in mucs

### DIFF
--- a/src/xmpp/presence.c
+++ b/src/xmpp/presence.c
@@ -752,6 +752,8 @@ _muc_user_self_handler(xmpp_stanza_t* stanza)
             log_warning("presence: jid without resource");
             return;
         }
+
+        muc_nick_change_complete(room, nick);
         char* reason = stanza_get_reason(stanza);
         char* show_str = stanza_get_show(stanza, "online");
         char* status_str = stanza_get_status(stanza, NULL);


### PR DESCRIPTION
Profanity would ignore the silent nick change in some places. The roster
and history would show the correct nick, new messages from the current
user and the "Autojoined <jid> as <nick>" message would show the wrong
one. This commit fixes that problem.

Fixes https://github.com/profanity-im/profanity/issues/757
