### PR TITLE
add `/statusbar tabmode actlist`

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -265,6 +265,7 @@ static Autocomplete statusbar_self_ac;
 static Autocomplete statusbar_chat_ac;
 static Autocomplete statusbar_room_ac;
 static Autocomplete statusbar_show_ac;
+static Autocomplete statusbar_tabmode_ac;
 static Autocomplete clear_ac;
 static Autocomplete invite_ac;
 static Autocomplete status_ac;
@@ -1030,6 +1031,7 @@ cmd_ac_init(void)
     autocomplete_add(statusbar_ac, "hide");
     autocomplete_add(statusbar_ac, "maxtabs");
     autocomplete_add(statusbar_ac, "tablen");
+    autocomplete_add(statusbar_ac, "tabmode");
     autocomplete_add(statusbar_ac, "self");
     autocomplete_add(statusbar_ac, "chat");
     autocomplete_add(statusbar_ac, "room");
@@ -1057,6 +1059,10 @@ cmd_ac_init(void)
     autocomplete_add(statusbar_show_ac, "name");
     autocomplete_add(statusbar_show_ac, "number");
     autocomplete_add(statusbar_show_ac, "read");
+
+    statusbar_tabmode_ac = autocomplete_new();
+    autocomplete_add(statusbar_tabmode_ac, "actlist");
+    autocomplete_add(statusbar_tabmode_ac, "default");
 
     status_ac = autocomplete_new();
     autocomplete_add(status_ac, "set");
@@ -1678,6 +1684,7 @@ cmd_ac_reset(ProfWin* window)
     autocomplete_reset(statusbar_chat_ac);
     autocomplete_reset(statusbar_room_ac);
     autocomplete_reset(statusbar_show_ac);
+    autocomplete_reset(statusbar_tabmode_ac);
     autocomplete_reset(clear_ac);
     autocomplete_reset(invite_ac);
     autocomplete_reset(status_ac);
@@ -1864,6 +1871,7 @@ cmd_ac_uninit(void)
     autocomplete_free(statusbar_chat_ac);
     autocomplete_free(statusbar_room_ac);
     autocomplete_free(statusbar_show_ac);
+    autocomplete_free(statusbar_tabmode_ac);
     autocomplete_free(clear_ac);
     autocomplete_free(invite_ac);
     autocomplete_free(status_ac);
@@ -4106,6 +4114,11 @@ _statusbar_autocomplete(ProfWin* window, const char* const input, gboolean previ
     }
 
     found = autocomplete_param_with_ac(input, "/statusbar chat", statusbar_chat_ac, TRUE, previous);
