### PR TITLE
Fix duplicate messages in chat with oneself.

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -60,6 +60,7 @@
 #include "ui/screen.h"
 #include "xmpp/xmpp.h"
 #include "xmpp/roster_list.h"
+#include "xmpp/connection.h"
 
 #define CONS_WIN_TITLE "Profanity. Type /help for help information."
 #define XML_WIN_TITLE  "XML Console"
@@ -1192,7 +1193,10 @@ win_print_incoming(ProfWin* window, const char* const display_name_from, ProfMes
         if (prefs_get_boolean(PREF_CORRECTION_ALLOW) && message->replace_id) {
             _win_correct(window, message->plain, message->id, message->replace_id, message->from_jid->barejid);
         } else {
-            _win_printf(window, enc_char, 0, message->timestamp, flags, THEME_TEXT_THEM, display_name_from, message->from_jid->barejid, message->id, "%s", message->plain);
+            // Prevent duplicate messages when current client is sending a message
+            if (g_strcmp0(message->from_jid->fulljid, connection_get_fulljid()) != 0) {
+                _win_printf(window, enc_char, 0, message->timestamp, flags, THEME_TEXT_THEM, display_name_from, message->from_jid->barejid, message->id, "%s", message->plain);
+            }
         }
 
         free(enc_char);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1314,6 +1314,14 @@ _handle_carbons(xmpp_stanza_t* const stanza)
         return NULL;
     }
 
+    // Eliminate duplicate messages in chat with oneself when another client is sending a message
+    char* bare_from = xmpp_jid_bare(connection_get_ctx(), xmpp_stanza_get_from(message_stanza));
+    if (g_strcmp0(bare_from, xmpp_stanza_get_to(message_stanza)) == 0) {
+        free(bare_from);
+        return NULL;
+    }
+    free(bare_from);
+
     return message_stanza;
 }
 


### PR DESCRIPTION
Messages would get duplicated when you chat with yourself, worse if you
had omemo enabled the duplicated message would say something along the
lines of "Your client doesn't support OMEMO". The cause was carbons
when the message was sent from another client, whilst it was a sent
and received message when profanity was the one to send it. This commit
ignores the carbon message in the 1st case and ignores the received one
in the 2nd.

Fixes https://github.com/profanity-im/profanity/issues/1595
