### PR TITLE
Fix plugins managment

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -961,6 +961,8 @@ cmd_ac_init(void)
 
     plugins_ac = autocomplete_new();
     autocomplete_add(plugins_ac, "install");
+    autocomplete_add(plugins_ac, "update");
+    autocomplete_add(plugins_ac, "uninstall");
     autocomplete_add(plugins_ac, "load");
     autocomplete_add(plugins_ac, "unload");
     autocomplete_add(plugins_ac, "reload");
@@ -2752,6 +2754,10 @@ _plugins_autocomplete(ProfWin* window, const char* const input, gboolean previou
 
     if (strncmp(input, "/plugins install ", 17) == 0) {
         return cmd_ac_complete_filepath(input, "/plugins install", previous);
+    }
+
+    if (strncmp(input, "/plugins update ", 16) == 0) {
+        return cmd_ac_complete_filepath(input, "/plugins update", previous);
     }
 
     if (strncmp(input, "/plugins load ", 14) == 0) {

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2729,7 +2729,7 @@ static struct cmd_t command_defs[] = {
               "Set your mood (XEP-0107).")
       CMD_ARGS(
               { "on|off", "Enable or disable displaying the mood of other users. On by default."},
-              { "set <mood> [text]", "Set user mood to <mood> with an optional [text]. Use /mood set <tab> to toggle through predfined moods." },
+              { "set <mood> [text]", "Set user mood to <mood> with an optional [text]. Use /mood set <tab> to toggle through predefined moods." },
               { "clear", "Clear your user mood." })
       CMD_EXAMPLES(
               "/mood set happy \"So happy to use Profanity!\"",

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2162,7 +2162,7 @@ static struct cmd_t command_defs[] = {
               "/plugins reload [<plugin>]",
               "/plugins python_version")
       CMD_DESC(
-              "Manage plugins. Passing no arguments lists currently loaded plugins and global plugins which are available for local installation. Global directory for Python plugins is " GLOBAL_PYTHON_PLUGINS_PATH " and for C Plugins is " GLOBAL_C_PLUGINS_PATH ".")
+              "Manage plugins. Passing no arguments lists installed plugins and global plugins which are available for local installation. Global directory for Python plugins is " GLOBAL_PYTHON_PLUGINS_PATH " and for C Plugins is " GLOBAL_C_PLUGINS_PATH ".")
       CMD_ARGS(
               { "install [<path>]", "Install a plugin, or all plugins found in a directory (recursive). And loads it/them." },
               { "uninstall [<plugin>]", "Uninstall a plugin." },

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7247,14 +7247,16 @@ cmd_plugins(ProfWin* window, const char* const command, gchar** args)
         const gchar* filename;
         cons_show("The following Python plugins are available globally and can be installed:");
         while ((filename = g_dir_read_name(global_pyp_dir))) {
-            cons_show("  %s", filename);
+            if (g_str_has_suffix(filename, ".py"))
+                cons_show("  %s", filename);
         }
     }
     if (global_cp_dir) {
         const gchar* filename;
         cons_show("The following C plugins are available globally and can be installed:");
         while ((filename = g_dir_read_name(global_cp_dir))) {
-            cons_show("  %s", filename);
+            if (g_str_has_suffix(filename, ".so"))
+                cons_show("  %s", filename);
         }
     }
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7258,14 +7258,25 @@ cmd_plugins(ProfWin* window, const char* const command, gchar** args)
         }
     }
 
+    GSList* unloaded_plugins = plugins_unloaded_list();
+    if (unloaded_plugins) {
+        GSList* curr = unloaded_plugins;
+        cons_show("The following plugins already installed and can be loaded:");
+        while (curr) {
+            cons_show("  %s", curr->data);
+            curr = g_slist_next(curr);
+        }
+        g_slist_free_full(unloaded_plugins, g_free);
+    }
+
     GList* plugins = plugins_loaded_list();
     if (plugins == NULL) {
-        cons_show("No plugins installed.");
+        cons_show("No loaded plugins.");
         return TRUE;
     }
 
     GList* curr = plugins;
-    cons_show("Installed plugins:");
+    cons_show("Loaded plugins:");
     while (curr) {
         cons_show("  %s", curr->data);
         curr = g_list_next(curr);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6984,7 +6984,7 @@ cmd_plugins_install(ProfWin* window, const char* const command, gchar** args)
     char* path = NULL;
 
     if (args[1] == NULL) {
-        cons_show("Please provide a path to the plugin file or directory, see /help plugins");
+        cons_bad_cmd_usage(command);
         return TRUE;
     }
 
@@ -7068,7 +7068,7 @@ cmd_plugins_update(ProfWin* window, const char* const command, gchar** args)
     char* path;
 
     if (args[1] == NULL) {
-        cons_show("Please provide a path to the plugin file, see /help plugins");
+        cons_bad_cmd_usage(command);
         return TRUE;
     } else {
         path = get_expanded_path(args[1]);
@@ -7117,7 +7117,7 @@ gboolean
 cmd_plugins_uninstall(ProfWin* window, const char* const command, gchar** args)
 {
     if (args[1] == NULL) {
-        cons_show("Please specify plugin name, see /help plugins");
+        cons_bad_cmd_usage(command);
         return TRUE;
     }
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7260,7 +7260,14 @@ cmd_plugins(ProfWin* window, const char* const command, gchar** args)
         }
     }
 
+    GList* plugins = plugins_loaded_list();
     GSList* unloaded_plugins = plugins_unloaded_list();
+
+    if (plugins == NULL && unloaded_plugins == NULL) {
+        cons_show("No plugins installed.");
+        return TRUE;
+    }
+
     if (unloaded_plugins) {
         GSList* curr = unloaded_plugins;
         cons_show("The following plugins already installed and can be loaded:");
@@ -7271,19 +7278,15 @@ cmd_plugins(ProfWin* window, const char* const command, gchar** args)
         g_slist_free_full(unloaded_plugins, g_free);
     }
 
-    GList* plugins = plugins_loaded_list();
-    if (plugins == NULL) {
-        cons_show("No loaded plugins.");
-        return TRUE;
+    if (plugins) {
+        GList* curr = plugins;
+        cons_show("Loaded plugins:");
+        while (curr) {
+            cons_show("  %s", curr->data);
+            curr = g_list_next(curr);
+        }
+        g_list_free(plugins);
     }
-
-    GList* curr = plugins;
-    cons_show("Loaded plugins:");
-    while (curr) {
-        cons_show("  %s", curr->data);
-        curr = g_list_next(curr);
-    }
-    g_list_free(plugins);
 
     return TRUE;
 }

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7117,7 +7117,8 @@ gboolean
 cmd_plugins_uninstall(ProfWin* window, const char* const command, gchar** args)
 {
     if (args[1] == NULL) {
-        return FALSE;
+        cons_show("Please specify plugin name, see /help plugins");
+        return TRUE;
     }
 
     gboolean res = plugins_uninstall(args[1]);


### PR DESCRIPTION
* The `/plugins uninstall` command  <__without plugin name__>  behave same as `/quit`. I'm not sure that it was so conceived.  dd1a9a1e in this case  displays a hint, without exit.
 * For the `/plugins` command  <__without args__> 45fa60e7 add to output the list plugins which have already been installed, but  unloaded  (If there are such).
<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
