### PR TITLE
Use ASCII chars for MAM loading string

### DIFF
--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -57,7 +57,7 @@
 #include "xmpp/muc.h"
 
 #define PAD_SIZE        1000
-#define LOADING_MESSAGE "Loading older messages…"
+#define LOADING_MESSAGE "Loading older messages..."
 
 void win_move_to_end(ProfWin* window);
 void win_show_status_string(ProfWin* window, const char* const from,


### PR DESCRIPTION
 * Fix non-ASCII chars, for correct display in TTY
 * UTF-8 personal names are excluded from this fix

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
