### PR TITLE
Fix typo in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -272,11 +272,11 @@ AS_IF([test "x$PLATFORM" = xosx],
                     [AC_MSG_NOTICE([libnotify support will be disabled])])])])])
 
 dnl feature: xscreensaver
-AS_IF([test "x$enable_xscreensaver" != xno],
+AS_IF([test "x$with_xscreensaver" != xno],
     [PKG_CHECK_MODULES([xscrnsaver], [xscrnsaver],
         [AC_MSG_NOTICE([xscreensaver support is enabled]);
          LIBS="$xscrnsaver_LIBS $LIBS" CFLAGS="$CFLAGS $xscrnsaver_CFLAGS"],
-        [AS_IF([test "x$enable_xscreensaver" = xyes],
+        [AS_IF([test "x$with_xscreensaver" = xyes],
             [AC_MSG_ERROR([xscreensaver is required but does not exist])],
             [AC_MSG_NOTICE([xscreensaver support is disabled])])])])
 


### PR DESCRIPTION
This is similar to #1752. If `xscreensaver` is installed then port can't be built without xscreensaver support due to the typo.

Thanks!