### PR TITLE
Adapt to g_string_free glib 2.75.3 change

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -3817,12 +3817,7 @@ _subject_autocomplete(ProfWin* window, const char* const input, gboolean previou
 
             char* subject = muc_subject(mucwin->roomjid);
             if (subject) {
-                GString* result_str = g_string_new("/subject edit \"");
-                g_string_append(result_str, subject);
-                g_string_append(result_str, "\"");
-
-                result = result_str->str;
-                g_string_free(result_str, FALSE);
+                result = g_strdup_printf("/subject edit \"%s\"", subject);
             }
         }
     }
@@ -4260,10 +4255,7 @@ _correction_autocomplete(ProfWin* window, const char* const input, gboolean prev
 static char*
 _correct_autocomplete(ProfWin* window, const char* const input, gboolean previous)
 {
-    GString* result_str = g_string_new("/correct ");
-    g_string_append(result_str, win_get_last_sent_message(window));
-    char* result = result_str->str;
-    g_string_free(result_str, FALSE);
+    char* result = g_strdup_printf("/correct %s", win_get_last_sent_message(window));
 
     return result;
 }

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2738,10 +2738,7 @@ _cmd_index(const Command* cmd)
     }
     g_strfreev(tokens);
 
-    char* res = index->str;
-    g_string_free(index, FALSE);
-
-    return res;
+    return g_string_free(index, FALSE);
 }
 
 GList*

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -3635,12 +3635,7 @@ cmd_join(ProfWin* window, const char* const command, gchar** args)
 
         // server not supplied (room), use account preference
     } else if (account->muc_service) {
-        GString* room_str = g_string_new("");
-        g_string_append(room_str, args[0]);
-        g_string_append(room_str, "@");
-        g_string_append(room_str, account->muc_service);
-        room = room_str->str;
-        g_string_free(room_str, FALSE);
+        room = g_strdup_printf("%s@%s", args[0], account->muc_service);
 
         // no account preference
     } else {
@@ -10107,13 +10102,7 @@ cmd_vcard_photo(ProfWin* window, const char* const command, gchar** args)
                 jid_destroy(jid_occupant);
             } else {
                 // anon muc: send the vcard request through the MUC's server
-                GString* full_jid = g_string_new(mucwin->roomjid);
-                g_string_append(full_jid, "/");
-                g_string_append(full_jid, user);
-
-                jid = full_jid->str;
-
-                g_string_free(full_jid, FALSE);
+                jid = g_strdup_printf("%s/%s", mucwin->roomjid, user);
             }
         } else {
             char* jid_temp = roster_barejid_from_name(user);

--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -457,13 +457,7 @@ otr_key_loaded(void)
 char*
 otr_tag_message(const char* const msg)
 {
-    GString* otr_message = g_string_new(msg);
-    g_string_append(otr_message, OTRL_MESSAGE_TAG_BASE);
-    g_string_append(otr_message, OTRL_MESSAGE_TAG_V2);
-    char* result = otr_message->str;
-    g_string_free(otr_message, FALSE);
-
-    return result;
+    return g_strdup_printf("%s%s%s", msg, OTRL_MESSAGE_TAG_BASE, OTRL_MESSAGE_TAG_V2);
 }
 
 gboolean

--- a/src/pgp/gpg.c
+++ b/src/pgp/gpg.c
@@ -100,8 +100,7 @@ _p_gpg_passphrase_cb(void* hook, const char* uid_hint, const char* passphrase_in
         if (passphrase_attempt) {
             free(passphrase_attempt);
         }
-        passphrase_attempt = pass_term->str;
-        g_string_free(pass_term, FALSE);
+        passphrase_attempt = g_string_free(pass_term, FALSE);
 
         gpgme_io_write(fd, passphrase_attempt, strlen(passphrase_attempt));
     }
@@ -768,10 +767,7 @@ p_gpg_format_fp_str(char* fp)
         }
     }
 
-    char* result = format->str;
-    g_string_free(format, FALSE);
-
-    return result;
+    return g_string_free(format, FALSE);
 }
 
 static char*
