### PR TITLE
Don't forget encryption status for OX and PGP.

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7475,6 +7475,7 @@ cmd_pgp(ProfWin* window, const char* const command, gchar** args)
         }
 
         chatwin->pgp_send = TRUE;
+        accounts_add_pgp_state(session_get_account_name(), chatwin->barejid, TRUE);
         win_println(window, THEME_DEFAULT, "!", "PGP encryption enabled.");
         return TRUE;
     }
@@ -7498,6 +7499,7 @@ cmd_pgp(ProfWin* window, const char* const command, gchar** args)
         }
 
         chatwin->pgp_send = FALSE;
+        accounts_add_pgp_state(session_get_account_name(), chatwin->barejid, FALSE);
         win_println(window, THEME_DEFAULT, "!", "PGP encryption disabled.");
         return TRUE;
     }
@@ -7673,6 +7675,7 @@ cmd_ox(ProfWin* window, const char* const command, gchar** args)
         }
 
         chatwin->is_ox = TRUE;
+        accounts_add_ox_state(session_get_account_name(), chatwin->barejid, TRUE);
         win_println(window, THEME_DEFAULT, "!", "OX encryption enabled.");
         return TRUE;
     } else if (g_strcmp0(args[0], "end") == 0) {
@@ -7688,6 +7691,7 @@ cmd_ox(ProfWin* window, const char* const command, gchar** args)
             win_println(window, THEME_DEFAULT, "!", "No OX session has been started.");
         } else {
             chatwin->is_ox = FALSE;
+            accounts_add_ox_state(session_get_account_name(), chatwin->barejid, FALSE);
             win_println(window, THEME_DEFAULT, "!", "OX encryption disabled.");
         }
         return TRUE;

--- a/src/config/account.c
+++ b/src/config/account.c
@@ -57,8 +57,9 @@ account_new(const gchar* const name, const gchar* const jid,
             const gchar* const muc_service, const gchar* const muc_nick,
             const gchar* const otr_policy, GList* otr_manual, GList* otr_opportunistic,
             GList* otr_always, const gchar* const omemo_policy, GList* omemo_enabled,
-            GList* omemo_disabled, const gchar* const pgp_keyid, const char* const startscript,
-            const char* const theme, gchar* tls_policy, gchar* auth_policy)
+            GList* omemo_disabled, GList* ox_enabled, GList* pgp_enabled,
+            const gchar* const pgp_keyid, const char* const startscript, const char* const theme,
+            gchar* tls_policy, gchar* auth_policy)
 {
     ProfAccount* new_account = malloc(sizeof(ProfAccount));
     memset(new_account, 0, sizeof(ProfAccount));
@@ -153,6 +154,10 @@ account_new(const gchar* const name, const gchar* const jid,
 
     new_account->omemo_enabled = omemo_enabled;
     new_account->omemo_disabled = omemo_disabled;
+
+    new_account->ox_enabled = ox_enabled;
+
+    new_account->pgp_enabled = pgp_enabled;
 
     if (pgp_keyid != NULL) {
         new_account->pgp_keyid = strdup(pgp_keyid);
@@ -281,6 +286,8 @@ account_free(ProfAccount* account)
     g_list_free_full(account->otr_always, g_free);
     g_list_free_full(account->omemo_enabled, g_free);
     g_list_free_full(account->omemo_disabled, g_free);
+    g_list_free_full(account->ox_enabled, g_free);
+    g_list_free_full(account->pgp_enabled, g_free);
     free(account);
 }
 

--- a/src/config/account.h
+++ b/src/config/account.h
@@ -64,6 +64,8 @@ typedef struct prof_account_t
     gchar* omemo_policy;
     GList* omemo_enabled;
     GList* omemo_disabled;
+    GList* ox_enabled;
+    GList* pgp_enabled;
     gchar* pgp_keyid;
     gchar* startscript;
     gchar* theme;
@@ -79,8 +81,9 @@ ProfAccount* account_new(const gchar* const name, const gchar* const jid,
                          const gchar* const muc_service, const gchar* const muc_nick,
                          const gchar* const otr_policy, GList* otr_manual, GList* otr_opportunistic,
                          GList* otr_always, const gchar* const omemo_policy, GList* omemo_enabled,
-                         GList* omemo_disabled, const gchar* const pgp_keyid, const char* const startscript,
-                         const char* const theme, gchar* tls_policy, gchar* auth_policy);
+                         GList* omemo_disabled, GList* ox_enabled, GList* pgp_enabled, const gchar* const pgp_keyid,
+                         const char* const startscript, const char* const theme, gchar* tls_policy,
+                         gchar* auth_policy);
 char* account_create_connect_jid(ProfAccount* account);
 gboolean account_eval_password(ProfAccount* account);
 void account_free(ProfAccount* account);

--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -283,21 +283,39 @@ accounts_get_account(const char* const name)
         }
 
         GList* omemo_enabled = NULL;
