### PR TITLE
Fix /autoaway command logic

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6677,9 +6677,6 @@ cmd_autoaway(ProfWin* window, const char* const command, gchar** args)
             cons_bad_cmd_usage(command);
             return TRUE;
         }
-    } else {
-        cons_bad_cmd_usage(command);
-        return TRUE;
     }
 
     if (g_strcmp0(args[0], "message") == 0) {
@@ -6693,7 +6690,7 @@ cmd_autoaway(ProfWin* window, const char* const command, gchar** args)
             }
 
             return TRUE;
-        } else if (g_strcmp0(args[1], "xa") == 0) {
+        } else if (g_strcmp0(args[1], "xa") == 0 && args[2] != NULL) {
             if (g_strcmp0(args[2], "off") == 0) {
                 prefs_set_string(PREF_AUTOXA_MESSAGE, NULL);
                 cons_show("Auto xa message cleared.");
@@ -6714,6 +6711,7 @@ cmd_autoaway(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
+    cons_bad_cmd_usage(command);
     return TRUE;
 }
 


### PR DESCRIPTION
Two issues were fixed in the parser logic:
* A call to cons_bad_cmd_usage() was placed at the end of the "time"
  parser section that blocked reachability to both "message" and
  "check" parser sections. This caused "/autoaway message ..." and
  "/autoaway check ..." to always fail with "Invalid usage". This
  issue was introduced in commit 3c1e4ba.
* "/autoaway message xa" with no message argument returns message
  set to (null). This should be fixed the same way as
  "/autoaway message away" was fixed in commit 3c1e4ba.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
