### PR TITLE
Add ability to disable avatar publishing

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -1102,6 +1102,7 @@ cmd_ac_init(void)
 
     avatar_ac = autocomplete_new();
     autocomplete_add(avatar_ac, "set");
+    autocomplete_add(avatar_ac, "disable");
     autocomplete_add(avatar_ac, "get");
     autocomplete_add(avatar_ac, "open");
 

--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2418,25 +2418,29 @@ static const struct cmd_t command_defs[] = {
     },
 
     { CMD_PREAMBLE("/avatar",
-                   parse_args, 2, 2, NULL)
+                   parse_args, 1, 2, NULL)
       CMD_MAINFUNC(cmd_avatar)
       CMD_TAGS(
               CMD_TAG_CHAT)
       CMD_SYN(
               "/avatar set <path>",
+              "/avatar disable",
               "/avatar get <barejid>",
               "/avatar open <barejid>")
       CMD_DESC(
-              "Upload avatar for oneself (XEP-0084). "
-              "Download avatar (XEP-0084) for a certain contact. "
-              "If nothing happens after using this command the user either doesn't have an avatar set at all "
+              "Upload an avatar for yourself, "
+              "disable your avatar, "
+              "or download a contact's avatar (XEP-0084). "
+              "If nothing happens after using this command, the user either doesn't have an avatar set "
               "or doesn't use XEP-0084 to publish it.")
       CMD_ARGS(
               { "set <path>", "Set avatar to the image at <path>." },
+              { "disable", "Disable avatar publishing; your avatar will not display to others." },
               { "get <barejid>", "Download the avatar. barejid is the JID to download avatar from." },
               { "open <barejid>", "Download avatar and open it with command." })
       CMD_EXAMPLES(
               "/avatar set ~/images/avatar.png",
+              "/avatar disable",
               "/avatar get thor@valhalla.edda",
               "/avatar open freyja@vanaheimr.edda") },
 

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9287,25 +9287,34 @@ gboolean
 cmd_avatar(ProfWin* window, const char* const command, gchar** args)
 {
     if (args[1] == NULL) {
-        cons_bad_cmd_usage(command);
-        return TRUE;
-    }
-
-    if (g_strcmp0(args[0], "set") == 0) {
-#ifdef HAVE_PIXBUF
-        if (avatar_set(args[1])) {
-            cons_show("Avatar updated successfully");
+        if (g_strcmp0(args[0], "disable") == 0) {
+            if (avatar_publishing_disable()) {
+                cons_show("Avatar publishing disabled. To enable avatar publishing, use '/avatar set <path>'.");
+            } else {
+                cons_show("Failed to disable avatar publishing.");
+            }
+        } else {
+            cons_bad_cmd_usage(command);
         }
+    } else {
+        if (g_strcmp0(args[0], "set") == 0) {
+#ifdef HAVE_PIXBUF
+            if (avatar_set(args[1])) {
+                cons_show("Avatar updated successfully");
+            }
 #else
-        cons_show("Profanity has not been built with GDK Pixbuf support enabled which is needed to scale the avatar when uploading.");
+            cons_show("Profanity has not been built with GDK Pixbuf support enabled which is needed to scale the avatar when uploading.");
 #endif
-    } else if (g_strcmp0(args[0], "get") == 0) {
-        avatar_get_by_nick(args[1], false);
-    } else if (g_strcmp0(args[0], "open") == 0) {
-        avatar_get_by_nick(args[1], true);
-    } else if (g_strcmp0(args[0], "cmd") == 0) {
-        prefs_set_string(PREF_AVATAR_CMD, args[1]);
-        cons_show("Avatar cmd set to: %s", args[1]);
+        } else if (g_strcmp0(args[0], "get") == 0) {
+            avatar_get_by_nick(args[1], false);
+        } else if (g_strcmp0(args[0], "open") == 0) {
+            avatar_get_by_nick(args[1], true);
+        } else if (g_strcmp0(args[0], "cmd") == 0) {
+            prefs_set_string(PREF_AVATAR_CMD, args[1]);
+            cons_show("Avatar cmd set to: %s", args[1]);
+        } else {
+            cons_bad_cmd_usage(command);
+        }
     }
 
     return TRUE;

--- a/src/xmpp/avatar.c
+++ b/src/xmpp/avatar.c
@@ -151,6 +151,17 @@ avatar_set(const char* path)
 #endif
 
 gboolean
+avatar_publishing_disable()
+{
+    xmpp_ctx_t* const ctx = connection_get_ctx();
+    xmpp_stanza_t* iq = stanza_disable_avatar_publish_iq(ctx);
+    iq_send_stanza(iq);
+    xmpp_stanza_release(iq);
+
+    return TRUE;
+}
+
+gboolean
 avatar_get_by_nick(const char* nick, gboolean open)
 {
     // in case we set the feature, remove it
@@ -224,6 +235,9 @@ _avatar_metadata_handler(xmpp_stanza_t* const stanza, void* const userdata)
                         _avatar_request_item_by_id(from, data);
                     }
                 }
+            } else {
+                cons_show("We couldn't get the user's avatar, possibly because they haven't set one or have disabled avatar publishing. "
+                          "During this Profanity session, you will receive future changes to this user's avatar.");
             }
         }
     }

