### PR TITLE
Fix quote and url autocompletion for MAM and history

### DIFF
--- a/src/tools/autocomplete.c
+++ b/src/tools/autocomplete.c
@@ -141,7 +141,7 @@ autocomplete_update(Autocomplete ac, char** items)
 }
 
 void
-autocomplete_add_reverse(Autocomplete ac, const char* item)
+autocomplete_add_unsorted(Autocomplete ac, const char* item, const gboolean is_reversed)
 {
     if (ac) {
         char* item_cpy;
@@ -153,7 +153,12 @@ autocomplete_add_reverse(Autocomplete ac, const char* item)
         }
 
         item_cpy = strdup(item);
-        ac->items = g_list_prepend(ac->items, item_cpy);
+
+        if (is_reversed) {
+            ac->items = g_list_prepend(ac->items, item_cpy);
+        } else {
+            ac->items = g_list_append(ac->items, item_cpy);
+        }
     }
 }
 

--- a/src/tools/autocomplete.h
+++ b/src/tools/autocomplete.h
@@ -55,7 +55,7 @@ void autocomplete_add_all(Autocomplete ac, char** items);
 void autocomplete_update(Autocomplete ac, char** items);
 void autocomplete_remove(Autocomplete ac, const char* const item);
 void autocomplete_remove_all(Autocomplete ac, char** items);
-void autocomplete_add_reverse(Autocomplete ac, const char* item);
+void autocomplete_add_unsorted(Autocomplete ac, const char* item, const gboolean is_reversed);
 
 // find the next item prefixed with search string
 gchar* autocomplete_complete(Autocomplete ac, const gchar* search_str, gboolean quote, gboolean previous);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -380,11 +380,13 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         win_print_incoming(window, display_name, message);
     }
 
-    wins_add_urls_ac(window, message);
-    wins_add_quotes_ac(window, message->plain);
+    if (!message->is_mam) {
+        wins_add_urls_ac(window, message, FALSE);
+        wins_add_quotes_ac(window, message->plain, FALSE);
 
-    if (prefs_get_boolean(PREF_BEEP) && !message->is_mam) {
-        beep();
+        if (prefs_get_boolean(PREF_BEEP)) {
+            beep();
+        }
     }
 
     if (notify) {
@@ -406,7 +408,7 @@ chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, 
     assert(chatwin != NULL);
 
     ProfWin* window = (ProfWin*)chatwin;
-    wins_add_quotes_ac(window, message);
+    wins_add_quotes_ac(window, message, FALSE);
 
     char* enc_char;
     if (chatwin->outgoing_char) {

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -542,7 +542,7 @@ mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* c
         _mucwin_set_last_message(mucwin, id, message);
     }
 
-    wins_add_quotes_ac(window, message);
+    wins_add_quotes_ac(window, message, FALSE);
 }
 
 void
@@ -582,8 +582,8 @@ mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList
     }
 
     win_insert_last_read_position_marker((ProfWin*)mucwin, mucwin->roomjid);
-    wins_add_urls_ac(window, message);
-    wins_add_quotes_ac(window, message->plain);
+    wins_add_urls_ac(window, message, FALSE);
+    wins_add_quotes_ac(window, message->plain, FALSE);
 
     if (g_slist_length(mentions) > 0) {
         _mucwin_print_mention(window, message->plain, message->from_jid->resourcepart, mynick, mentions, ch, flags);

--- a/src/ui/privwin.c
+++ b/src/ui/privwin.c
@@ -87,8 +87,8 @@ privwin_incoming_msg(ProfPrivateWin* privatewin, ProfMessage* message)
         }
     }
 
-    wins_add_urls_ac(window, message);
-    wins_add_quotes_ac(window, message->plain);
+    wins_add_urls_ac(window, message, FALSE);
+    wins_add_quotes_ac(window, message->plain, TRUE);
 
     if (prefs_get_boolean(PREF_BEEP)) {
         beep();
@@ -107,7 +107,7 @@ privwin_outgoing_msg(ProfPrivateWin* privwin, const char* const message)
     assert(privwin != NULL);
 
     ProfWin* window = (ProfWin*)privwin;
-    wins_add_quotes_ac(window, message);
+    wins_add_quotes_ac(window, message, FALSE);
     win_print_outgoing((ProfWin*)privwin, "-", NULL, NULL, message);
 }
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -35,6 +35,7 @@
  */
 
 #include "config.h"
