### PR TITLE
JID Display in Titlebar and Fix

### DIFF
--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -1260,8 +1260,8 @@ static const struct cmd_t command_defs[] = {
               { "show tls", "Show or hide TLS indicator in the titlebar." },
               { "show encwarn", "Enable or disable the unencrypted warning message in the titlebar." },
               { "show resource", "Show or hide the current resource in the titlebar." },
-              { "show name", "In case of a MUC. Show the MUC name in the titlebar." },
-              { "show jid", "In case of a MUC. Show the JID in the titlebar." })
+              { "show name", "Show the nickname or MUC name in the titlebar." },
+              { "show jid", "Show the JID in the titlebar." })
       CMD_EXAMPLES(
               "/titlebar up",
               "/titlebar show tls",

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -328,7 +328,7 @@ win_get_title(ProfWin* window)
         if (name == NULL) {
             return strdup(chatwin->barejid);
         }
-        if(show_titlebar_jid){
+        if (show_titlebar_jid) {
             return g_strdup_printf("%s <%s>", name, chatwin->barejid);
         }
         return g_strdup_printf("%s", name);

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -312,18 +312,26 @@ win_get_title(ProfWin* window)
     {
         ProfChatWin* chatwin = (ProfChatWin*)window;
         assert(chatwin->memcheck == PROFCHATWIN_MEMCHECK);
+
+        gboolean show_titlebar_jid = prefs_get_boolean(PREF_TITLEBAR_MUC_TITLE_JID);
+        gboolean show_titlebar_name = prefs_get_boolean(PREF_TITLEBAR_MUC_TITLE_NAME);
         jabber_conn_status_t conn_status = connection_get_status();
-        if (conn_status == JABBER_CONNECTED) {
-            PContact contact = roster_get_contact(chatwin->barejid);
-            if (contact) {
-                const char* name = p_contact_name_or_jid(contact);
-                return strdup(name);
-            } else {
-                return strdup(chatwin->barejid);
-            }
-        } else {
+
+        if (conn_status != JABBER_CONNECTED || !show_titlebar_name) {
             return strdup(chatwin->barejid);
         }
+        PContact contact = roster_get_contact(chatwin->barejid);
+        if (!contact) {
+            return strdup(chatwin->barejid);
+        }
+        const char* name = p_contact_name(contact);
+        if (name == NULL) {
+            return strdup(chatwin->barejid);
+        }
+        if(show_titlebar_jid){
+            return g_strdup_printf("%s <%s>", name, chatwin->barejid);
+        }
+        return g_strdup_printf("%s", name);
     }
     case WIN_MUC:
     {


### PR DESCRIPTION
Fixes #1816 and more
See commit messages.
**Note:** on all of the screenshots setting `/statusbar self` set to `off` to preserve privacy of testing account.
## Before
### `/statusbar chat jid`
![image](https://user-images.githubusercontent.com/129467592/229655744-475b74d5-2790-4e17-931e-63986f1bd3f8.png)
### `/statusbar chat user`
![image](https://user-images.githubusercontent.com/129467592/229655744-475b74d5-2790-4e17-931e-63986f1bd3f8.png)

## After
### `/statusbar chat jid`
![image](https://user-images.githubusercontent.com/129467592/229656339-892c0d3b-3663-450d-9221-092992bc5fc2.png)

### `/statusbar chat user`
![image](https://user-images.githubusercontent.com/129467592/229656174-a89b8fc5-748e-479f-94d1-0bfe5d535f7e.png)


<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