--- a/src/xmpp/avatar.h
+++ b/src/xmpp/avatar.h
@@ -45,3 +45,4 @@ gboolean avatar_set(const char* path);
 #endif
 
 #endif
+gboolean avatar_publishing_disable();

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -2698,6 +2698,42 @@ stanza_create_avatar_metadata_publish_iq(xmpp_ctx_t* ctx, const char* img_data, 
 }
 
 xmpp_stanza_t*
+stanza_disable_avatar_publish_iq(xmpp_ctx_t* ctx)
+{
+    char* id = connection_create_stanza_id();
+    xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_SET, id);
+    free(id);
+    xmpp_stanza_set_attribute(iq, STANZA_ATTR_FROM, connection_get_fulljid());
+
+    xmpp_stanza_t* pubsub = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(pubsub, STANZA_NAME_PUBSUB);
+    xmpp_stanza_set_ns(pubsub, STANZA_NS_PUBSUB);
+
+    xmpp_stanza_t* publish = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(publish, STANZA_NAME_PUBLISH);
+    xmpp_stanza_set_attribute(publish, STANZA_ATTR_NODE, STANZA_NS_USER_AVATAR_METADATA);
+
+    xmpp_stanza_t* item = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(item, STANZA_NAME_ITEM);
+
+    xmpp_stanza_t* metadata = xmpp_stanza_new(ctx);
+    xmpp_stanza_set_name(metadata, STANZA_NAME_METADATA);
+    xmpp_stanza_set_ns(metadata, STANZA_NS_USER_AVATAR_METADATA);
+
+    xmpp_stanza_add_child(item, metadata);
+    xmpp_stanza_add_child(publish, item);
+    xmpp_stanza_add_child(pubsub, publish);
+    xmpp_stanza_add_child(iq, pubsub);
+
+    xmpp_stanza_release(metadata);
+    xmpp_stanza_release(item);
+    xmpp_stanza_release(publish);
+    xmpp_stanza_release(pubsub);
+
+    return iq;
+}
+
+xmpp_stanza_t*
 stanza_create_vcard_request_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const stanza_id)
 {
     xmpp_stanza_t* iq = xmpp_iq_new(ctx, STANZA_TYPE_GET, stanza_id);

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -418,6 +418,7 @@ void stanza_free_caps(XMPPCaps* caps);
 xmpp_stanza_t* stanza_create_avatar_retrieve_data_request(xmpp_ctx_t* ctx, const char* stanza_id, const char* const item_id, const char* const jid);
 xmpp_stanza_t* stanza_create_avatar_data_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len);
 xmpp_stanza_t* stanza_create_avatar_metadata_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len, int height, int width);
+xmpp_stanza_t* stanza_disable_avatar_publish_iq(xmpp_ctx_t* ctx);
 xmpp_stanza_t* stanza_create_vcard_request_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const stanza_id);
 xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const enddate, const char* const firstid, const char* const lastid);
 xmpp_stanza_t* stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* const password);

--- a/tests/unittests/xmpp/stub_avatar.c
+++ b/tests/unittests/xmpp/stub_avatar.c
@@ -14,3 +14,9 @@ avatar_set(const char* path)
 {
     return TRUE;
 }
+
+gboolean
+avatar_publishing_disable()
+{
+    return TRUE;
+}


### PR DESCRIPTION
Add "/avatar disable" to comply with point "3.5 Publisher Disables Avatar Publishing" in XEP-0084.

**src/command/cmd_defs.c:2416**
Add "disable" argument. Reword the "/avatar" command description so it flows better.

**src/command/cmd_ac.c:1101**
Add "disable" to the "/avatar" autocomplete dictionary.

**src/command/cmd_funcs.c:9277**
Split "/avatar" commands into two groups with an if statement; those with a parameter and those without. "cons_bad_cmd_usage()" is in both groups, which is messy. "disable" has similar logic to "set", but it includes a failure message.

**src/xmpp/avatar.c:152**
"avatar_publishing_disable()" uses the same logic to publish metadata as in "avatar_set()".

**src/xmpp/avatar.c:238**
Add a message to inform users when they do not receive an avatar after using "/avatar get" and "/avatar open". In case of a failure, the user will be subscribed to future avatar updates as long as they continue to use their current instance of profanity. Adding "caps_remove_feature()" after "cons_show()" will unsubscribe the user from avatar updates and prevent the user from downloading an avatar unexpectedly hours later without issuing an "/avatar" command.

**src/xmpp/stanza.c:2698**
The new "disable" function follows the same logic as "stanza_create_avatar_metadata_publish_iq()".

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

# How to test the functionality
* Use "/avatar set" to upload an avatar.
* Use "/avatar get" on a second Profanity instance using another JID. The avatar should download.
* Use "/avatar disable" on the first Profanity instance. A _disabled_ message should appear.
* Use "/avatar get" again on the second instance. A _failure_ message should appear.
* Use "/avatar set" again on the first instance. The avatar should automatically download on the second instance.

# I ran valgrind when using my new feature
Yes
