### PR TITLE
doap: fix missing foaf namespace prefix

### DIFF
--- a/profanity.doap
+++ b/profanity.doap
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
          xmlns='http://usefulinc.com/ns/doap#'
          xmlns:xmpp='https://linkmauve.fr/ns/xmpp-doap#'
          xmlns:schema='https://schema.org/'>


### PR DESCRIPTION
```
$ xmllint profanity.doap
profanity.doap:43: namespace error : Namespace prefix foaf on Person is not defined
        <foaf:Person>
                    ^
profanity.doap:44: namespace error : Namespace prefix foaf on name is not defined
            <foaf:name>Michael Vetter</foaf:name>
                      ^
profanity.doap:45: namespace error : Namespace prefix foaf on homepage is not defined
            <foaf:homepage rdf:resource="https://iodoru.org/"/>
                                                             ^
```