### PR TITLE
Editor executable support flags

### DIFF
--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2545,7 +2545,7 @@ static const struct cmd_t command_defs[] = {
               "/executable urlsave set \"curl %u -o %p\"",
               "/executable urlsave default",
               "/executable vcard_photo set \"feh %p\"",
-              "/executable editor set vim")
+              "/executable editor set \"emacsclient -t\"")
     },
 
     { CMD_PREAMBLE("/url",

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2523,6 +2523,7 @@ static const struct cmd_t command_defs[] = {
               "/executable urlopen default",
               "/executable urlsave set <cmdtemplate>",
               "/executable urlsave default",
+              "/executable editor set <cmdtemplate>",
               "/executable vcard_photo set <cmdtemplate>",
               "/executable vcard_photo default")
       CMD_DESC(

--- a/src/tools/editor.c
+++ b/src/tools/editor.c
@@ -88,11 +88,16 @@ get_message_from_editor(gchar* message, gchar** returned_message)
     }
 
     char* editor = prefs_get_string(PREF_COMPOSE_EDITOR);
+    gchar* editor_with_filename = g_strdup_printf("%s %s", editor, filename);
+    gchar** editor_argv = g_strsplit(editor_with_filename, " ", 0);
+
+    g_free(editor_with_filename);
 
     // Fork / exec
     pid_t pid = fork();
     if (pid == 0) {
-        int x = execlp(editor, editor, filename, (char*)NULL);
+        int x = execvp(editor_argv[0], editor_argv);
+        g_strfreev(editor_argv);
         if (x == -1) {
             log_error("[Editor] Failed to exec %s", editor);
         }


### PR DESCRIPTION
 * Make editor executable into a string to be able to support (multiple) flags.
 * Change /help executable to suit this new feature

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
It was not working when setting /executable editor to "emacsclient -t", because of the "-f" flag.
Now it does work with this setting.