+    if (found) {
+        return found;
+    }
+
+    found = autocomplete_param_with_ac(input, "/statusbar tabmode", statusbar_tabmode_ac, TRUE, previous);
     if (found) {
         return found;
     }

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1293,6 +1293,7 @@ static const struct cmd_t command_defs[] = {
               "/statusbar hide name|number|read",
               "/statusbar maxtabs <value>",
               "/statusbar tablen <value>",
+              "/statusbar tabmode default|actlist",
               "/statusbar self user|barejid|fulljid|off",
               "/statusbar chat user|jid",
               "/statusbar room room|jid",
@@ -1303,6 +1304,7 @@ static const struct cmd_t command_defs[] = {
       CMD_ARGS(
               { "maxtabs <value>", "Set the maximum number of tabs to display, <value> must be between 0 and 10." },
               { "tablen <value>", "Set the maximum number of characters to show as the tab name, 0 sets to unlimited." },
+              { "tabmode default|actlist", "Set the mode how the 'active tabs' are shown." },
               { "show|hide name", "Show or hide names in tabs." },
               { "show|hide number", "Show or hide numbers in tabs." },
               { "show|hide read", "Show or hide inactive tabs." },
@@ -1315,6 +1317,7 @@ static const struct cmd_t command_defs[] = {
       CMD_EXAMPLES(
               "/statusbar maxtabs 8",
               "/statusbar tablen 5",
+              "/statusbar tabmode actlist",
               "/statusbar self user",
               "/statusbar chat jid",
               "/statusbar hide read",

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -6341,6 +6341,21 @@ cmd_statusbar(ProfWin* window, const char* const command, gchar** args)
         }
     }
 
+    if (g_strcmp0(args[0], "tabmode") == 0) {
+        char* tabmode = NULL;
+        if ((g_strcmp0(args[1], "default") == 0) || (g_strcmp0(args[1], "actlist") == 0)) {
+            tabmode = args[1];
+        }
+        if (tabmode == NULL) {
+            cons_bad_cmd_usage(command);
+            return TRUE;
+        }
+        prefs_set_string(PREF_STATUSBAR_TABMODE, tabmode);
+        cons_show("Using \"%s\" tabmode for statusbar.", tabmode);
+        ui_resize();
+        return TRUE;
+    }
+
     if (g_strcmp0(args[0], "self") == 0) {
         if (g_strcmp0(args[1], "barejid") == 0) {
             prefs_set_string(PREF_STATUSBAR_SELF, "barejid");

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -1813,6 +1813,7 @@ _get_group(preference_t pref)
     case PREF_STATUSBAR_SELF:
     case PREF_STATUSBAR_CHAT:
     case PREF_STATUSBAR_ROOM:
+    case PREF_STATUSBAR_TABMODE:
     case PREF_TITLEBAR_MUC_TITLE_JID:
     case PREF_TITLEBAR_MUC_TITLE_NAME:
     case PREF_SLASH_GUARD:
@@ -2136,6 +2137,8 @@ _get_key(preference_t pref)
         return "statusbar.chat";
     case PREF_STATUSBAR_ROOM:
         return "statusbar.room";
+    case PREF_STATUSBAR_TABMODE:
+        return "statusbar.tabmode";
     case PREF_OMEMO_LOG:
         return "log";
     case PREF_OMEMO_POLICY:
@@ -2300,6 +2303,8 @@ _get_default_string(preference_t pref)
         return "user";
     case PREF_STATUSBAR_ROOM:
         return "room";
+    case PREF_STATUSBAR_TABMODE:
+        return "default";
     case PREF_OMEMO_LOG:
         return "on";
     case PREF_OMEMO_POLICY:

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -186,6 +186,7 @@ typedef enum {
     PREF_STROPHE_SM_ENABLED,
     PREF_STROPHE_SM_RESEND,
     PREF_VCARD_PHOTO_CMD,
+    PREF_STATUSBAR_TABMODE,
 } preference_t;
 
 typedef struct prof_alias_t

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -2005,21 +2005,21 @@ cons_statusbar_setting(void)
         cons_show("Max tab length (/statusbar)                 : %d", pref_len);
     }
 
-    char* pref_self = prefs_get_string(PREF_STATUSBAR_SELF);
+    auto_gchar gchar* pref_self = prefs_get_string(PREF_STATUSBAR_SELF);
     if (g_strcmp0(pref_self, "off") == 0) {
         cons_show("Self statusbar display (/statusbar)         : OFF");
     } else {
         cons_show("Self statusbar display (/statusbar)         : %s", pref_self);
     }
-    g_free(pref_self);
 
-    char* pref_chat = prefs_get_string(PREF_STATUSBAR_CHAT);
+    auto_gchar gchar* pref_chat = prefs_get_string(PREF_STATUSBAR_CHAT);
     cons_show("Chat tab display (/statusbar)               : %s", pref_chat);
-    g_free(pref_chat);
 
-    char* pref_room = prefs_get_string(PREF_STATUSBAR_ROOM);
+    auto_gchar gchar* pref_room = prefs_get_string(PREF_STATUSBAR_ROOM);
     cons_show("Room tab display (/statusbar)               : %s", pref_room);
-    g_free(pref_room);
+
+    auto_gchar gchar* pref_tabmode = prefs_get_string(PREF_STATUSBAR_TABMODE);
+    cons_show("Tab mode (/statusbar)                       : %s", pref_tabmode);
 }
 
 void


### PR DESCRIPTION
The existing way how active tabs are displayed didn't allow showing more than 10 tabs. This patch adds a mode where the statusbar shows a comma-separated list of tabs which were active since the last time viewed.
This view is inspired by how `irssi` shows the active tabs, therefore it is also called `actlist`.
