### PR TITLE
Use our omemo sid/fingerprint in qr code

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9049,8 +9049,10 @@ cmd_omemo_qrcode(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
-    char* fingerprint = omemo_own_fingerprint(TRUE);
-    cons_show_omemo_qrcode(fingerprint);
+    char* qrstr = omemo_qrcode_str();
+    cons_show_qrcode(qrstr);
+    free(qrstr);
+
     return TRUE;
 #else
     cons_show("This version of Profanity has not been built with OMEMO support enabled");

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -1896,3 +1896,21 @@ out:
     curl_url_cleanup(url);
     return ret;
 }
+
+/* returns a string in the format `xmpp:<user@server>?omemo-sid-<numerical-sid>=<omemo-fingerprint-hex-string>`
+ * used for verification over QR codes
+ */
+char*
+omemo_qrcode_str()
+{
+    char* mybarejid = connection_get_barejid();
+    char* fingerprint = omemo_own_fingerprint(TRUE);
+    uint32_t sid = omemo_device_id();
+
+    char* qrstr = g_strdup_printf("xmpp:%s?omemo-sid-%d=%s", mybarejid, sid, fingerprint);
+
+    free(mybarejid);
+    free(fingerprint);
+
+    return qrstr;
+}

--- a/src/omemo/omemo.h
+++ b/src/omemo/omemo.h
@@ -105,3 +105,5 @@ char* omemo_encrypt_file(FILE* in, FILE* out, off_t file_size, int* gcry_res);
 gcry_error_t omemo_decrypt_file(FILE* in, FILE* out, off_t file_size, const char* fragment);
 void omemo_free(void* a);
 int omemo_parse_aesgcm_url(const char* aesgcm_url, char** https_url, char** fragment);
+
+char* omemo_qrcode_str();

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -867,7 +867,7 @@ cons_show_disco_contact_information(GHashTable* addresses)
 }
 
 void
-cons_show_omemo_qrcode(const char* const text)
+cons_show_qrcode(const char* const text)
 {
 #ifdef HAVE_QRENCODE
     static const size_t ZOOM_SIZE = 10;

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -280,7 +280,7 @@ void cons_show_disco_info(const char* from, GSList* identities, GSList* features
 
 void cons_show_disco_contact_information(GHashTable* addresses);
 
-void cons_show_omemo_qrcode(const char* const text);
+void cons_show_qrcode();
 
 void cons_show_room_invite(const char* const invitor, const char* const room, const char* const reason);
 void cons_check_version(gboolean not_available_msg);

--- a/tests/unittests/omemo/stub_omemo.c
+++ b/tests/unittests/omemo/stub_omemo.c
@@ -120,3 +120,9 @@ omemo_device_id()
 {
     return 123;
 }
+
+char*
+omemo_qrcode_str()
+{
+    return NULL;
+}

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -930,7 +930,7 @@ cons_show_disco_info(const char* from, GSList* identities, GSList* features)
 }
 
 void
-cons_show_omemo_qrcode(const char* const text)
+cons_show_qrcode(const char* const text)
 {
 }
 


### PR DESCRIPTION
Current clients sid/fingerprint will be shown in following format:
`xmpp:<user@server>?omemo-sid-<numerical-sid>=<omemo-fingerprint-hex-string>`

Fix https://github.com/profanity-im/profanity/issues/1320