+#include "ui/window_list.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -1498,6 +1499,8 @@ win_print_history(ProfWin* window, const ProfMessage* const message)
     jid_destroy(jidp);
 
     buffer_append(window->layout->buffer, "-", 0, message->timestamp, flags, THEME_TEXT_HISTORY, display_name, NULL, message->plain, NULL, NULL);
+    wins_add_urls_ac(window, message, FALSE);
+    wins_add_quotes_ac(window, message->plain, FALSE);
     _win_print_internal(window, "-", 0, message->timestamp, flags, THEME_TEXT_HISTORY, display_name, message->plain, NULL);
 
     free(display_name);
@@ -1526,6 +1529,8 @@ win_print_old_history(ProfWin* window, const ProfMessage* const message)
     jid_destroy(jidp);
 
     buffer_prepend(window->layout->buffer, "-", 0, message->timestamp, flags, THEME_TEXT_HISTORY, display_name, NULL, message->plain, NULL, NULL);
+    wins_add_urls_ac(window, message, TRUE);
+    wins_add_quotes_ac(window, message->plain, TRUE);
     _win_print_internal(window, "-", 0, message->timestamp, flags, THEME_TEXT_HISTORY, display_name, message->plain, NULL);
 
     free(display_name);

--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -1315,7 +1315,7 @@ wins_get_next_attention(void)
 }
 
 void
-wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message)
+wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message, const gboolean flip)
 {
     GRegex* regex;
     GMatchInfo* match_info;
@@ -1326,7 +1326,11 @@ wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message)
     while (g_match_info_matches(match_info)) {
         gchar* word = g_match_info_fetch(match_info, 0);
 
-        autocomplete_add_reverse(win->urls_ac, word);
+        if (flip) {
+            autocomplete_add_unsorted(win->urls_ac, word, FALSE);
+        } else {
+            autocomplete_add_unsorted(win->urls_ac, word, TRUE);
+        }
         // for people who run profanity a long time, we don't want to waste a lot of memory
         autocomplete_remove_older_than_max_reverse(win->urls_ac, 20);
 
@@ -1339,9 +1343,14 @@ wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message)
 }
 
 void
-wins_add_quotes_ac(const ProfWin* const win, const char* const message)
+wins_add_quotes_ac(const ProfWin* const win, const char* const message, const gboolean flip)
 {
-    autocomplete_add_reverse(win->quotes_ac, message);
+    if (flip) {
+        autocomplete_add_unsorted(win->quotes_ac, message, FALSE);
+    } else {
+        autocomplete_add_unsorted(win->quotes_ac, message, TRUE);
+    }
+
     // for people who run profanity a long time, we don't want to waste a lot of memory
     autocomplete_remove_older_than_max_reverse(win->quotes_ac, 20);
 }

--- a/src/ui/window_list.h
+++ b/src/ui/window_list.h
@@ -102,9 +102,9 @@ void win_reset_search_attempts(void);
 char* win_close_autocomplete(const char* const search_str, gboolean previous, void* context);
 void win_close_reset_search_attempts(void);
 
-void wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message);
+void wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message, const gboolean flip);
 char* wins_get_url(const char* const search_str, gboolean previous, void* context);
-void wins_add_quotes_ac(const ProfWin* const win, const char* const message);
+void wins_add_quotes_ac(const ProfWin* const win, const char* const message, const gboolean flip);
 char* wins_get_quote(const char* const search_str, gboolean previous, void* context);
 
 #endif


### PR DESCRIPTION
After adding MAM quote and url autocompletion wouldn't pick up messages from MAM or history(from DB) or would have them in the wrong order. This commit fixes that.

Fixes https://github.com/profanity-im/profanity/issues/1770