-        gchar** enabled_list = g_key_file_get_string_list(accounts, name, "omemo.enabled", &length, NULL);
-        if (enabled_list) {
+        gchar** omemo_enabled_list = g_key_file_get_string_list(accounts, name, "omemo.enabled", &length, NULL);
+        if (omemo_enabled_list) {
             for (int i = 0; i < length; i++) {
-                omemo_enabled = g_list_append(omemo_enabled, strdup(enabled_list[i]));
+                omemo_enabled = g_list_append(omemo_enabled, strdup(omemo_enabled_list[i]));
             }
-            g_strfreev(enabled_list);
+            g_strfreev(omemo_enabled_list);
         }
 
         GList* omemo_disabled = NULL;
-        gchar** disabled_list = g_key_file_get_string_list(accounts, name, "omemo.disabled", &length, NULL);
-        if (disabled_list) {
+        gchar** omemo_disabled_list = g_key_file_get_string_list(accounts, name, "omemo.disabled", &length, NULL);
+        if (omemo_disabled_list) {
             for (int i = 0; i < length; i++) {
-                omemo_disabled = g_list_append(omemo_disabled, strdup(disabled_list[i]));
+                omemo_disabled = g_list_append(omemo_disabled, strdup(omemo_disabled_list[i]));
             }
-            g_strfreev(disabled_list);
+            g_strfreev(omemo_disabled_list);
+        }
+
+        GList* ox_enabled = NULL;
+        gchar** ox_enabled_list = g_key_file_get_string_list(accounts, name, "ox.enabled", &length, NULL);
+        if (ox_enabled_list) {
+            for (int i = 0; i < length; i++) {
+                ox_enabled = g_list_append(ox_enabled, strdup(ox_enabled_list[i]));
+            }
+            g_strfreev(ox_enabled_list);
+        }
+
+        GList* pgp_enabled = NULL;
+        gchar** pgp_enabled_list = g_key_file_get_string_list(accounts, name, "pgp.enabled", &length, NULL);
+        if (pgp_enabled_list) {
+            for (int i = 0; i < length; i++) {
+                pgp_enabled = g_list_append(pgp_enabled, strdup(pgp_enabled_list[i]));
+            }
+            g_strfreev(pgp_enabled_list);
         }
 
         gchar* pgp_keyid = NULL;
@@ -328,8 +346,8 @@ accounts_get_account(const char* const name)
                                                priority_online, priority_chat, priority_away, priority_xa,
                                                priority_dnd, muc_service, muc_nick, otr_policy, otr_manual,
                                                otr_opportunistic, otr_always, omemo_policy, omemo_enabled,
-                                               omemo_disabled, pgp_keyid, startscript, theme, tls_policy,
-                                               auth_policy);
+                                               omemo_disabled, ox_enabled, pgp_enabled, pgp_keyid,
+                                               startscript, theme, tls_policy, auth_policy);
 
         g_free(jid);
         g_free(password);
@@ -415,6 +433,8 @@ accounts_rename(const char* const account_name, const char* const new_name)
         "omemo.policy",
         "omemo.enabled",
         "omemo.disabled",
+        "ox.enabled",
+        "pgp.enabled",
         "pgp.keyid",
         "last.activity",
         "script.start",
