### PR TITLE
MAM improvements

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -248,15 +248,15 @@ log_database_get_previous_chat(const gchar* const contact_barejid, char* start_t
     gchar* sort = !flip ? "ASC" : "DESC";
     GDateTime* now = g_date_time_new_now_local();
     gchar* end_date_fmt = end_time ? end_time : g_date_time_format_iso8601(now);
-    gchar* start_date_fmt = start_time ? start_time : NULL;
-    query = sqlite3_mprintf("SELECT * FROM (SELECT `message`, `timestamp`, `from_jid`, `type` from `ChatLogs` WHERE ((`from_jid` = '%q' AND `to_jid` = '%q') OR (`from_jid` = '%q' AND `to_jid` = '%q')) AND `timestamp` < '%q' AND (%Q IS NULL OR `timestamp` > %Q) ORDER BY `timestamp` DESC LIMIT %d) ORDER BY `timestamp` %s;", contact_barejid, myjid->barejid, myjid->barejid, contact_barejid, end_date_fmt, start_date_fmt, start_date_fmt, MESSAGES_TO_RETRIEVE, sort);
+    query = sqlite3_mprintf("SELECT * FROM (SELECT `message`, `timestamp`, `from_jid`, `type` from `ChatLogs` WHERE ((`from_jid` = '%q' AND `to_jid` = '%q') OR (`from_jid` = '%q' AND `to_jid` = '%q')) AND `timestamp` < '%q' AND (%Q IS NULL OR `timestamp` > %Q) ORDER BY `timestamp` %s LIMIT %d) ORDER BY `timestamp` %s;", contact_barejid, myjid->barejid, myjid->barejid, contact_barejid, end_date_fmt, start_time, start_time, sort, MESSAGES_TO_RETRIEVE, sort);
+
+    g_date_time_unref(now);
+    g_free(end_date_fmt);
+
     if (!query) {
         log_error("log_database_get_previous_chat(): SQL query. could not allocate memory");
         return NULL;
     }
-
-    g_date_time_unref(now);
-    g_free(end_date_fmt);
 
     jid_destroy(myjid);
 

--- a/src/database.c
+++ b/src/database.c
@@ -366,7 +366,7 @@ _add_to_db(ProfMessage* message, char* type, const Jid* const from_jid, const Ji
         type = (char*)_get_message_type_str(message->type);
     }
 
-    query = sqlite3_mprintf("INSERT INTO `ChatLogs` (`from_jid`, `from_resource`, `to_jid`, `to_resource`, `message`, `timestamp`, `stanza_id`, `archive_id`, `replace_id`, `type`, `encryption`) SELECT '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q' WHERE NOT EXISTS (SELECT 1 FROM `ChatLogs` WHERE `archive_id` = '%q' AND `archive_id` != '')",
+    query = sqlite3_mprintf("INSERT INTO `ChatLogs` (`from_jid`, `from_resource`, `to_jid`, `to_resource`, `message`, `timestamp`, `stanza_id`, `archive_id`, `replace_id`, `type`, `encryption`) SELECT '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q', '%q' WHERE NOT EXISTS (SELECT 1 FROM `ChatLogs` WHERE (`archive_id` = '%q' AND `archive_id` != '') OR (`stanza_id` = '%q' AND `stanza_id` != ''))",
                             from_jid->barejid,
                             from_jid->resourcepart ? from_jid->resourcepart : "",
                             to_jid->barejid,
@@ -378,7 +378,8 @@ _add_to_db(ProfMessage* message, char* type, const Jid* const from_jid, const Ji
                             message->replace_id ? message->replace_id : "",
                             type ? type : "",
                             enc ? enc : "",
-                            message->stanzaid ? message->stanzaid : "");
+                            message->stanzaid ? message->stanzaid : "",
+                            message->id ? message->id : "");
     if (!query) {
         log_error("log_database_add(): SQL query. could not allocate memory");
         return;

--- a/src/database.c
+++ b/src/database.c
@@ -246,7 +246,8 @@ log_database_get_previous_chat(const gchar* const contact_barejid, char* start_t
 
     // Flip order when querying older pages
     gchar* sort = !flip ? "ASC" : "DESC";
-    gchar* end_date_fmt = end_time ? end_time : g_date_time_format_iso8601(g_date_time_new_now_local());
+    GDateTime* now = g_date_time_new_now_local();
+    gchar* end_date_fmt = end_time ? end_time : g_date_time_format_iso8601(now);
     gchar* start_date_fmt = start_time ? start_time : NULL;
     query = sqlite3_mprintf("SELECT * FROM (SELECT `message`, `timestamp`, `from_jid`, `type` from `ChatLogs` WHERE ((`from_jid` = '%q' AND `to_jid` = '%q') OR (`from_jid` = '%q' AND `to_jid` = '%q')) AND `timestamp` < '%q' AND (%Q IS NULL OR `timestamp` > %Q) ORDER BY `timestamp` DESC LIMIT %d) ORDER BY `timestamp` %s;", contact_barejid, myjid->barejid, myjid->barejid, contact_barejid, end_date_fmt, start_date_fmt, start_date_fmt, MESSAGES_TO_RETRIEVE, sort);
     if (!query) {
@@ -254,6 +255,7 @@ log_database_get_previous_chat(const gchar* const contact_barejid, char* start_t
         return NULL;
     }
 
+    g_date_time_unref(now);
     g_free(end_date_fmt);
 
     jid_destroy(myjid);

--- a/src/database.c
+++ b/src/database.c
@@ -251,7 +251,7 @@ log_database_get_previous_chat(const gchar* const contact_barejid, char* start_t
     gchar* sort2 = !flip ? "ASC" : "DESC";
     GDateTime* now = g_date_time_new_now_local();
     gchar* end_date_fmt = end_time ? end_time : g_date_time_format_iso8601(now);
-    query = sqlite3_mprintf("SELECT * FROM (SELECT `message`, `timestamp`, `from_jid`, `type` from `ChatLogs` WHERE ((`from_jid` = '%q' AND `to_jid` = '%q') OR (`from_jid` = '%q' AND `to_jid` = '%q')) AND `timestamp` < '%q' AND (%Q IS NULL OR `timestamp` > %Q) ORDER BY `timestamp` %s LIMIT %d) ORDER BY `timestamp` %s;", contact_barejid, myjid->barejid, myjid->barejid, contact_barejid, end_date_fmt, start_time, start_time, sort1, MESSAGES_TO_RETRIEVE, sort2);
+    query = sqlite3_mprintf("SELECT * FROM (SELECT COALESCE(B.`message`, A.`message`) AS message, A.`timestamp`, A.`from_jid`, A.`type` from `ChatLogs` AS A LEFT JOIN `ChatLogs` AS B ON A.`stanza_id` = B.`replace_id` WHERE A.`replace_id` = '' AND ((A.`from_jid` = '%q' AND A.`to_jid` = '%q') OR (A.`from_jid` = '%q' AND A.`to_jid` = '%q')) AND A.`timestamp` < '%q' AND (%Q IS NULL OR A.`timestamp` > %Q) ORDER BY A.`timestamp` %s LIMIT %d) ORDER BY `timestamp` %s;", contact_barejid, myjid->barejid, myjid->barejid, contact_barejid, end_date_fmt, start_time, start_time, sort1, MESSAGES_TO_RETRIEVE, sort2);
 
     g_date_time_unref(now);
     g_free(end_date_fmt);

--- a/src/database.h
+++ b/src/database.h
@@ -40,12 +40,14 @@
 #include "config/account.h"
 #include "xmpp/xmpp.h"
 
+#define MESSAGES_TO_RETRIEVE 10
+
 gboolean log_database_init(ProfAccount* account);
 void log_database_add_incoming(ProfMessage* message);
 void log_database_add_outgoing_chat(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc_pm(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
-GSList* log_database_get_previous_chat(const gchar* const contact_barejid, GDateTime* end_time, gboolean flip);
+GSList* log_database_get_previous_chat(const gchar* const contact_barejid, char* start_time, char* end_time, gboolean flip);
 ProfMessage* log_database_get_limits_info(const gchar* const contact_barejid, gboolean is_last);
 void log_database_close(void);
 

--- a/src/database.h
+++ b/src/database.h
@@ -47,7 +47,7 @@ void log_database_add_incoming(ProfMessage* message);
 void log_database_add_outgoing_chat(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc_pm(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
-GSList* log_database_get_previous_chat(const gchar* const contact_barejid, char* start_time, char* end_time, gboolean flip);
+GSList* log_database_get_previous_chat(const gchar* const contact_barejid, char* start_time, char* end_time, gboolean from_start, gboolean flip);
 ProfMessage* log_database_get_limits_info(const gchar* const contact_barejid, gboolean is_last);
 void log_database_close(void);
 

--- a/src/database.h
+++ b/src/database.h
@@ -45,7 +45,7 @@ void log_database_add_incoming(ProfMessage* message);
 void log_database_add_outgoing_chat(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc_pm(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
-GSList* log_database_get_previous_chat(const gchar* const contact_barejid);
+GSList* log_database_get_previous_chat(const gchar* const contact_barejid, GDateTime* end_time, gboolean flip);
 ProfMessage* log_database_get_limits_info(const gchar* const contact_barejid, gboolean is_last);
 void log_database_close(void);
 

--- a/src/database.h
+++ b/src/database.h
@@ -46,6 +46,7 @@ void log_database_add_outgoing_chat(const char* const id, const char* const bare
 void log_database_add_outgoing_muc(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc_pm(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 GSList* log_database_get_previous_chat(const gchar* const contact_barejid);
+ProfMessage* log_database_get_limits_info(const gchar* const contact_barejid, gboolean is_last);
 void log_database_close(void);
 
 #endif // DATABASE_H

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -54,6 +54,7 @@
 #include "event/common.h"
 #include "plugins/plugins.h"
 #include "ui/window_list.h"
+#include "ui/window.h"
 #include "tools/bookmark_ignore.h"
 #include "xmpp/xmpp.h"
 #include "xmpp/muc.h"
@@ -637,6 +638,11 @@ sv_ev_incoming_message(ProfMessage* message)
         ProfWin* window = wins_new_chat(looking_for_jid);
         chatwin = (ProfChatWin*)window;
         new_win = TRUE;
+
+        if (prefs_get_boolean(PREF_MAM)) {
+            iq_mam_request(chatwin);
+            win_print_loading_history(window);
+        }
 
 #ifdef HAVE_OMEMO
         if (!message->is_mam) {

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -640,8 +640,8 @@ sv_ev_incoming_message(ProfMessage* message)
         new_win = TRUE;
 
         if (prefs_get_boolean(PREF_MAM)) {
-            iq_mam_request(chatwin);
             win_print_loading_history(window);
+            iq_mam_request(chatwin, g_date_time_add_seconds(message->timestamp, 0)); // copy timestamp
         }
 
 #ifdef HAVE_OMEMO

--- a/src/ui/buffer.c
+++ b/src/ui/buffer.c
@@ -153,6 +153,14 @@ buffer_remove_entry_by_id(ProfBuff buffer, const char* const id)
     }
 }
 
+void
+buffer_remove_entry(ProfBuff buffer, int entry)
+{
+    GSList* node = g_slist_nth(buffer->entries, entry);
+    _free_entry(node->data);
+    buffer->entries = g_slist_delete_link(buffer->entries, node);
+}
+
 gboolean
 buffer_mark_received(ProfBuff buffer, const char* const id)
 {

--- a/src/ui/buffer.c
+++ b/src/ui/buffer.c
@@ -111,6 +111,34 @@ buffer_append(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime*
 }
 
 void
+buffer_prepend(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const from_jid, const char* const message, DeliveryReceipt* receipt, const char* const id)
+{
+    ProfBuffEntry* e = malloc(sizeof(struct prof_buff_entry_t));
+    e->show_char = strdup(show_char);
+    e->pad_indent = pad_indent;
+    e->flags = flags;
+    e->theme_item = theme_item;
+    e->time = g_date_time_ref(time);
+    e->display_from = display_from ? strdup(display_from) : NULL;
+    e->from_jid = from_jid ? strdup(from_jid) : NULL;
+    e->message = strdup(message);
+    e->receipt = receipt;
+    if (id) {
+        e->id = strdup(id);
+    } else {
+        e->id = NULL;
+    }
+
+    if (g_slist_length(buffer->entries) == BUFF_SIZE) {
+        GSList* last = g_slist_last(buffer->entries);
+        _free_entry(last->data);
+        buffer->entries = g_slist_delete_link(buffer->entries, last);
+    }
+
+    buffer->entries = g_slist_prepend(buffer->entries, e);
+}
+
+void
 buffer_remove_entry_by_id(ProfBuff buffer, const char* const id)
 {
     GSList* entries = buffer->entries;

--- a/src/ui/buffer.h
+++ b/src/ui/buffer.h
@@ -72,6 +72,7 @@ void buffer_free(ProfBuff buffer);
 void buffer_append(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id);
 void buffer_prepend(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id);
 void buffer_remove_entry_by_id(ProfBuff buffer, const char* const id);
+void buffer_remove_entry(ProfBuff buffer, int entry);
 int buffer_size(ProfBuff buffer);
 ProfBuffEntry* buffer_get_entry(ProfBuff buffer, int entry);
 ProfBuffEntry* buffer_get_entry_by_id(ProfBuff buffer, const char* const id);

--- a/src/ui/buffer.h
+++ b/src/ui/buffer.h
@@ -70,6 +70,7 @@ typedef struct prof_buff_t* ProfBuff;
 ProfBuff buffer_create();
 void buffer_free(ProfBuff buffer);
 void buffer_append(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id);
+void buffer_prepend(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id);
 void buffer_remove_entry_by_id(ProfBuff buffer, const char* const id);
 int buffer_size(ProfBuff buffer);
 ProfBuffEntry* buffer_get_entry(ProfBuff buffer, int entry);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -519,7 +519,7 @@ static void
 _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 {
     if (!chatwin->history_shown) {
-        GSList* history = log_database_get_previous_chat(contact_barejid, NULL, NULL, FALSE);
+        GSList* history = log_database_get_previous_chat(contact_barejid, NULL, NULL, FALSE, FALSE);
         GSList* curr = history;
 
         while (curr) {
@@ -547,7 +547,7 @@ chatwin_db_history(ProfChatWin* chatwin, char* start_time, char* end_time, gbool
         end_time = buffer_size(((ProfWin*)chatwin)->layout->buffer) == 0 ? NULL : g_date_time_format_iso8601(buffer_get_entry(((ProfWin*)chatwin)->layout->buffer, 0)->time);
     }
 
-    GSList* history = log_database_get_previous_chat(chatwin->barejid, start_time, end_time, flip);
+    GSList* history = log_database_get_previous_chat(chatwin->barejid, start_time, end_time, !flip, flip);
     gboolean has_items = g_slist_length(history) != 0;
     GSList* curr = history;
 

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -66,11 +66,8 @@ chatwin_new(const char* const barejid)
     ProfWin* window = wins_new_chat(barejid);
     ProfChatWin* chatwin = (ProfChatWin*)window;
 
-    if (!prefs_get_boolean(PREF_MAM) || (prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY))) {
-        if (0) {
-            
+    if (!prefs_get_boolean(PREF_MAM) && (prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY))) {
         _chatwin_history(chatwin, barejid);
-        }
     }
 
     // if the contact is offline, show a message
@@ -311,7 +308,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         // MUCPMs also get printed here. In their case we don't save any logs (because nick owners can change) and thus we shouldn't read logs
         // (and if we do we need to check the resourcepart)
         if (!prefs_get_boolean(PREF_MAM) && prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY) && message->type == PROF_MSG_TYPE_CHAT) {
-            /* _chatwin_history(chatwin, chatwin->barejid); */
+            _chatwin_history(chatwin, chatwin->barejid);
         }
 
         // show users status first, when receiving message via delayed delivery

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -66,8 +66,11 @@ chatwin_new(const char* const barejid)
     ProfWin* window = wins_new_chat(barejid);
     ProfChatWin* chatwin = (ProfChatWin*)window;
 
-    if (prefs_get_boolean(PREF_MAM) || (prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY))) {
+    if (!prefs_get_boolean(PREF_MAM) || (prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY))) {
+        if (0) {
+            
         _chatwin_history(chatwin, barejid);
+        }
     }
 
     // if the contact is offline, show a message
@@ -307,7 +310,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         // MUCPMs also get printed here. In their case we don't save any logs (because nick owners can change) and thus we shouldn't read logs
         // (and if we do we need to check the resourcepart)
         if (!prefs_get_boolean(PREF_MAM) && prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY) && message->type == PROF_MSG_TYPE_CHAT) {
-            _chatwin_history(chatwin, chatwin->barejid);
+            /* _chatwin_history(chatwin, chatwin->barejid); */
         }
 
         // show users status first, when receiving message via delayed delivery
@@ -518,7 +521,7 @@ static void
 _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 {
     if (!chatwin->history_shown) {
-        GSList* history = log_database_get_previous_chat(contact_barejid, NULL, FALSE);
+        GSList* history = log_database_get_previous_chat(contact_barejid, NULL, NULL, FALSE);
         GSList* curr = history;
 
         while (curr) {
@@ -538,11 +541,11 @@ _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 }
 
 gboolean
-chatwin_old_history(ProfChatWin* chatwin)
+chatwin_old_history(ProfChatWin* chatwin, char* start_time)
 {
     // TODO: not correct location but check whether notifications get screwed
-    GDateTime* time = buffer_size(((ProfWin*)chatwin)->layout->buffer) == 0 ? NULL : buffer_get_entry(((ProfWin*)chatwin)->layout->buffer, 0)->time;
-    GSList* history = log_database_get_previous_chat(chatwin->barejid, time, TRUE);
+    char* end_time = buffer_size(((ProfWin*)chatwin)->layout->buffer) == 0 ? NULL : g_date_time_format_iso8601(buffer_get_entry(((ProfWin*)chatwin)->layout->buffer, 0)->time);
+    GSList* history = log_database_get_previous_chat(chatwin->barejid, start_time, end_time, TRUE);
     gboolean has_items = g_slist_length(history) != 0;
     GSList* curr = history;
 

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -102,6 +102,7 @@ chatwin_new(const char* const barejid)
 
     if (prefs_get_boolean(PREF_MAM)) {
         iq_mam_request(chatwin);
+        win_print_loading_history(window);
     }
 
     return chatwin;

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -280,7 +280,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
     free(mybarejid);
 
     gboolean is_current = wins_is_current(window);
-    gboolean notify = prefs_do_chat_notify(is_current);
+    gboolean notify = prefs_do_chat_notify(is_current) && !message->is_mam;
 
     // currently viewing chat window with sender
     if (wins_is_current(window)) {
@@ -291,13 +291,16 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         // not currently viewing chat window with sender
     } else {
         status_bar_new(num, WIN_CHAT, chatwin->barejid);
-        cons_show_incoming_message(display_name, num, chatwin->unread, window);
 
-        if (prefs_get_boolean(PREF_FLASH)) {
-            flash();
+        if (!message->is_mam) {
+            cons_show_incoming_message(display_name, num, chatwin->unread, window);
+
+            if (prefs_get_boolean(PREF_FLASH)) {
+                flash();
+            }
+
+            chatwin->unread++;
         }
-
-        chatwin->unread++;
 
         // TODO: so far we don't ask for MAM when incoming message occurs.
         // Need to figure out:
@@ -326,7 +329,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
     wins_add_urls_ac(window, message);
     wins_add_quotes_ac(window, message->plain);
 
-    if (prefs_get_boolean(PREF_BEEP)) {
+    if (prefs_get_boolean(PREF_BEEP) && !message->is_mam) {
         beep();
     }
 

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -320,7 +320,10 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         }
 
         win_insert_last_read_position_marker((ProfWin*)chatwin, chatwin->barejid);
-        win_print_incoming(window, display_name, message);
+
+        if (!win_created || !prefs_get_boolean(PREF_MAM)) {
+            win_print_incoming(window, display_name, message);
+        }
     }
 
     wins_add_urls_ac(window, message);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -98,7 +98,7 @@ chatwin_new(const char* const barejid)
 #endif // HAVE_OMEMO
 
     if (prefs_get_boolean(PREF_MAM)) {
-        iq_mam_request(chatwin);
+        iq_mam_request(chatwin, NULL);
         win_print_loading_history(window);
     }
 
@@ -320,10 +320,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         }
 
         win_insert_last_read_position_marker((ProfWin*)chatwin, chatwin->barejid);
-
-        if (!win_created || !prefs_get_boolean(PREF_MAM)) {
-            win_print_incoming(window, display_name, message);
-        }
+        win_print_incoming(window, display_name, message);
     }
 
     wins_add_urls_ac(window, message);
@@ -542,7 +539,8 @@ _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 }
 
 // Print history starting from start_time to end_time if end_time is null the
-// first entrie's timestamp in the buffer is used. Flip true to prepend to buffer.
+// first entry's timestamp in the buffer is used. Flip true to prepend to buffer.
+// Timestamps should be in iso8601
 gboolean
 chatwin_db_history(ProfChatWin* chatwin, char* start_time, char* end_time, gboolean flip)
 {

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -145,7 +145,7 @@ void chatwin_set_incoming_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_incoming_char(ProfChatWin* chatwin);
 void chatwin_set_outgoing_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_outgoing_char(ProfChatWin* chatwin);
-gboolean chatwin_old_history(ProfChatWin* chatwin);
+gboolean chatwin_old_history(ProfChatWin* chatwin, char* start_date);
 
 // MUC window
 ProfMucWin* mucwin_new(const char* const barejid);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -145,6 +145,7 @@ void chatwin_set_incoming_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_incoming_char(ProfChatWin* chatwin);
 void chatwin_set_outgoing_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_outgoing_char(ProfChatWin* chatwin);
+gboolean chatwin_old_history(ProfChatWin* chatwin);
 
 // MUC window
 ProfMucWin* mucwin_new(const char* const barejid);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -145,7 +145,7 @@ void chatwin_set_incoming_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_incoming_char(ProfChatWin* chatwin);
 void chatwin_set_outgoing_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_outgoing_char(ProfChatWin* chatwin);
-gboolean chatwin_old_history(ProfChatWin* chatwin, char* start_date);
+gboolean chatwin_db_history(ProfChatWin* chatwin, char* start_time, char* end_time, gboolean flip);
 
 // MUC window
 ProfMucWin* mucwin_new(const char* const barejid);

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -602,11 +602,19 @@ win_page_up(ProfWin* window)
 
     if (*page_start == -page_space && prefs_get_boolean(PREF_MAM) && window->type == WIN_CHAT) {
         ProfChatWin* chatwin = (ProfChatWin*) window;
-        if (!chatwin_old_history(chatwin)) {
-            cons_show("Fetched mam");
-            iq_mam_request_older(chatwin);
-        } else {
-            cons_show("Showed history");
+        ProfBuffEntry* first_entry = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0) : NULL;
+        char* loading_text = "Loading older messages ...";
+
+        // Don't do anything if still fetching mam messages
+        if (first_entry && !(first_entry->theme_item == THEME_ROOMINFO && g_strcmp0(first_entry->message, loading_text) == 0)) {
+            if (!chatwin_old_history(chatwin)) {
+                cons_show("Fetched mam");
+                buffer_prepend(window->layout->buffer, "-", 0, first_entry->time, NO_DATE, THEME_ROOMINFO, NULL, NULL, loading_text, NULL, NULL);
+                win_redraw(window);
+                iq_mam_request_older(chatwin);
+            } else {
+                cons_show("Showed history");
+            }
         }
     }
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -610,8 +610,7 @@ win_page_up(ProfWin* window)
         if (first_entry && !(first_entry->theme_item == THEME_ROOMINFO && g_strcmp0(first_entry->message, loading_text) == 0)) {
             if (!chatwin_old_history(chatwin, NULL)) {
                 cons_show("Fetched mam");
-                buffer_prepend(window->layout->buffer, "-", 0, first_entry->time, NO_DATE, THEME_ROOMINFO, NULL, NULL, loading_text, NULL, NULL);
-                win_redraw(window);
+                win_print_loading_history(window);
                 iq_mam_request_older(chatwin);
             } else {
                 cons_show("Showed history");
@@ -1853,6 +1852,15 @@ win_redraw(ProfWin* window)
             _win_print_internal(window, e->show_char, e->pad_indent, e->time, e->flags, e->theme_item, e->display_from, e->message, e->receipt);
         }
     }
+}
+
+void
+win_print_loading_history(ProfWin* window)
+{
+    char* loading_text = "Loading older messages ...";
+    GDateTime* timestamp = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0)->time : g_date_time_new_now_local();
+    buffer_prepend(window->layout->buffer, "-", 0, timestamp, NO_DATE, THEME_ROOMINFO, NULL, NULL, loading_text, NULL, NULL);
+    win_redraw(window);
 }
 
 gboolean

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -602,8 +602,14 @@ win_page_up(ProfWin* window)
 
     if (*page_start == -page_space && prefs_get_boolean(PREF_MAM) && window->type == WIN_CHAT) {
         ProfChatWin* chatwin = (ProfChatWin*) window;
-        chatwin_old_history(chatwin);
+        if (!chatwin_old_history(chatwin)) {
+            cons_show("Fetched mam");
+            iq_mam_request_older(chatwin);
+        } else {
+            cons_show("Showed history");
+        }
     }
+
     // went past beginning, show first page
     if (*page_start < 0)
         *page_start = 0;

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -601,13 +601,13 @@ win_page_up(ProfWin* window)
 
     *page_start -= page_space;
 
-    if (*page_start == -page_space && prefs_get_boolean(PREF_MAM) && window->type == WIN_CHAT) {
+    if (*page_start == -page_space && window->type == WIN_CHAT) {
         ProfChatWin* chatwin = (ProfChatWin*) window;
         ProfBuffEntry* first_entry = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0) : NULL;
 
         // Don't do anything if still fetching mam messages
         if (first_entry && !(first_entry->theme_item == THEME_ROOMINFO && g_strcmp0(first_entry->message, LOADING_MESSAGE) == 0)) {
-            if (!chatwin_db_history(chatwin, NULL, NULL, TRUE)) {
+            if (!chatwin_db_history(chatwin, NULL, NULL, TRUE) && prefs_get_boolean(PREF_MAM)) {
                 win_print_loading_history(window);
                 iq_mam_request_older(chatwin);
             }
@@ -638,7 +638,7 @@ win_page_down(ProfWin* window)
     *page_start += page_space;
 
     // Scrolled down after reaching the bottom of the page
-    if ((*page_start == y || (*page_start == page_space && *page_start >= y)) && prefs_get_boolean(PREF_MAM) && window->type == WIN_CHAT) {
+    if ((*page_start == y || (*page_start == page_space && *page_start >= y)) && window->type == WIN_CHAT) {
         int bf_size = buffer_size(window->layout->buffer);
         if (bf_size > 0) {
             char* start = g_date_time_format_iso8601(buffer_get_entry(window->layout->buffer, bf_size - 1)->time);

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1869,6 +1869,7 @@ win_print_loading_history(ProfWin* window)
 {
     GDateTime* timestamp = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0)->time : g_date_time_new_now_local();
     buffer_prepend(window->layout->buffer, "-", 0, timestamp, NO_DATE, THEME_ROOMINFO, NULL, NULL, LOADING_MESSAGE, NULL, NULL);
+    g_date_time_unref(timestamp);
     win_redraw(window);
 }
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -604,16 +604,12 @@ win_page_up(ProfWin* window)
     if (*page_start == -page_space && prefs_get_boolean(PREF_MAM) && window->type == WIN_CHAT) {
         ProfChatWin* chatwin = (ProfChatWin*) window;
         ProfBuffEntry* first_entry = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0) : NULL;
-        char* loading_text = "Loading older messages ...";
 
         // Don't do anything if still fetching mam messages
-        if (first_entry && !(first_entry->theme_item == THEME_ROOMINFO && g_strcmp0(first_entry->message, loading_text) == 0)) {
+        if (first_entry && !(first_entry->theme_item == THEME_ROOMINFO && g_strcmp0(first_entry->message, LOADING_MESSAGE) == 0)) {
             if (!chatwin_old_history(chatwin, NULL)) {
-                cons_show("Fetched mam");
                 win_print_loading_history(window);
                 iq_mam_request_older(chatwin);
-            } else {
-                cons_show("Showed history");
             }
         }
     }
@@ -1857,9 +1853,8 @@ win_redraw(ProfWin* window)
 void
 win_print_loading_history(ProfWin* window)
 {
-    char* loading_text = "Loading older messages ...";
     GDateTime* timestamp = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0)->time : g_date_time_new_now_local();
-    buffer_prepend(window->layout->buffer, "-", 0, timestamp, NO_DATE, THEME_ROOMINFO, NULL, NULL, loading_text, NULL, NULL);
+    buffer_prepend(window->layout->buffer, "-", 0, timestamp, NO_DATE, THEME_ROOMINFO, NULL, NULL, LOADING_MESSAGE, NULL, NULL);
     win_redraw(window);
 }
 

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -57,6 +57,7 @@
 #include "xmpp/muc.h"
 
 #define PAD_SIZE 1000
+#define LOADING_MESSAGE "Loading older messages ..."
 
 void win_move_to_end(ProfWin* window);
 void win_show_status_string(ProfWin* window, const char* const from,

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -77,6 +77,7 @@ void win_print_http_transfer(ProfWin* window, const char* const message, char* u
 
 void win_newline(ProfWin* window);
 void win_redraw(ProfWin* window);
+void win_print_loading_history(ProfWin* window);
 int win_roster_cols(void);
 int win_occpuants_cols(void);
 void win_sub_print(WINDOW* win, char* msg, gboolean newline, gboolean wrap, int indent);

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -71,6 +71,7 @@ void win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, con
 void win_println_incoming_muc_msg(ProfWin* window, char* show_char, int flags, const ProfMessage* const message);
 void win_print_outgoing_muc_msg(ProfWin* window, char* show_char, const char* const me, const char* const id, const char* const replace_id, const char* const message);
 void win_print_history(ProfWin* window, const ProfMessage* const message);
+void win_print_old_history(ProfWin* window, const ProfMessage* const message);
 
 void win_print_http_transfer(ProfWin* window, const char* const message, char* url);
 

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2581,7 +2581,6 @@ static int
 _mam_buffer_commit_handler(xmpp_stanza_t* const stanza, void* const userdata)
 {
     ProfChatWin* chatwin = (ProfChatWin*)userdata;
-    cons_show("Comitted history");
     // Remove the "Loading messages ..." message
     buffer_remove_entry(((ProfWin*)chatwin)->layout->buffer, 0);
     chatwin_old_history(chatwin, NULL);

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2583,7 +2583,7 @@ _mam_buffer_commit_handler(xmpp_stanza_t* const stanza, void* const userdata)
     ProfChatWin* chatwin = (ProfChatWin*)userdata;
     // Remove the "Loading messages ..." message
     buffer_remove_entry(((ProfWin*)chatwin)->layout->buffer, 0);
-    chatwin_old_history(chatwin, NULL);
+    chatwin_db_history(chatwin, NULL, NULL, TRUE);
     return 0;
 }
 
@@ -2685,10 +2685,10 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
 
             buffer_remove_entry(window->layout->buffer, 0);
             if (is_complete || data->end_datestr) {
-                chatwin_old_history(data->win, is_complete ? NULL : data->start_datestr);
+                chatwin_db_history(data->win, is_complete ? NULL : data->start_datestr, NULL, TRUE);
                 return 0;
             }
-            chatwin_old_history(data->win, data->start_datestr);
+            chatwin_db_history(data->win, data->start_datestr, NULL, TRUE);
 
             xmpp_stanza_t* set = xmpp_stanza_get_child_by_name_and_ns(fin, STANZA_TYPE_SET, STANZA_NS_RSM);
             if (set) {

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -67,6 +67,7 @@
 #include "xmpp/roster.h"
 #include "xmpp/muc.h"
 #include "src/database.h"
+#include "ui/window.h"
 
 #ifdef HAVE_OMEMO
 #include "omemo/omemo.h"
@@ -2681,7 +2682,9 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
         if (fin) {
             gboolean is_complete = g_strcmp0(xmpp_stanza_get_attribute(fin, "complete"), "true") == 0;
             MamRsmUserdata* data = (MamRsmUserdata*)userdata;
+            ProfWin* window = (ProfWin*)data->win;
 
+            buffer_remove_entry(window->layout->buffer, 0);
             if (is_complete || data->end_datestr) {
                 chatwin_old_history(data->win, is_complete ? NULL : data->start_datestr);
                 return 0;
@@ -2690,6 +2693,8 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
 
             xmpp_stanza_t* set = xmpp_stanza_get_child_by_name_and_ns(fin, STANZA_TYPE_SET, STANZA_NS_RSM);
             if (set) {
+                win_print_loading_history(window);
+
                 char* firstid = NULL;
                 xmpp_stanza_t* first = xmpp_stanza_get_child_by_name(set, STANZA_NAME_FIRST);
                 firstid = xmpp_stanza_get_text(first);

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -66,6 +66,7 @@
 #include "xmpp/roster_list.h"
 #include "xmpp/roster.h"
 #include "xmpp/muc.h"
+#include "src/database.h"
 
 #ifdef HAVE_OMEMO
 #include "omemo/omemo.h"
@@ -105,7 +106,8 @@ typedef struct command_config_data_t
 typedef struct mam_rsm_userdata
 {
     char* barejid;
-    char* datestr;
+    char* start_datestr;
+    char* end_datestr;
 } MamRsmUserdata;
 
 static int _iq_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata);

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2580,6 +2580,8 @@ _mam_buffer_commit_handler(xmpp_stanza_t* const stanza, void* const userdata)
 {
     ProfChatWin* chatwin = (ProfChatWin*)userdata;
     cons_show("Comitted history");
+    // Remove the "Loading messages ..." message
+    buffer_remove_entry(((ProfWin*)chatwin)->layout->buffer, 0);
     chatwin_old_history(chatwin);
     return 0;
 }

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -109,8 +109,16 @@ typedef struct mam_rsm_userdata
     char* barejid;
     char* start_datestr;
     char* end_datestr;
+    gboolean fetch_next;
     ProfChatWin* win;
 } MamRsmUserdata;
+
+typedef struct late_delivery_userdata
+{
+    ProfChatWin* win;
+    GDateTime* enddate;
+    GDateTime* startdate;
+} LateDeliveryUserdata;
 
 static int _iq_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata);
 
@@ -149,6 +157,7 @@ static int _command_exec_response_handler(xmpp_stanza_t* const stanza, void* con
 static int _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata);
 static int _register_change_password_result_id_handler(xmpp_stanza_t* const stanza, void* const userdata);
 
+static void _iq_mam_request(ProfChatWin* win, GDateTime* startdate, GDateTime* enddate);
 static void _iq_free_room_data(ProfRoomInfoData* roominfo);
 static void _iq_free_affiliation_set(ProfPrivilegeSet* affiliation_set);
 static void _iq_free_affiliation_list(ProfAffiliationList* affiliation_list);
@@ -164,6 +173,8 @@ static gboolean autoping_wait = FALSE;
 static GTimer* autoping_time = NULL;
 static GHashTable* id_handlers;
 static GHashTable* rooms_cache = NULL;
+static GSList* late_delivery_windows = NULL;
+static gboolean received_disco_items = FALSE;
 
 static int
 _iq_handler(xmpp_conn_t* const conn, xmpp_stanza_t* const stanza, void* const userdata)
@@ -258,6 +269,8 @@ iq_handlers_init(void)
 
     id_handlers = g_hash_table_new_full(g_str_hash, g_str_equal, free, (GDestroyNotify)_iq_id_handler_free);
     rooms_cache = g_hash_table_new_full(g_str_hash, g_str_equal, free, (GDestroyNotify)xmpp_stanza_release);
+    late_delivery_windows = malloc(sizeof(GSList *));
+    late_delivery_windows->data = NULL;
 }
 
 void
@@ -2525,7 +2538,16 @@ _disco_items_result_handler(xmpp_stanza_t* const stanza)
     if (g_strcmp0(id, "discoitemsreq") == 0) {
         cons_show_disco_items(items, from);
     } else if (g_strcmp0(id, "discoitemsreq_onconnect") == 0) {
+        received_disco_items = TRUE;
         connection_set_disco_items(items);
+
+        while (late_delivery_windows->data) {
+            LateDeliveryUserdata* del_data = late_delivery_windows->data;
+            _iq_mam_request(del_data->win, del_data->startdate, del_data->enddate);
+
+            late_delivery_windows = g_slist_next(late_delivery_windows);
+            free(del_data);
+        }
     }
 
     g_slist_free_full(items, (GDestroyNotify)_item_destroy);
@@ -2622,7 +2644,7 @@ iq_mam_request_older(ProfChatWin* win)
 }
 
 void
-iq_mam_request(ProfChatWin* win)
+_iq_mam_request(ProfChatWin* win, GDateTime* startdate, GDateTime* enddate)
 {
     if (connection_supports(XMPP_FEATURE_MAM2) == FALSE) {
         log_warning("Server doesn't advertise %s feature.", XMPP_FEATURE_MAM2);
@@ -2630,39 +2652,68 @@ iq_mam_request(ProfChatWin* win)
         return;
     }
 
-    ProfMessage* last_msg = log_database_get_limits_info(win->barejid, TRUE);
-    // To get last page and have flipped paging set firstid to empty string
     char* firstid = "";
-    char* startdate = NULL;
-    char* enddate = NULL;
+    char* startdate_str = NULL;
+    char* enddate_str = NULL;
+    gboolean fetch_next = FALSE;
 
-    // If last message found
-    if (last_msg->timestamp) {
-        startdate = g_date_time_format(last_msg->timestamp, "%FT%T.%f%:z");
-    } else {
+    if (startdate) {
+        startdate_str = g_date_time_format(startdate, "%FT%T.%f%:z");
+        fetch_next = TRUE;
+        g_date_time_unref(startdate);
+    } else if (!enddate) {
         GDateTime* now = g_date_time_new_now_utc();
-        enddate = g_date_time_format(now, "%FT%T.%f%:z");
+        enddate_str = g_date_time_format(now, "%FT%T.%f%:z");
         g_date_time_unref(now);
+    }
+
+    if (enddate) {
+        enddate_str = g_date_time_format(enddate, "%FT%T.%f%:z");
+        g_date_time_unref(enddate);
     }
 
     xmpp_ctx_t* const ctx = connection_get_ctx();
 
-    xmpp_stanza_t* iq = stanza_create_mam_iq(ctx, win->barejid, startdate, enddate, firstid, NULL);
+    xmpp_stanza_t* iq = stanza_create_mam_iq(ctx, win->barejid, startdate_str, enddate_str, firstid, NULL);
 
     MamRsmUserdata* data = malloc(sizeof(MamRsmUserdata));
     if (data) {
-        data->start_datestr = startdate;
-        data->end_datestr = enddate;
+        data->start_datestr = startdate_str;
+        data->end_datestr = enddate_str;
         data->barejid = strdup(win->barejid);
+        data->fetch_next = fetch_next;
         data->win = win;
 
         iq_id_handler_add(xmpp_stanza_get_id(iq), _mam_rsm_id_handler, NULL, data);
     }
 
-    message_free(last_msg);
-
     iq_send_stanza(iq);
     xmpp_stanza_release(iq);
+
+    return;
+}
+
+void
+iq_mam_request(ProfChatWin* win, GDateTime* enddate)
+{
+    ProfMessage* last_msg = log_database_get_limits_info(win->barejid, TRUE);
+    GDateTime* startdate = last_msg->timestamp ? g_date_time_add_seconds(last_msg->timestamp, 0) : NULL; // copy timestamp
+    message_free(last_msg);
+
+    // Save request for later if disco items haven't been received yet
+    if (!received_disco_items) {
+        if (late_delivery_windows->data == NULL) {
+            LateDeliveryUserdata* cur_del_data = malloc(sizeof(LateDeliveryUserdata));
+            cur_del_data->win = win;
+            cur_del_data->enddate = enddate;
+            cur_del_data->startdate = startdate;
+            late_delivery_windows->data = cur_del_data;
+        }
+        late_delivery_windows = g_slist_append(late_delivery_windows, NULL);
+    }
+
+
+    _iq_mam_request(win, startdate, enddate);
 
     return;
 }
@@ -2684,11 +2735,39 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
             ProfWin* window = (ProfWin*)data->win;
 
             buffer_remove_entry(window->layout->buffer, 0);
-            if (is_complete || data->end_datestr) {
-                chatwin_db_history(data->win, is_complete ? NULL : data->start_datestr, NULL, TRUE);
+
+            char *start_str = NULL;
+            if (data->start_datestr) {
+                start_str = strdup(data->start_datestr);
+                // Convert to iso8601
+                start_str[strlen(start_str) - 3] = '\0';
+            }
+            char *end_str = NULL;
+            if (data->end_datestr) {
+                end_str = strdup(data->end_datestr);
+                // Convert to iso8601
+                end_str[strlen(end_str) - 3] = '\0';
+            }
+
+            if (is_complete || !data->fetch_next) {
+                chatwin_db_history(data->win, is_complete ? NULL : start_str, end_str, TRUE);
+                // TODO free memory
+                if (start_str) {
+                    free(start_str);
+                    free(data->start_datestr);
+                }
+
+                if (end_str) {
+                    free(data->end_datestr);
+                }
+
+                free(data->barejid);
+                free(data);
                 return 0;
             }
-            chatwin_db_history(data->win, data->start_datestr, NULL, TRUE);
+
+            chatwin_db_history(data->win, start_str, end_str, TRUE);
+            if (start_str) free(start_str);
 
             xmpp_stanza_t* set = xmpp_stanza_get_child_by_name_and_ns(fin, STANZA_TYPE_SET, STANZA_NS_RSM);
             if (set) {
@@ -2701,6 +2780,10 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
                 // 4.3.2. send same stanza with set,max stanza
                 xmpp_ctx_t* const ctx = connection_get_ctx();
 
+                if (end_str) {
+                    free(data->end_datestr);
+                }
+                data->end_datestr = NULL;
                 xmpp_stanza_t* iq = stanza_create_mam_iq(ctx, data->barejid, data->start_datestr, data->end_datestr, firstid, NULL);
                 free(firstid);
 

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2701,7 +2701,7 @@ stanza_attach_correction(xmpp_ctx_t* ctx, xmpp_stanza_t* stanza, const char* con
 }
 
 xmpp_stanza_t*
-stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const lastid)
+stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const enddate, const char* const firstid, const char* const lastid)
 {
     char* id = connection_create_stanza_id();
     xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, id);
@@ -2747,26 +2747,48 @@ stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const s
     xmpp_stanza_add_child(field_with, value_with);
 
     // field 'start'
-    xmpp_stanza_t* field_start = xmpp_stanza_new(ctx);
-    xmpp_stanza_set_name(field_start, STANZA_NAME_FIELD);
-    xmpp_stanza_set_attribute(field_start, STANZA_ATTR_VAR, "start");
+    xmpp_stanza_t* field_start, *value_start, *start_date_text;
+    if (startdate) {
+        field_start = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_name(field_start, STANZA_NAME_FIELD);
+        xmpp_stanza_set_attribute(field_start, STANZA_ATTR_VAR, "start");
 
-    xmpp_stanza_t* value_start = xmpp_stanza_new(ctx);
-    xmpp_stanza_set_name(value_start, STANZA_NAME_VALUE);
+        value_start = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_name(value_start, STANZA_NAME_VALUE);
 
-    xmpp_stanza_t* date_text = xmpp_stanza_new(ctx);
-    xmpp_stanza_set_text(date_text, startdate);
-    xmpp_stanza_add_child(value_start, date_text);
+        start_date_text = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_text(start_date_text, startdate);
+        xmpp_stanza_add_child(value_start, start_date_text);
 
-    xmpp_stanza_add_child(field_start, value_start);
+        xmpp_stanza_add_child(field_start, value_start);
+    }
+
+    xmpp_stanza_t* field_end, *value_end, *end_date_text;
+    if (enddate) {
+        field_end = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_name(field_end, STANZA_NAME_FIELD);
+        xmpp_stanza_set_attribute(field_end, STANZA_ATTR_VAR, "end");
+
+        value_end = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_name(value_end, STANZA_NAME_VALUE);
+
+        end_date_text = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_text(end_date_text, enddate);
+        xmpp_stanza_add_child(value_end, end_date_text);
+
+        xmpp_stanza_add_child(field_end, value_end);
+    }
 
     // 4.3.2 set/rsm
-    xmpp_stanza_t *after, *after_text, *set;
-    if (lastid) {
+    xmpp_stanza_t *set;
+    if (lastid || firstid) {
         set = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(set, STANZA_TYPE_SET);
         xmpp_stanza_set_ns(set, STANZA_NS_RSM);
+    }
 
+    xmpp_stanza_t *after, *after_text;
+    if (lastid) {
         after = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(after, STANZA_NAME_AFTER);
 
@@ -2777,30 +2799,59 @@ stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const s
         xmpp_stanza_add_child(set, after);
     }
 
+    xmpp_stanza_t *before, *before_text;
+    if (firstid) {
+        before = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_name(before, STANZA_NAME_BEFORE);
+
+        before_text = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_text(before_text, firstid);
+
+        xmpp_stanza_add_child(before, before_text);
+        xmpp_stanza_add_child(set, before);
+    }
+
     // add and release
     xmpp_stanza_add_child(iq, query);
     xmpp_stanza_add_child(query, x);
     xmpp_stanza_add_child(x, field_form_type);
     xmpp_stanza_add_child(x, field_with);
-    xmpp_stanza_add_child(x, field_start);
+
+    if (startdate) {
+        xmpp_stanza_add_child(x, field_start);
+        xmpp_stanza_release(field_start);
+        xmpp_stanza_release(value_start);
+        xmpp_stanza_release(start_date_text);
+    }
+
+    if (enddate) {
+        xmpp_stanza_add_child(x, field_end);
+        xmpp_stanza_release(field_end);
+        xmpp_stanza_release(value_end);
+        xmpp_stanza_release(end_date_text);
+    }
+
+    if (firstid || lastid) {
+        xmpp_stanza_add_child(query, set);
+        xmpp_stanza_release(set);
+    }
 
     if (lastid) {
-        xmpp_stanza_add_child(query, after);
-
         xmpp_stanza_release(after_text);
         xmpp_stanza_release(after);
-        xmpp_stanza_release(set);
+    }
+
+    if (firstid) {
+        xmpp_stanza_release(before_text);
+        xmpp_stanza_release(before);
     }
 
     xmpp_stanza_release(mam_text);
     xmpp_stanza_release(with_text);
-    xmpp_stanza_release(date_text);
     xmpp_stanza_release(value_mam);
     xmpp_stanza_release(value_with);
-    xmpp_stanza_release(value_start);
     xmpp_stanza_release(field_form_type);
     xmpp_stanza_release(field_with);
-    xmpp_stanza_release(field_start);
     xmpp_stanza_release(x);
     xmpp_stanza_release(query);
 

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -115,7 +115,9 @@
 #define STANZA_NAME_MINIMIZE         "minimize"
 #define STANZA_NAME_FIN              "fin"
 #define STANZA_NAME_LAST             "last"
+#define STANZA_NAME_FIRST            "first"
 #define STANZA_NAME_AFTER            "after"
+#define STANZA_NAME_BEFORE           "before"
 #define STANZA_NAME_USERNAME         "username"
 #define STANZA_NAME_PROPOSE          "propose"
 #define STANZA_NAME_REPORT           "report"
@@ -413,7 +415,7 @@ void stanza_free_caps(XMPPCaps* caps);
 xmpp_stanza_t* stanza_create_avatar_retrieve_data_request(xmpp_ctx_t* ctx, const char* stanza_id, const char* const item_id, const char* const jid);
 xmpp_stanza_t* stanza_create_avatar_data_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len);
 xmpp_stanza_t* stanza_create_avatar_metadata_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len, int height, int width);
-xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const lastid);
+xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const enddate, const char* const firstid, const char* const lastid);
 xmpp_stanza_t* stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* const password);
 xmpp_stanza_t* stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char* const password);
 xmpp_stanza_t* stanza_request_voice(xmpp_ctx_t* ctx, const char* const room);

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -118,6 +118,7 @@
 #define STANZA_NAME_FIRST            "first"
 #define STANZA_NAME_AFTER            "after"
 #define STANZA_NAME_BEFORE           "before"
+#define STANZA_NAME_MAX              "max"
 #define STANZA_NAME_USERNAME         "username"
 #define STANZA_NAME_PROPOSE          "propose"
 #define STANZA_NAME_REPORT           "report"

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -64,6 +64,7 @@
 #define XMPP_FEATURE_USER_AVATAR_METADATA_NOTIFY "urn:xmpp:avatar:metadata+notify"
 #define XMPP_FEATURE_LAST_MESSAGE_CORRECTION     "urn:xmpp:message-correct:0"
 #define XMPP_FEATURE_MAM2                        "urn:xmpp:mam:2"
+#define XMPP_FEATURE_MAM2_EXTENDED               "urn:xmpp:mam:2#extended"
 #define XMPP_FEATURE_SPAM_REPORTING              "urn:xmpp:reporting:1"
 
 typedef enum {
@@ -261,6 +262,7 @@ void iq_http_upload_request(HTTPUpload* upload);
 void iq_command_list(const char* const target);
 void iq_command_exec(const char* const target, const char* const command);
 void iq_mam_request(ProfChatWin* win);
+void iq_mam_request_older(ProfChatWin* win);
 void iq_register_change_password(const char* const user, const char* const password);
 void iq_muc_register_nick(const char* const roomjid);
 

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -261,7 +261,7 @@ void iq_autoping_check(void);
 void iq_http_upload_request(HTTPUpload* upload);
 void iq_command_list(const char* const target);
 void iq_command_exec(const char* const target, const char* const command);
-void iq_mam_request(ProfChatWin* win);
+void iq_mam_request(ProfChatWin* win, GDateTime* enddate);
 void iq_mam_request_older(ProfChatWin* win);
 void iq_register_change_password(const char* const user, const char* const password);
 void iq_muc_register_nick(const char* const roomjid);


### PR DESCRIPTION
Started trying to finish MAM here's what I've done so far. Nowhere near production ready btw. Many temporary stuff in here.

* When we open new chat (`/msg someone`) if no msgs in db fetch using before: now. else fetch after most recent one.
* When scrolled to top, fetch older messages from db and display them above the previous ones.
* After all db history gets displayed when scrolling up, fetch older messages from mam (these ones get displayed after everything instead of before)

Todo:
* Only fetch once if no msgs for one chat (further fetching will be done when scrolling).
* MAM for mucs
* Have different pagination counters for each chat (currently one temporary global one)
* When scrolling up display new mam messages before other ones instead of after. (start of buffer instead of end)
* In case that the buffer fills up while scrolling upwards and messages get deleted from the end, handle scrolling down to the bottom.
* Check notifications cause I think older messages from db might get displayed in notification after scrolling instead of new incoming ones.
* Mam when we receive a message instead of `/msg someone`