### PR TITLE
User proper ellipsis char

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -1312,7 +1312,7 @@ cmd_disconnect(ProfWin* window, const char* const command, gchar** args)
 gboolean
 cmd_quit(ProfWin* window, const char* const command, gchar** args)
 {
-    log_info("Profanity is shutting down...");
+    log_info("Profanity is shutting down…");
     exit(0);
     return FALSE;
 }
@@ -3765,11 +3765,11 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
             value = args[0];
             if (g_strcmp0(value, "on") == 0) {
                 form_set_value(form, tag, "1");
-                win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                win_println(window, THEME_DEFAULT, "-", "Field updated…");
                 confwin_show_form_field(confwin, form, tag);
             } else if (g_strcmp0(value, "off") == 0) {
                 form_set_value(form, tag, "0");
-                win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                win_println(window, THEME_DEFAULT, "-", "Field updated…");
                 confwin_show_form_field(confwin, form, tag);
             } else {
                 win_println(window, THEME_DEFAULT, "-", "Invalid command, usage:");
@@ -3788,7 +3788,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
                 win_println(window, THEME_DEFAULT, "-", "");
             } else {
                 form_set_value(form, tag, value);
-                win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                win_println(window, THEME_DEFAULT, "-", "Field updated…");
                 confwin_show_form_field(confwin, form, tag);
             }
             break;
@@ -3800,7 +3800,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
                 win_println(window, THEME_DEFAULT, "-", "");
             } else {
                 form_set_value(form, tag, value);
-                win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                win_println(window, THEME_DEFAULT, "-", "Field updated…");
                 confwin_show_form_field(confwin, form, tag);
             }
             break;
@@ -3824,7 +3824,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
             }
             if (g_strcmp0(cmd, "add") == 0) {
                 form_add_value(form, tag, value);
-                win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                win_println(window, THEME_DEFAULT, "-", "Field updated…");
                 confwin_show_form_field(confwin, form, tag);
                 break;
             }