@@ -801,18 +797,7 @@ _remove_header_footer(char* str, const char* const footer)
 static char*
 _add_header_footer(const char* const str, const char* const header, const char* const footer)
 {
-    GString* result_str = g_string_new("");
-
-    g_string_append(result_str, header);
-    g_string_append(result_str, "\n\n");
-    g_string_append(result_str, str);
-    g_string_append(result_str, "\n");
-    g_string_append(result_str, footer);
-
-    char* result = result_str->str;
-    g_string_free(result_str, FALSE);
-
-    return result;
+    return g_strdup_printf("%s\n\n%s\n%s", header, str, footer);
 }
 
 static void

--- a/src/plugins/c_api.c
+++ b/src/plugins/c_api.c
@@ -540,13 +540,9 @@ c_api_init(void)
 static char*
 _c_plugin_name(const char* filename)
 {
-    GString* plugin_name_str = g_string_new("");
     gchar* name = g_strndup(filename, strlen(filename) - 1);
-    g_string_append(plugin_name_str, name);
+    gchar* result = g_strdup_printf("%sso", name);
     g_free(name);
-    g_string_append(plugin_name_str, "so");
-    char* result = plugin_name_str->str;
-    g_string_free(plugin_name_str, FALSE);
 
     return result;
 }

--- a/src/tools/autocomplete.c
+++ b/src/tools/autocomplete.c
@@ -314,7 +314,6 @@ autocomplete_complete(Autocomplete ac, const gchar* search_str, gboolean quote, 
 static char*
 _autocomplete_param_common(const char* const input, char* command, autocomplete_func func, Autocomplete ac, gboolean quote, gboolean previous, void* context)
 {
-    GString* auto_msg;
     char* command_cpy;
     char* result = NULL;
     int len;
@@ -344,11 +343,7 @@ _autocomplete_param_common(const char* const input, char* command, autocomplete_
         }
 
         if (found) {
-            auto_msg = g_string_new(command_cpy);
-            g_string_append(auto_msg, found);
-            free(found);
-            result = auto_msg->str;
-            g_string_free(auto_msg, FALSE);
+            result = g_strdup_printf("%s%s", command_cpy, found);
         }
     }
     free(command_cpy);

--- a/src/tools/parser.c
+++ b/src/tools/parser.c
@@ -295,7 +295,6 @@ get_start(const char* const string, int tokens)
     GString* result = g_string_new("");
     int length = g_utf8_strlen(string, -1);
     gboolean in_quotes = FALSE;
-    char* result_str = NULL;
     int num_tokens = 0;
 
     // include first token
@@ -325,10 +324,7 @@ get_start(const char* const string, int tokens)
         }
     }
 
-    result_str = result->str;
-    g_string_free(result, FALSE);
-
-    return result_str;
+    return g_string_free(result, FALSE);
 }
 
 GHashTable*

--- a/src/ui/confwin.c
+++ b/src/ui/confwin.c
@@ -340,14 +340,5 @@ confwin_get_string(ProfConfWin* confwin)
 {
     assert(confwin != NULL);
 
-    GString* res = g_string_new("");
-
-    char* title = win_get_title((ProfWin*)confwin);
-    g_string_append(res, title);
-    free(title);
-
-    char* resstr = res->str;
-    g_string_free(res, FALSE);
-
-    return resstr;
+    return win_get_title((ProfWin*)confwin);
 }

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -310,9 +310,7 @@ _room_triggers_to_string(GList* triggers)
         }
     }
 
-    char* result = triggers_str->str;
-    g_string_free(triggers_str, FALSE);
-    return result;
+    return g_string_free(triggers_str, FALSE);
 }
 
 void

--- a/src/ui/privwin.c
+++ b/src/ui/privwin.c
@@ -286,8 +286,5 @@ privwin_get_string(ProfPrivateWin* privwin)
         g_string_append_printf(res, ", %d unread", privwin->unread);
     }
 
-    char* resstr = res->str;
-    g_string_free(res, FALSE);
-
-    return resstr;
+    return g_string_free(res, FALSE);
 }

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -337,9 +337,7 @@ win_get_title(ProfWin* window)
             g_string_append(title, mucwin->roomjid);
         }
 
