### PR TITLE
Fix segfault when loading from MAM

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -2056,9 +2056,20 @@ win_redraw(ProfWin* window)
 void
 win_print_loading_history(ProfWin* window)
 {
-    GDateTime* timestamp = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0)->time : g_date_time_new_now_local();
+    GDateTime* timestamp;
+    gboolean is_buffer_empty = buffer_size(window->layout->buffer) == 0;
+
+    if (!is_buffer_empty) {
+        timestamp = buffer_get_entry(window->layout->buffer, 0)->time;
+    } else {
+        timestamp = g_date_time_new_now_local();
+    }
+
     buffer_prepend(window->layout->buffer, "-", 0, timestamp, NO_DATE, THEME_ROOMINFO, NULL, NULL, LOADING_MESSAGE, NULL, NULL);
-    g_date_time_unref(timestamp);
+
+    if (is_buffer_empty)
+        g_date_time_unref(timestamp);
+
     win_redraw(window);
 }
 


### PR DESCRIPTION
When loading messages from MAM profanity would segfault. Reason was that we were freeing the timestamp of messages when displaying them and we needed it for loading MAM.