### PR TITLE
Fix typos and add codespell configuration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,5 @@
 [codespell]
-skip = libtool,./autom4te.cache/*,*.html,./build-aux/*,./.git/*,aclocal*,./m4/*,./config.status,./configure,./config.log,todo
+skip = libtool,./autom4te.cache/*,*.html,./build-aux/*,./.git/*,aclocal*,./m4/*,./config.status,./configure,./config.log,todo,jquery.js,*~
+ignore-words-list = iterm
+ignore-regex = \"Hel\"|ist ein|\->fpr
+uri-ignore-words-list = *

--- a/src/log.c
+++ b/src/log.c
@@ -105,7 +105,7 @@ _rotate_log_file(void)
     log_info("Log has been rotated");
 }
 
-// abbreviation string is the prefix thats used in the log file
+// abbreviation string is the prefix that's used in the log file
 static char*
 _log_abbreviation_string_from_level(log_level_t level)
 {

--- a/src/xmpp/vcard.c
+++ b/src/xmpp/vcard.c
@@ -297,7 +297,7 @@ vcard_parse(xmpp_stanza_t* vcard_xml, vCard* vcard)
             element->nickname = stanza_text_strdup(child_pointer);
 
             if (!element->nickname) {
-                // Invaild element, free and do not push
+                // Invalid element, free and do not push
                 free(element);
                 continue;
             }

--- a/tests/unittests/test_parser.c
+++ b/tests/unittests/test_parser.c
@@ -274,7 +274,7 @@ parse_cmd_with_many_quoted_and_many_spaces(void** state)
 void
 parse_cmd_freetext_with_quoted(void** state)
 {
-    char* inp = "/cmd \"arg1\" arg2 hello there whats up";
+    char* inp = "/cmd \"arg1\" arg2 hello there what's up";
     gboolean result = FALSE;
     gchar** args = parse_args_with_freetext(inp, 3, 3, &result);
 
@@ -282,7 +282,7 @@ parse_cmd_freetext_with_quoted(void** state)
     assert_int_equal(3, g_strv_length(args));
     assert_string_equal("arg1", args[0]);
     assert_string_equal("arg2", args[1]);
-    assert_string_equal("hello there whats up", args[2]);
+    assert_string_equal("hello there what's up", args[2]);
     g_strfreev(args);
 }
 


### PR DESCRIPTION
 * Fix typos
 * Add some words that cannot be fixed to codespell ignore words list.
 * `make doublecheck` now is throwing no error

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