-        char* title_str = title->str;
-        g_string_free(title, FALSE);
-        return title_str;
+        return g_string_free(title, FALSE);
     }
     if (window->type == WIN_CONFIG) {
         ProfConfWin* confwin = (ProfConfWin*)window;
@@ -349,9 +347,7 @@ win_get_title(ProfWin* window)
         if (confwin->form->modified) {
             g_string_append(title, " *");
         }
-        char* title_str = title->str;
-        g_string_free(title, FALSE);
-        return title_str;
+        return g_string_free(title, FALSE);
     }
     if (window->type == WIN_PRIVATE) {
         ProfPrivateWin* privatewin = (ProfPrivateWin*)window;
@@ -500,9 +496,7 @@ win_to_string(ProfWin* window)
         ProfPluginWin* pluginwin = (ProfPluginWin*)window;
         GString* gstring = g_string_new("");
         g_string_append_printf(gstring, "Plugin: %s", pluginwin->tag);
-        char* res = gstring->str;
-        g_string_free(gstring, FALSE);
-        return res;
+        return g_string_free(gstring, FALSE);
     }
     case WIN_VCARD:
     {
@@ -2320,7 +2314,5 @@ win_quote_autocomplete(ProfWin* window, const char* const input, gboolean previo
     g_free(quoted_result);
     g_strfreev(parts);
 
-    result = replace_with->str;
-    g_string_free(replace_with, FALSE);
-    return result;
+    return g_string_free(replace_with, FALSE);
 }

--- a/src/xmpp/contact.c
+++ b/src/xmpp/contact.c
@@ -214,21 +214,17 @@ p_contact_name_or_jid(const PContact contact)
 char*
 p_contact_create_display_string(const PContact contact, const char* const resource)
 {
-    GString* result_str = g_string_new("");
+    gchar* result;
 
     // use nickname if exists
     const char* display_name = p_contact_name_or_jid(contact);
-    g_string_append(result_str, display_name);
 
     // add resource if not default provided by profanity
     if (strcmp(resource, "__prof_default") != 0) {
-        g_string_append(result_str, " (");
-        g_string_append(result_str, resource);
-        g_string_append(result_str, ")");
+        result = g_strdup_printf("%s (%s)", display_name, resource);
+    } else {
+        result = g_strdup_printf("%s", display_name);
     }
-
-    char* result = result_str->str;
-    g_string_free(result_str, FALSE);
 
     return result;
 }

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -572,12 +572,10 @@ iq_send_caps_request_legacy(const char* const to, const char* const id,
         return;
     }
 
-    GString* node_str = g_string_new("");
-    g_string_printf(node_str, "%s#%s", node, ver);
-    xmpp_stanza_t* iq = stanza_create_disco_info_iq(ctx, id, to, node_str->str);
+    gchar* node_str = g_strdup_printf("%s#%s", node, ver);
+    xmpp_stanza_t* iq = stanza_create_disco_info_iq(ctx, id, to, node_str);
 
-    iq_id_handler_add(id, _caps_response_legacy_id_handler, g_free, node_str->str);
-    g_string_free(node_str, FALSE);
+    iq_id_handler_add(id, _caps_response_legacy_id_handler, g_free, node_str);
 
     iq_send_stanza(iq);
     xmpp_stanza_release(iq);

--- a/src/xmpp/muc.c
+++ b/src/xmpp/muc.c
@@ -749,9 +749,7 @@ muc_autocomplete(ProfWin* window, const char* const input, gboolean previous)
         g_string_append(replace_with, ": ");
     }
     g_free(result);
-    result = replace_with->str;
-    g_string_free(replace_with, FALSE);
-    return result;
+    return g_string_free(replace_with, FALSE);
 }
 
 void

--- a/src/xmpp/roster_list.c
+++ b/src/xmpp/roster_list.c
@@ -188,10 +188,7 @@ roster_get_display_name(const char* const barejid)
         g_string_append(result, barejid);
     }
 
-    char* result_str = result->str;
-    g_string_free(result, FALSE);
-
-    return result_str;
+    return g_string_free(result, FALSE);
 }
 
 char*
@@ -223,10 +220,7 @@ roster_get_msg_display_name(const char* const barejid, const char* const resourc
         g_string_append(result, resource);
     }
 
-    char* result_str = result->str;
-    g_string_free(result, FALSE);
-
-    return result_str;
+    return g_string_free(result, FALSE);
 }
 
 gboolean


### PR DESCRIPTION
    glib 2.75.3 changes warning behaviour of `g_string_free()`.
    See:
    * https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3219
    * https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3226
    
    Use this opportunity to replace the use of GString with
    `g_strdup_printf()` where possible.
    Otherwise correctly take the return value of `g_string_free()`
    which is nicer anyways