### PR TITLE
Fix empty window after reconnect

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -160,7 +160,7 @@ sv_ev_roster_received(void)
         // Redraw the screen after entry of the PGP secret key, but not init
         ProfWin* win = wins_get_current();
         char* theme = prefs_get_string(PREF_THEME);
-        win_clear(win);
+        win_redraw(win);
         theme_init(theme);
         g_free(theme);
         ui_resize();

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -1367,6 +1367,10 @@ void
 win_clear(ProfWin* window)
 {
 }
+void
+win_redraw(ProfWin* window)
+{
+}
 char*
 win_to_string(ProfWin* window)
 {


### PR DESCRIPTION
Sometimes after a reconnect the current window would get cleared. This was a deliberate change to fix the profanity window looking all garbled up after providing the passphrase for a gpg key using pinentry-curses.
See https://github.com/profanity-im/profanity/commit/6034b833be41909982b0d2bdac0a1d8499ad8e76

Fixes https://github.com/profanity-im/profanity/issues/1556
