### PR TITLE
/executable async on|off

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -1104,6 +1104,7 @@ cmd_ac_init(void)
     autocomplete_add(executable_ac, "urlopen");
     autocomplete_add(executable_ac, "urlsave");
     autocomplete_add(executable_ac, "editor");
+    autocomplete_add(executable_ac, "async");
 
     intype_ac = autocomplete_new();
     autocomplete_add(intype_ac, "console");

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2514,7 +2514,8 @@ static const struct cmd_t command_defs[] = {
               { "urlopen", cmd_executable_urlopen },
               { "urlsave", cmd_executable_urlsave },
               { "editor", cmd_executable_editor },
-              { "vcard_photo", cmd_executable_vcard_photo })
+              { "vcard_photo", cmd_executable_vcard_photo },
+              { "async", cmd_executable_async })
       CMD_TAGS(
               CMD_TAG_DISCOVERY)
       CMD_SYN(
@@ -2525,7 +2526,8 @@ static const struct cmd_t command_defs[] = {
               "/executable urlsave default",
               "/executable editor set <cmdtemplate>",
               "/executable vcard_photo set <cmdtemplate>",
-              "/executable vcard_photo default")
+              "/executable vcard_photo default",
+              "/executable async on|off")
       CMD_DESC(
               "Configure executable that should be called upon a certain command.")
       CMD_ARGS(
@@ -2536,7 +2538,8 @@ static const struct cmd_t command_defs[] = {
               { "urlsave default", "Use the built-in download method for saving." },
               { "editor set", "Set editor to be used with /editor. Needs a terminal editor or a script to run a graphical editor." },
               { "vcard_photo set", "Set executable that is run by /vcard photo open. Takes a command template that replaces %p with the path" },
-              { "vcard_photo default", "Restore to default settings." })
+              { "vcard_photo default", "Restore to default settings." },
+              { "async on|off", "Enable or disable async call of executables. Disable async if all executables run inside the TTY." })
       CMD_EXAMPLES(
               "/executable avatar xdg-open",
               "/executable urlopen set \"xdg-open %u\"",
@@ -2545,8 +2548,9 @@ static const struct cmd_t command_defs[] = {
               "/executable urlsave set \"wget %u -O %p\"",
               "/executable urlsave set \"curl %u -o %p\"",
               "/executable urlsave default",
+              "/executable editor set \"emacsclient -t\"",
               "/executable vcard_photo set \"feh %p\"",
-              "/executable editor set \"emacsclient -t\"")
+              "/executable async off")
     },
 
     { CMD_PREAMBLE("/url",

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -10835,3 +10835,16 @@ cmd_vcard_save(ProfWin* window, const char* const command, gchar** args)
     cons_show("User vCard uploaded");
     return TRUE;
 }
+
+gboolean
+cmd_executable_async(ProfWin* window, const char* const command, gchar** args)
+{
+    if (args[1] == NULL) {
+        cons_bad_cmd_usage(command);
+        return TRUE;
+    }
+
+    _cmd_set_boolean_preference(args[1], command, "Run executables asynchronously", PREF_EXECUTABLE_ASYNC);
+
+    return TRUE;
+}

--- a/src/command/cmd_funcs.h
+++ b/src/command/cmd_funcs.h
@@ -267,5 +267,6 @@ gboolean cmd_vcard_photo(ProfWin* window, const char* const command, gchar** arg
 gboolean cmd_vcard_refresh(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_vcard_set(ProfWin* window, const char* const command, gchar** args);
 gboolean cmd_vcard_save(ProfWin* window, const char* const command, gchar** args);
+gboolean cmd_executable_async(ProfWin* window, const char* const command, gchar** args);
 
 #endif

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -1852,6 +1852,7 @@ _get_group(preference_t pref)
     case PREF_URL_OPEN_CMD:
     case PREF_URL_SAVE_CMD:
     case PREF_VCARD_PHOTO_CMD:
+    case PREF_EXECUTABLE_ASYNC:
         return PREF_GROUP_EXECUTABLES;
     case PREF_AUTOAWAY_CHECK:
     case PREF_AUTOAWAY_MODE:
@@ -2154,6 +2155,8 @@ _get_key(preference_t pref)
         return "url.open.cmd";
     case PREF_URL_SAVE_CMD:
         return "url.save.cmd";
+    case PREF_EXECUTABLE_ASYNC:
+        return "run.async";
     case PREF_COMPOSE_EDITOR:
         return "compose.editor";
     case PREF_SILENCE_NON_ROSTER:
@@ -2228,6 +2231,7 @@ _get_default_boolean(preference_t pref)
     case PREF_MOOD:
     case PREF_STROPHE_SM_ENABLED:
     case PREF_STROPHE_SM_RESEND:
+    case PREF_EXECUTABLE_ASYNC:
         return TRUE;
     default:
         return FALSE;

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -186,6 +186,7 @@ typedef enum {
     PREF_STROPHE_SM_ENABLED,
     PREF_STROPHE_SM_RESEND,
     PREF_VCARD_PHOTO_CMD,
+    PREF_EXECUTABLE_ASYNC,
 } preference_t;
 
 typedef struct prof_alias_t

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2272,6 +2272,8 @@ cons_executable_setting(void)
     gchar* vcard_cmd = prefs_get_string(PREF_VCARD_PHOTO_CMD);
     cons_show("Default '/vcard photo open' command (/executable vcard_photo)            : %s", vcard_cmd);
     g_free(vcard_cmd);
+
+    cons_show("Run executables asynchronously (/executable async)                       : %s", prefs_get_boolean(PREF_EXECUTABLE_ASYNC) ? "ON" : "OFF");
 }
 
 void


### PR DESCRIPTION
 * rename call_external() to call_external_async().
 * add call_external_fork(). This function makes all executable calls to be forked and synchronous. So that running profanity inside a TTY, we can set all executables to be TTY programs (fbi, mpv, w3m, emacs eww, etc.), making possible to open urls or see images inside the TTY.
 * add '/executable async' command.
 * make call_external() use either call_external_async() or call_external_fork(), according to the '/executable async' configuration.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

This is the PR of this discussion (issue) https://github.com/profanity-im/profanity/issues/1805 .

This PR might need some refactor, so I am allowing Maintainers edits. But the code is working.