### PR TITLE
Make `/url save` autocomplete filenames after a url

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -4352,7 +4352,21 @@ _url_autocomplete(ProfWin* window, const char* const input, gboolean previous)
             return result;
         }
 
-        result = autocomplete_param_with_func(input, "/url save", wins_get_url, previous, window);
+        gboolean arg_result;
+        gchar** args = parse_args(input, 1, 8, &arg_result);
+        gboolean space_at_end = g_str_has_suffix(input, " ");
+        int num_args = g_strv_length(args);
+
+        if (arg_result) {
+            if ((num_args == 1 && space_at_end) || (num_args == 2 && !space_at_end)) {
+                result = autocomplete_param_with_func(input, "/url save", wins_get_url, previous, window);
+            } else if ((num_args == 2 && space_at_end) || (num_args == 3 && !space_at_end)) {
+                gchar* cmd = g_strdup_printf("/url save %s", args[1]);
+                result = cmd_ac_complete_filepath(input, cmd, previous);
+                g_free(cmd);
+            }
+        }
+        g_strfreev(args);
     }
 
     return result;


### PR DESCRIPTION
Previously after the url if you pressed tab, even if you typed out a filepath, profanity would erase that and cycle through url autocomplete results.

This patch solves that and autocompletes filepaths after the url.

Fixes https://github.com/profanity-im/profanity/issues/1783