@@ -671,6 +691,36 @@ accounts_add_omemo_state(const char* const account_name, const char* const conta
         } else {
             conf_string_list_add(accounts, account_name, "omemo.disabled", contact_jid);
             conf_string_list_remove(accounts, account_name, "omemo.enabled", contact_jid);
+        }
+
+        _save_accounts();
+    }
+}
+
+void
+accounts_add_ox_state(const char* const account_name, const char* const contact_jid, gboolean enabled)
+{
+    if (accounts_account_exists(account_name)) {
+        if (enabled) {
+            conf_string_list_add(accounts, account_name, "ox.enabled", contact_jid);
+        } else {
+            conf_string_list_remove(accounts, account_name, "ox.enabled", contact_jid);
+        }
+
+        _save_accounts();
+    }
+}
+
+void
+accounts_add_pgp_state(const char* const account_name, const char* const contact_jid, gboolean enabled)
+{
+    if (accounts_account_exists(account_name)) {
+        if (enabled) {
+            conf_string_list_add(accounts, account_name, "pgp.enabled", contact_jid);
+            conf_string_list_remove(accounts, account_name, "pgp.disabled", contact_jid);
+        } else {
+            conf_string_list_add(accounts, account_name, "pgp.disabled", contact_jid);
+            conf_string_list_remove(accounts, account_name, "pgp.enabled", contact_jid);
         }
 
         _save_accounts();

--- a/src/config/accounts.h
+++ b/src/config/accounts.h
@@ -100,6 +100,8 @@ void accounts_clear_muc(const char* const account_name);
 void accounts_clear_resource(const char* const account_name);
 void accounts_add_otr_policy(const char* const account_name, const char* const contact_jid, const char* const policy);
 void accounts_add_omemo_state(const char* const account_name, const char* const contact_jid, gboolean enabled);
+void accounts_add_ox_state(const char* const account_name, const char* const contact_jid, gboolean enabled);
+void accounts_add_pgp_state(const char* const account_name, const char* const contact_jid, gboolean enabled);
 void accounts_clear_omemo_state(const char* const account_name, const char* const contact_jid);
 
 #endif

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -60,6 +60,36 @@
 static void _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid);
 static void _chatwin_set_last_message(ProfChatWin* chatwin, const char* const id, const char* const message);
 
+gboolean
+_pgp_automatic_start(const char* const recipient)
+{
+    gboolean result = FALSE;
+    char* account_name = session_get_account_name();
+    ProfAccount* account = accounts_get_account(account_name);
+
+    if (g_list_find_custom(account->pgp_enabled, recipient, (GCompareFunc)g_strcmp0)) {
+        result = TRUE;
+    }
+
+    account_free(account);
+    return result;
+}
+
+gboolean
+_ox_automatic_start(const char* const recipient)
+{
+    gboolean result = FALSE;
+    char* account_name = session_get_account_name();
+    ProfAccount* account = accounts_get_account(account_name);
+
+    if (g_list_find_custom(account->ox_enabled, recipient, (GCompareFunc)g_strcmp0)) {
+        result = TRUE;
+    }
+
+    account_free(account);
+    return result;
+}
+
 ProfChatWin*
 chatwin_new(const char* const barejid)
 {
@@ -82,20 +112,36 @@ chatwin_new(const char* const barejid)
 
     // We start a new OMEMO session if this contact has been configured accordingly.
     // However, if OTR is *also* configured, ask the user to choose between OMEMO and OTR.
-#ifdef HAVE_OMEMO
+
+    gboolean is_ox_secure = FALSE;
     gboolean is_otr_secure = FALSE;
+    gboolean is_omemo_secure = FALSE;
+#ifdef HAVE_LIBGPGME
+    is_ox_secure = _ox_automatic_start(barejid);
+#endif
+
+#ifdef HAVE_OMEMO
+    is_omemo_secure = omemo_automatic_start(barejid);
+#endif
+
 #ifdef HAVE_LIBOTR
     is_otr_secure = otr_is_secure(barejid);
-#endif // HAVE_LIBOTR
-    if (omemo_automatic_start(barejid) && is_otr_secure) {
-        win_println(window, THEME_DEFAULT, "!", "This chat could be either OMEMO or OTR encrypted, but not both. "
-                                                "Use '/omemo start' or '/otr start' to select the encryption method.");
-    } else if (omemo_automatic_start(barejid)) {
+#endif
+
+    if (is_omemo_secure + is_otr_secure + _pgp_automatic_start(barejid) + is_ox_secure > 1) {
+        win_println(window, THEME_DEFAULT, "!", "This chat could be either OMEMO, PGP, OX or OTR encrypted, but not more than one. "
+                                                "Use '/omemo start', '/pgp start', '/ox start' or '/otr start' to select the encryption method.");
+    } else if (is_omemo_secure) {
         // Start the OMEMO session
         omemo_start_session(barejid);
         chatwin->is_omemo = TRUE;
+    } else if (_pgp_automatic_start(barejid)) {
+        // Start the PGP session
+        chatwin->pgp_send = TRUE;
+    } else if (is_ox_secure) {
+        // Start the OX session
+        chatwin->is_ox = TRUE;
     }
-#endif // HAVE_OMEMO
 
     if (prefs_get_boolean(PREF_MAM)) {
         iq_mam_request(chatwin);

--- a/tests/unittests/config/stub_accounts.c
+++ b/tests/unittests/config/stub_accounts.c
@@ -318,3 +318,13 @@ void
 accounts_add_omemo_state(const char* const account_name, const char* const contact_jid, gboolean enabled)
 {
 }
+
+void
+accounts_add_pgp_state(const char* const account_name, const char* const contact_jid, gboolean enabled)
+{
+}
+
+void
+accounts_add_ox_state(const char* const account_name, const char* const contact_jid, gboolean enabled)
+{
+}

--- a/tests/unittests/test_cmd_account.c
+++ b/tests/unittests/test_cmd_account.c
@@ -34,7 +34,7 @@ void
 cmd_account_shows_account_when_connected_and_no_args(void** state)
 {
     ProfAccount* account = account_new("jabber_org", "me@jabber.org", NULL, NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     gchar* args[] = { NULL };
 
     will_return(connection_get_status, JABBER_CONNECTED);
@@ -98,7 +98,7 @@ cmd_account_show_shows_account_when_exists(void** state)
 {
     gchar* args[] = { "show", "account_name", NULL };
     ProfAccount* account = account_new("jabber_org", "me@jabber.org", NULL, NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_get_account, name);
     will_return(accounts_get_account, account);
@@ -437,7 +437,7 @@ cmd_account_set_password_sets_password(void** state)
 {
     gchar* args[] = { "set", "a_account", "password", "a_password", NULL };
     ProfAccount* account = account_new("a_account", NULL, NULL, NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -460,7 +460,7 @@ cmd_account_set_eval_password_sets_eval_password(void** state)
 {
     gchar* args[] = { "set", "a_account", "eval_password", "a_password", NULL };
     ProfAccount* account = account_new("a_account", NULL, NULL, NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -483,7 +483,7 @@ cmd_account_set_password_when_eval_password_set(void** state)
 {
     gchar* args[] = { "set", "a_account", "password", "a_password", NULL };
     ProfAccount* account = account_new("a_account", NULL, NULL, "a_password",
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -502,7 +502,7 @@ cmd_account_set_eval_password_when_password_set(void** state)
 {
     gchar* args[] = { "set", "a_account", "eval_password", "a_password", NULL };
     ProfAccount* account = account_new("a_account", NULL, "a_password", NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     expect_any(accounts_account_exists, account_name);
     will_return(accounts_account_exists, TRUE);
@@ -853,7 +853,7 @@ cmd_account_set_priority_updates_presence_when_account_connected_with_presence(v
 
 #ifdef HAVE_LIBGPGME
     ProfAccount* account = account_new("a_account", "a_jid", NULL, NULL, TRUE, NULL, 5222, "a_resource",
-                                       NULL, NULL, 10, 10, 10, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       NULL, NULL, 10, 10, 10, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(session_get_account_name, "a_account");
     expect_any(accounts_get_account, name);

--- a/tests/unittests/test_cmd_connect.c
+++ b/tests/unittests/test_cmd_connect.c
@@ -124,7 +124,7 @@ cmd_connect_lowercases_argument_with_account(void** state)
 {
     gchar* args[] = { "Jabber_org", NULL };
     ProfAccount* account = account_new("Jabber_org", "me@jabber.org", "password", NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 
@@ -145,7 +145,7 @@ cmd_connect_asks_password_when_not_in_account(void** state)
 {
     gchar* args[] = { "jabber_org", NULL };
     ProfAccount* account = account_new("jabber_org", "me@jabber.org", NULL, NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 
@@ -408,7 +408,7 @@ cmd_connect_shows_message_when_connecting_with_account(void** state)
 {
     gchar* args[] = { "jabber_org", NULL };
     ProfAccount* account = account_new("jabber_org", "user@jabber.org", "password", NULL,
-                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 
@@ -429,7 +429,7 @@ cmd_connect_connects_with_account(void** state)
 {
     gchar* args[] = { "jabber_org", NULL };
     ProfAccount* account = account_new("jabber_org", "me@jabber.org", "password", NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_DISCONNECTED);
 

--- a/tests/unittests/test_cmd_join.c
+++ b/tests/unittests/test_cmd_join.c
@@ -71,7 +71,7 @@ cmd_join_uses_account_mucservice_when_no_service_specified(void** state)
     char* expected_room = "room@conference.server.org";
     gchar* args[] = { room, "nick", nick, NULL };
     ProfAccount* account = account_new(account_name, "user@server.org", NULL, NULL,
-                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 
@@ -99,7 +99,7 @@ cmd_join_uses_supplied_nick(void** state)
     char* nick = "bob";
     gchar* args[] = { room, "nick", nick, NULL };
     ProfAccount* account = account_new(account_name, "user@server.org", NULL, NULL,
-                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 
@@ -127,7 +127,7 @@ cmd_join_uses_account_nick_when_not_supplied(void** state)
     char* account_nick = "a_nick";
     gchar* args[] = { room, NULL };
     ProfAccount* account = account_new(account_name, "user@server.org", NULL, NULL,
-                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, NULL, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 
@@ -158,7 +158,7 @@ cmd_join_uses_password_when_supplied(void** state)
     char* expected_room = "room@a_service";
     gchar* args[] = { room, "password", password, NULL };
     ProfAccount* account = account_new(account_name, "user@server.org", NULL, NULL,
-                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, "laptop", NULL, NULL, 0, 0, 0, 0, 0, account_service, account_nick, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     muc_init();
 

--- a/tests/unittests/test_cmd_otr.c
+++ b/tests/unittests/test_cmd_otr.c
@@ -196,7 +196,7 @@ cmd_otr_gen_generates_key_for_connected_account(void** state)
     gchar* args[] = { "gen", NULL };
     char* account_name = "myaccount";
     ProfAccount* account = account_new(account_name, "me@jabber.org", NULL, NULL,
-                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       TRUE, NULL, 0, NULL, NULL, NULL, 0, 0, 0, 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_CONNECTED);
     will_return(session_get_account_name, account_name);

--- a/tests/unittests/test_cmd_rooms.c
+++ b/tests/unittests/test_cmd_rooms.c
@@ -51,7 +51,7 @@ cmd_rooms_uses_account_default_when_no_arg(void** state)
     gchar* args[] = { NULL };
 
     ProfAccount* account = account_new("testaccount", NULL, NULL, NULL, TRUE, NULL, 0, NULL, NULL, NULL,
-                                       0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_CONNECTED);
     will_return(session_get_account_name, "account_name");
@@ -91,7 +91,7 @@ cmd_rooms_filter_arg_used_when_passed(void** state)
     gchar* args[] = { "filter", "text", NULL };
 
     ProfAccount* account = account_new("testaccount", NULL, NULL, NULL, TRUE, NULL, 0, NULL, NULL, NULL,
-                                       0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+                                       0, 0, 0, 0, 0, "default_conf_server", NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     will_return(connection_get_status, JABBER_CONNECTED);
     will_return(session_get_account_name, "account_name");


### PR DESCRIPTION
Use a pgp.enabled and ox.enabled array the same way that omemo.enabled
is used.

Fixes https://github.com/profanity-im/profanity/issues/1694
Fixes https://github.com/profanity-im/profanity/issues/733
