### PR TITLE
Don't pass NULL pointers to vprintf

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -55,7 +55,7 @@ void auto_free_char(char** str);
 #define auto_char __attribute__((__cleanup__(auto_free_char)))
 
 #if defined(__OpenBSD__)
-#define STR_MAYBE_NULL(p) (p) ? : "(null)"
+#define STR_MAYBE_NULL(p) (p) ?: "(null)"
 #else
 #define STR_MAYBE_NULL(p) (p)
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -54,6 +54,12 @@ void auto_free_gcharv(gchar*** args);
 void auto_free_char(char** str);
 #define auto_char __attribute__((__cleanup__(auto_free_char)))
 
+#if defined(__OpenBSD__)
+#define STR_MAYBE_NULL(p) (p) ? : "(null)"
+#else
+#define STR_MAYBE_NULL(p) (p)
+#endif
+
 // assume malloc stores at most 8 bytes for size of allocated memory
 // and page size is at least 4KB
 #define READ_BUF_SIZE 4088

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -553,7 +553,7 @@ omemo_prekeys(GList** prekeys, GList** ids, GList** lengths)
 void
 omemo_set_device_list(const char* const from, GList* device_list)
 {
-    log_debug("[OMEMO] Setting device list for %s", (from == NULL) ? "" : from);
+    log_debug("[OMEMO] Setting device list for %s", STR_MAYBE_NULL(from));
     Jid* jid;
     if (from) {
         jid = jid_create(from);
@@ -570,7 +570,7 @@ omemo_set_device_list(const char* const from, GList* device_list)
             g_hash_table_remove(omemo_ctx.device_list_handler, jid->barejid);
         }
     } else {
-        log_debug("[OMEMO] No Device List Handler for %s", from);
+        log_debug("[OMEMO] No Device List Handler for %s", STR_MAYBE_NULL(from));
     }
 
     // OMEMO trustmode ToFu

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -553,7 +553,7 @@ omemo_prekeys(GList** prekeys, GList** ids, GList** lengths)
 void
 omemo_set_device_list(const char* const from, GList* device_list)
 {
-    log_debug("[OMEMO] Setting device list for %s", from);
+    log_debug("[OMEMO] Setting device list for %s", (from == NULL) ? "" : from);
     Jid* jid;
     if (from) {
         jid = jid_create(from);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -654,7 +654,7 @@ message_send_chat_omemo(const char* const jid, uint32_t sid, GList* keys,
         xmpp_stanza_t* key_stanza = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(key_stanza, "key");
         char* rid = g_strdup_printf("%d", key->device_id);
-        log_debug("[OMEMO] Sending to device rid %s", rid == NULL ? "NULL" : rid);
+        log_debug("[OMEMO] Sending to device rid %s", STR_MAYBE_NULL(rid));
         xmpp_stanza_set_attribute(key_stanza, "rid", rid);
         g_free(rid);
         if (key->prekey) {

--- a/src/xmpp/omemo.c
+++ b/src/xmpp/omemo.c
@@ -191,7 +191,7 @@ omemo_start_device_session_handle_bundle(xmpp_stanza_t* const stanza, void* cons
     char* from = NULL;
 
     const char* from_attr = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
-    log_debug("[OMEMO] omemo_start_device_session_handle_bundle: %s", from_attr);
+    log_debug("[OMEMO] omemo_start_device_session_handle_bundle: %s", (from_attr == NULL) ? "" : from_attr);
 
     const char* type = xmpp_stanza_get_type(stanza);
     if (g_strcmp0(type, "error") == 0) {

--- a/src/xmpp/omemo.c
+++ b/src/xmpp/omemo.c
@@ -191,11 +191,11 @@ omemo_start_device_session_handle_bundle(xmpp_stanza_t* const stanza, void* cons
     char* from = NULL;
 
     const char* from_attr = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
-    log_debug("[OMEMO] omemo_start_device_session_handle_bundle: %s", (from_attr == NULL) ? "" : from_attr);
+    log_debug("[OMEMO] omemo_start_device_session_handle_bundle: %s", STR_MAYBE_NULL(from_attr));
 
     const char* type = xmpp_stanza_get_type(stanza);
     if (g_strcmp0(type, "error") == 0) {
-        log_error("[OMEMO] Error to get key for a device from : %s", from_attr);
+        log_error("[OMEMO] Error to get key for a device from : %s", STR_MAYBE_NULL(from_attr));
     }
 
     if (!from_attr) {


### PR DESCRIPTION
Hi,

OpenBSD's kernel warns about NULL printfs.  Currently, the following messages appear in the system's logs:

```
Jan  6 10:30:53 kronos profanity: vfprintf %s NULL in "[OMEMO] Setting device list for %s"
Jan  6 10:30:53 kronos profanity: vfprintf %s NULL in "[OMEMO] omemo_start_device_session_handle_bundle: %s"
```

Fix this by checking if the variable is indeed NULL and print an empty string instead. There might be more places in the code where this happened, these are the ones that I got warning so far.

Cheers

