### PR TITLE
Work around different clang-format versions

### DIFF
--- a/src/config/color.c
+++ b/src/config/color.c
@@ -59,7 +59,7 @@ static struct color_pair_cache
     struct
     {
         int16_t fg, bg;
-    }* pairs;
+    } * pairs;
     int size;
     int capacity;
 } cache = { 0 };


### PR DESCRIPTION
Locally I have clang-format 15.0.2.
Our CI runs ubuntu-20.04 so it has 10.0.

Seems like a default value changed but I can't find it. When I still had clang-format 14.x everything was fine and checking: https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#clang-format

I only see irrelevant things.

Someone on the llvm IRC channel sais "there is no guarantee" and "maybe a regression or intended change".
But seems like noone knows which setting could be the one we need.

Since I don't have a better solution for now I will just edit this by hand to apply to the clang-format version we have on the CI. Will look into updating this one.

But in any case it would be best if the configuration file could have this setting so formatting works the same for all contributors.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
