### PR TITLE
typo in configure: enable_gdk_pixbuf not enable_pixbuf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,11 +311,11 @@ if test "x$enable_otr" != xno; then
 fi
 
 dnl feature: pixbuf / used for scaling avatars before uploading via `/avatar set`
-AS_IF([test "x$enable_pixbuf" != xno],
+AS_IF([test "x$enable_gdk_pixbuf" != xno],
     [PKG_CHECK_MODULES([gdk_pixbuf], [gdk-pixbuf-2.0 >= 2.4],
         [AC_DEFINE([HAVE_PIXBUF], [1], [gdk-pixbuf module])
          LIBS="$gdk_pixbuf_LIBS $LIBS" CFLAGS="$gdk_pixbuf_CFLAGS $CFLAGS"],
-        [AS_IF([test "x$enable_pixbuf" = xyes],
+        [AS_IF([test "x$enable_gdk_pixbuf" = xyes],
                [AC_MSG_ERROR([gdk-pixbuf-2.0 >= 2.4 is required to scale avatars before uploading])],
                [AC_MSG_NOTICE([gdk-pixbuf-2.0 >= 2.4 not found, GDK Pixbuf support not enabled])])])])
 


### PR DESCRIPTION
Otherwise gdk-pixbuf is always added as dependency even if disabled, when found.