### PR TITLE
Be more resilient when receiving empty messages

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -545,6 +545,14 @@ static void
 _sv_ev_incoming_ox(ProfChatWin* chatwin, gboolean new_win, ProfMessage* message, gboolean logit)
 {
 #ifdef HAVE_LIBGPGME
+    if (message->plain == NULL) {
+        if (message->body == NULL) {
+            log_error("Couldn't decrypt OX message and body was empty");
+            return;
+        }
+        message->plain = strdup(message->body);
+    }
+
     //_clean_incoming_message(message);
     chatwin_incoming_msg(chatwin, message, new_win);
     log_database_add_incoming(message);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -310,6 +310,12 @@ void
 chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_created)
 {
     assert(chatwin != NULL);
+
+    if (message->plain == NULL) {
+        log_error("chatwin_incoming_msg: Message with no plain field from: %s", message->from_jid);
+        return;
+    }
+
     char* old_plain = message->plain;
 
     message->plain = plugins_pre_chat_message_display(message->from_jid->barejid, message->from_jid->resourcepart, message->plain);

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -551,6 +551,11 @@ mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList
     assert(mucwin != NULL);
     int flags = 0;
 
+    if (message->plain == NULL) {
+        log_error("mucwin_incoming_msg: Message with no plain field from: %s", message->from_jid);
+        return;
+    }
+
     if (filter_reflection && message_is_sent_by_us(message, TRUE)) {
         /* Ignore reflection messages */
         return;

--- a/src/ui/privwin.c
+++ b/src/ui/privwin.c
@@ -39,6 +39,7 @@
 #include <glib.h>
 #include <stdlib.h>
 
+#include "log.h"
 #include "config/preferences.h"
 #include "ui/win_types.h"
 #include "ui/window.h"
@@ -49,6 +50,11 @@ void
 privwin_incoming_msg(ProfPrivateWin* privatewin, ProfMessage* message)
 {
     assert(privatewin != NULL);
+
+    if (message->plain == NULL) {
+        log_error("privwin_incoming_msg: Message with no plain field from: %s", message->from_jid);
+        return;
+    }
 
     ProfWin* window = (ProfWin*)privatewin;
     int num = wins_get_num(window);


### PR DESCRIPTION
Most likely some strange message was received.
Let's add a message-> plain check in the print functions for incoming messages for each window.

And in case we didn't get a text from the OX message in message->plain let copy over the one from the body. Like we do for pgp and others as well.