### PR TITLE
Don't scroll if not needed

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -598,6 +598,10 @@ win_page_up(ProfWin* window)
     int page_space = rows - 4;
     int* page_start = &(window->layout->y_pos);
 
+    // dont need to scroll
+    if (*page_start == 0)
+        return;
+
     *page_start -= page_space;
 
     // went past beginning, show first page


### PR DESCRIPTION
If we are in a window with a lot of text and press PAGE UP we scroll up
and write [scrolled] in the titlebar.

So far we also wrote [scrolled] in there even when actually nothing
happened. Like when opening a new window (/msg someone) and there is no
text inside.