### PR TITLE
Security fix of OTR, PGP and other

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -645,8 +645,8 @@ sv_ev_incoming_message(ProfMessage* message)
     chatwin = wins_get_chat(looking_for_jid);
 
     if (!chatwin) {
-        ProfWin* window = wins_new_chat(looking_for_jid);
-        chatwin = (ProfChatWin*)window;
+        chatwin = chatwin_new(looking_for_jid);
+        ProfWin* window = (ProfWin*)chatwin;
         new_win = TRUE;
 
         if (prefs_get_boolean(PREF_MAM)) {
@@ -689,8 +689,7 @@ sv_ev_incoming_carbon(ProfMessage* message)
     gboolean new_win = FALSE;
     ProfChatWin* chatwin = wins_get_chat(message->from_jid->barejid);
     if (!chatwin) {
-        ProfWin* window = wins_new_chat(message->from_jid->barejid);
-        chatwin = (ProfChatWin*)window;
+        chatwin = chatwin_new(message->from_jid->barejid);
         new_win = TRUE;
 
 #ifdef HAVE_OMEMO

--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -151,7 +151,7 @@ cb_gone_secure(void* opdata, ConnContext* context)
 {
     ProfChatWin* chatwin = wins_get_chat(context->username);
     if (!chatwin) {
-        chatwin = (ProfChatWin*)wins_new_chat(context->username);
+        chatwin = chatwin_new(context->username);
     }
 
     chatwin_otr_secured(chatwin, otr_is_trusted(context->username));

--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -768,20 +768,18 @@ ui_print_system_msg_from_recipient(const char* const barejid, const char* messag
         return;
 
     ProfChatWin* chatwin = wins_get_chat(barejid);
-    ProfWin* window = (ProfWin*)chatwin;
-    if (window == NULL) {
-        window = wins_new_chat(barejid);
-        if (window) {
-            chatwin = (ProfChatWin*)window;
-            int num = wins_get_num(window);
+    if (chatwin == NULL) {
+        chatwin = chatwin_new(barejid);
+        if (chatwin) {
+            int num = wins_get_num((ProfWin*)chatwin);
             status_bar_active(num, WIN_CHAT, chatwin->barejid);
         } else {
-            window = wins_get_console();
+            chatwin = (ProfChatWin*)wins_get_console();
             status_bar_active(1, WIN_CONSOLE, "console");
         }
     }
 
-    win_println(window, THEME_DEFAULT, "-", "*%s %s", barejid, message);
+    win_println((ProfWin*)chatwin, THEME_DEFAULT, "-", "*%s %s", barejid, message);
 }
 
 void

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -598,10 +598,6 @@ message_send_chat_otr(const char* const barejid, const char* const msg, gboolean
         stanza_attach_state(ctx, message, state);
     }
 
-    stanza_attach_carbons_private(ctx, message);
-    stanza_attach_hints_no_copy(ctx, message);
-    stanza_attach_hints_no_store(ctx, message);
-
     if (request_receipt) {
         stanza_attach_receipt_request(ctx, message);
     }


### PR DESCRIPTION
Fix of OTR in message.c: carbon in stanza breaks OTR and prevents it from starting and working properly

Fix of other encryption methods by calling correct function that would initiate them in case if someone writes.

PGP Bug Description
If someone writes using PGP and chat window was closed even if PGP was enabled before, PGP won't initiate, even though it should. The problem is in calling the wrong function to initiate window. It can make a user send a message which he expect to be encrypted in plain text, thus making a big security problem.

OTR Bug Description
If user tries to initiate OTR, it does not work. E.g. PSI+ will just print out the messages and other profanity client won't start the OTR session either. The problem is in the carbons inside of the message.

Minor formatting.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
