### PR TITLE
Improve cmd argument parser

### DIFF
--- a/src/tools/parser.c
+++ b/src/tools/parser.c
@@ -83,8 +83,17 @@ _parse_args_helper(const char* const inp, int min, int max, gboolean* result, gb
                     i++;
                     gchar* next_ch = g_utf8_next_char(curr_ch);
                     gunichar next_uni = g_utf8_get_char(next_ch);
-                    token_start = next_ch;
-                    token_size += g_unichar_to_utf8(next_uni, NULL);
+
+                    if (next_uni == '"') {
+                        tokens = g_slist_append(tokens, g_strndup(curr_ch,
+                                                                  0));
+                        token_size = 0;
+                        in_token = FALSE;
+                        in_quotes = FALSE;
+                    } else {
+                        token_start = next_ch;
+                        token_size += g_unichar_to_utf8(next_uni, NULL);
+                    }
                 }
                 if (curr_uni == '"') {
                     gchar* next_ch = g_utf8_next_char(curr_ch);
@@ -115,7 +124,7 @@ _parse_args_helper(const char* const inp, int min, int max, gboolean* result, gb
                                                               token_size));
                     token_size = 0;
                     in_token = FALSE;
-                } else if (curr_uni != '"') {
+                } else {
                     token_size += g_unichar_to_utf8(curr_uni, NULL);
                 }
             }


### PR DESCRIPTION
"" used to become " now it just becomes an empty argument.
Also if quotes appeared after a token started then if the number of
quotes in the token is n the resulting one would be a token with the
n last characters cut off, now it's fixed.

Fixes https://github.com/profanity-im/profanity/issues/497
