### PR TITLE
Fix for avatar opening executable

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -445,8 +445,8 @@ get_mentions(gboolean whole_word, gboolean case_sensitive, const char* const mes
 gboolean
 call_external(gchar** argv, gchar** std_out, gchar** std_err)
 {
-    GError *spawn_error = NULL;
-    GError *exit_error = NULL;
+    GError* spawn_error = NULL;
+    GError* exit_error = NULL;
     gboolean is_successful;
     gint wait_status;
 
@@ -457,22 +457,22 @@ call_external(gchar** argv, gchar** std_out, gchar** std_err)
         flags |= G_SPAWN_STDERR_TO_DEV_NULL;
 
     is_successful = g_spawn_sync(NULL, // Inherit the parent PWD.
-                                argv,
-                                NULL, // Inherit the parent environment.
-                                flags,
-                                NULL, NULL, // No func. before exec() in child.
-                                std_out, std_err,
-                                &wait_status, &spawn_error);
+                                 argv,
+                                 NULL, // Inherit the parent environment.
+                                 flags,
+                                 NULL, NULL, // No func. before exec() in child.
+                                 std_out, std_err,
+                                 &wait_status, &spawn_error);
 
     if (!is_successful) {
         gchar* cmd = g_strjoinv(" ", argv);
-        log_error("could not spawn '%s' with error '%s'", cmd, spawn_error->message);
+        log_error("Spawning '%s' failed with with error '%s'", cmd, spawn_error ? spawn_error->message : "Unknown, spawn_error is NULL");
+        ;
 
         g_error_free(spawn_error);
         g_free(cmd);
-    }
-    else {
-        is_successful = g_spawn_check_wait_status(wait_status, &exit_error);
+    } else {
+        is_successful = g_spawn_check_exit_status(wait_status, &exit_error);
 
         if (!is_successful) {
             gchar* cmd = g_strjoinv(" ", argv);

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -339,10 +339,20 @@ _avatar_request_item_result_handler(xmpp_stanza_t* const stanza, void* const use
 
     // if we shall open it
     if (g_hash_table_contains(shall_open, from_attr)) {
-        gchar* argv[] = { prefs_get_string(PREF_AVATAR_CMD), filename->str, NULL };
-        if (!call_external(argv, NULL, NULL)) {
-            cons_show_error("Unable to display avatar: check the logs for more information.");
+        gchar* cmdtemplate = prefs_get_string(PREF_AVATAR_CMD);
+
+        if (cmdtemplate == NULL) {
+            cons_show_error("No default `avatar open` command found in executables preferences.");
+        } else {
+            gchar** argv = format_call_external_argv(cmdtemplate, NULL, filename->str);
+
+            if (!call_external(argv, NULL, NULL)) {
+                cons_show_error("Unable to display avatar: check the logs for more information.");
+            }
+
+            g_strfreev(argv);
         }
+
         g_hash_table_remove(shall_open, from_attr);
     }
 


### PR DESCRIPTION
<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
In issue #1742 the reason behind crashing is supposedly undefined behavior because it was observed by me, `g_spawn_sync` may not modify `spawn_error` pointer. When I was debugging, it was pretty random and its value didn't fall into any of mapped memory regions.

`spawn_error` pointer was not null and code tried to read its field but this caused segfault instantly. I believe there was no message because for some reason glib did not set it to some value (there was an error!).

Though the basis for that is because mentioned `gio open` was considered to be one argument, it was failing to find such program and hence `g_spawn_sync` returned an error to that.

So this fixes undefined behaviour for that pointer and moreover made both pointers null by default just in case. Not sure why glib does not set the pointer value.

Also I made the `avatar open` use the preference string as a command template rather than an argv argument.