### PR TITLE
plugin: python: fix build for Python 3.11

### DIFF
--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -1619,8 +1619,16 @@ static char*
 _python_plugin_name(void)
 {
     PyThreadState* ts = PyThreadState_Get();
+#if PY_VERSION_HEX >= 0x030B0000
+    PyFrameObject* frame = PyThreadState_GetFrame(ts);
+    PyCodeObject* code = PyFrame_GetCode(frame);
+    char* filename = python_str_or_unicode_to_string(code->co_filename);
+    Py_DECREF(code);
+    Py_DECREF(frame);
+#else
     PyFrameObject* frame = ts->frame;
     char* filename = python_str_or_unicode_to_string(frame->f_code->co_filename);
+#endif
     gchar** split = g_strsplit(filename, "/", 0);
     free(filename);
     char* plugin_name = strdup(split[g_strv_length(split) - 1]);


### PR DESCRIPTION
From Python 3.11, PyFrameObject has been changed into opaque struct. We need to access those fields via API.

Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