@@ -3852,7 +3852,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
 
                 removed = form_remove_text_multi_value(form, tag, index);
                 if (removed) {
-                    win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                    win_println(window, THEME_DEFAULT, "-", "Field updated…");
                     confwin_show_form_field(confwin, form, tag);
                 } else {
                     win_println(window, THEME_DEFAULT, "-", "Could not remove %s from %s", value, tag);
@@ -3881,7 +3881,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
                 if (valid) {
                     added = form_add_unique_value(form, tag, value);
                     if (added) {
-                        win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                        win_println(window, THEME_DEFAULT, "-", "Field updated…");
                         confwin_show_form_field(confwin, form, tag);
                     } else {
                         win_println(window, THEME_DEFAULT, "-", "Value %s already selected for %s", value, tag);
@@ -3898,7 +3898,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
                 if (valid == TRUE) {
                     removed = form_remove_value(form, tag, value);
                     if (removed) {
-                        win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                        win_println(window, THEME_DEFAULT, "-", "Field updated…");
                         confwin_show_form_field(confwin, form, tag);
                     } else {
                         win_println(window, THEME_DEFAULT, "-", "Value %s is not currently set for %s", value, tag);
@@ -3930,7 +3930,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
             if (g_strcmp0(args[0], "add") == 0) {
                 added = form_add_unique_value(form, tag, value);
                 if (added) {
-                    win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                    win_println(window, THEME_DEFAULT, "-", "Field updated…");
                     confwin_show_form_field(confwin, form, tag);
                 } else {
                     win_println(window, THEME_DEFAULT, "-", "JID %s already exists in %s", value, tag);
@@ -3940,7 +3940,7 @@ cmd_form_field(ProfWin* window, char* tag, gchar** args)
             if (g_strcmp0(args[0], "remove") == 0) {
                 removed = form_remove_value(form, tag, value);
                 if (removed) {
-                    win_println(window, THEME_DEFAULT, "-", "Field updated...");
+                    win_println(window, THEME_DEFAULT, "-", "Field updated…");
                     confwin_show_form_field(confwin, form, tag);
                 } else {
                     win_println(window, THEME_DEFAULT, "-", "Field %s does not contain %s", tag, value);
@@ -6639,9 +6639,9 @@ cmd_ping(ProfWin* window, const char* const command, gchar** args)
     iq_send_ping(args[0]);
 
     if (args[0] == NULL) {
-        cons_show("Pinged server...");
+        cons_show("Pinged server…");
     } else {
-        cons_show("Pinged %s...", args[0]);
+        cons_show("Pinged %s…", args[0]);
     }
     return TRUE;
 }
@@ -8409,7 +8409,7 @@ cmd_command_exec(ProfWin* window, const char* const command, gchar** args)
 
     iq_command_exec(jid, args[1]);
 
-    cons_show("Execute %s...", args[1]);
+    cons_show("Execute %s…", args[1]);
     return TRUE;
 }
 
@@ -8625,7 +8625,7 @@ cmd_omemo_gen(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
-    cons_show("Generating OMEMO crytographic materials, it may take a while...");
+    cons_show("Generating OMEMO crytographic materials, it may take a while…");
     ui_update();
     ProfAccount* account = accounts_get_account(session_get_account_name());
     omemo_generate_crypto_materials(account);

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -704,7 +704,7 @@ omemo_start_device_session(const char* const jid, uint32_t device_id,
     }
 
     if (!contains_session(&jid_address, omemo_ctx.session_store)) {
-        log_debug("[OMEMO] There is no Session for %s ( %d) ,... building session.", jid_address.name, jid_address.device_id);
+        log_debug("[OMEMO] There is no Session for %s ( %d) ,… building session.", jid_address.name, jid_address.device_id);
         int res;
 
         address = malloc(sizeof(signal_protocol_address));

--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -304,7 +304,7 @@ otr_on_message_recv(const char* const barejid, const char* const resource, const
                 }
                 memmove(whitespace_base, whitespace_base + tag_length, tag_length);
                 char* otr_query_message = otr_start_query();
-                cons_show("OTR Whitespace pattern detected. Attempting to start OTR session...");
+                cons_show("OTR Whitespace pattern detected. Attempting to start OTR session…");
                 char* id = message_send_chat_otr(barejid, otr_query_message, FALSE, NULL);
                 free(id);
             }
@@ -318,7 +318,7 @@ otr_on_message_recv(const char* const barejid, const char* const resource, const
 
     if (policy == PROF_OTRPOLICY_ALWAYS && *decrypted == FALSE && !whitespace_base) {
         char* otr_query_message = otr_start_query();
-        cons_show("Attempting to start OTR session...");
+        cons_show("Attempting to start OTR session…");
         char* id = message_send_chat_otr(barejid, otr_query_message, FALSE, NULL);
         free(id);
     }

--- a/src/profanity.c
+++ b/src/profanity.c
@@ -183,12 +183,12 @@ _init(char* log_level, char* config_file, char* log_file, char* theme_name)
 
     if (strcmp(PACKAGE_STATUS, "development") == 0) {
 #ifdef HAVE_GIT_VERSION
-        log_info("Starting Profanity (%sdev.%s.%s)...", PACKAGE_VERSION, PROF_GIT_BRANCH, PROF_GIT_REVISION);
+        log_info("Starting Profanity (%sdev.%s.%s)…", PACKAGE_VERSION, PROF_GIT_BRANCH, PROF_GIT_REVISION);
 #else
-        log_info("Starting Profanity (%sdev)...", PACKAGE_VERSION);
+        log_info("Starting Profanity (%sdev)…", PACKAGE_VERSION);
 #endif
     } else {
-        log_info("Starting Profanity (%s)...", PACKAGE_VERSION);
+        log_info("Starting Profanity (%s)…", PACKAGE_VERSION);
     }
 
     chat_log_init();

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -246,10 +246,10 @@ chatwin_otr_smp_event(ProfChatWin* chatwin, prof_otr_smp_event_t event, void* da
         win_println((ProfWin*)chatwin, THEME_DEFAULT, "!", "%s failed to authenticate you.", chatwin->barejid);
         break;
     case PROF_OTR_SMP_AUTH:
-        win_println((ProfWin*)chatwin, THEME_DEFAULT, "!", "Authenticating %s...", chatwin->barejid);
+        win_println((ProfWin*)chatwin, THEME_DEFAULT, "!", "Authenticating %s…", chatwin->barejid);
         break;
     case PROF_OTR_SMP_AUTH_WAIT:
-        win_println((ProfWin*)chatwin, THEME_DEFAULT, "!", "Awaiting authentication from %s...", chatwin->barejid);
+        win_println((ProfWin*)chatwin, THEME_DEFAULT, "!", "Awaiting authentication from %s…", chatwin->barejid);
         break;
     default:
         break;

--- a/src/ui/console.c
+++ b/src/ui/console.c
@@ -293,7 +293,7 @@ cons_show_typing(const char* const barejid)
         display_usr = barejid;
     }
 
-    win_println(console, THEME_TYPING, "-", "!! %s is typing a message...", display_usr);
+    win_println(console, THEME_TYPING, "-", "!! %s is typing a message…", display_usr);
     cons_alert(NULL);
 }
 

--- a/src/ui/notifier.c
+++ b/src/ui/notifier.c
@@ -77,7 +77,7 @@ notifier_uninit(void)
 void
 notify_typing(const char* const name)
 {
-    gchar* message = g_strdup_printf("%s: typing...", name);
+    gchar* message = g_strdup_printf("%s: typing…", name);
     notify(message, 10000, "Incoming message");
     g_free(message);
 }

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -414,7 +414,7 @@ _register_handle_features(xmpp_conn_t* xmpp_conn, xmpp_stanza_t* stanza, void* u
     /* secure connection if possible */
     child = xmpp_stanza_get_child_by_name(stanza, "starttls");
     if (child && (strcmp(xmpp_stanza_get_ns(child), XMPP_NS_TLS) == 0)) {
-        log_debug("Server supports TLS. Attempting to establish...");
+        log_debug("Server supports TLS. Attempting to establish…");
         child = xmpp_stanza_new(ctx);
         xmpp_stanza_set_name(child, "starttls");
         xmpp_stanza_set_ns(child, XMPP_NS_TLS);

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2596,7 +2596,7 @@ static int
 _mam_buffer_commit_handler(xmpp_stanza_t* const stanza, void* const userdata)
 {
     ProfChatWin* chatwin = (ProfChatWin*)userdata;
-    // Remove the "Loading messages ..." message
+    // Remove the "Loading messages …" message
     buffer_remove_entry(((ProfWin*)chatwin)->layout->buffer, 0);
     chatwin_db_history(chatwin, NULL, NULL, TRUE);
     return 0;

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -91,7 +91,7 @@ ox_announce_public_key(const char* const filename)
 {
     assert(filename);
 
-    cons_show("Announce OpenPGP Key for OX %s ...", filename);
+    cons_show("Announce OpenPGP Key for OX %s …", filename);
     log_info("[OX] Announce OpenPGP Key of OX: %s", filename);
 
     // key the key and the fingerprint via GnuPG from file


### PR DESCRIPTION
As stated in
https://github.com/profanity-im/profanity/pull/1820#issuecomment-1498083383
profanity uses "..." (three dots) in a lot of places instead the proper
ellipsis char "…".

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->
