### PR TITLE
MUC MAM

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -47,8 +47,8 @@ void log_database_add_incoming(ProfMessage* message);
 void log_database_add_outgoing_chat(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
 void log_database_add_outgoing_muc_pm(const char* const id, const char* const barejid, const char* const message, const char* const replace_id, prof_enc_t enc);
-GSList* log_database_get_previous_chat(const gchar* const contact_barejid, const char* start_time, char* end_time, gboolean from_start, gboolean flip);
-ProfMessage* log_database_get_limits_info(const gchar* const contact_barejid, gboolean is_last);
+GSList* log_database_get_previous_chat(const gchar* const contact_barejid, const char* start_time, char* end_time, gboolean from_start, gboolean flip, gboolean limit_results);
+ProfMessage* log_database_get_limits_info(const gchar* const contact_barejid, gboolean is_last, char* from_timestamp);
 void log_database_close(void);
 
 #endif // DATABASE_H

--- a/src/event/common.c
+++ b/src/event/common.c
@@ -61,6 +61,7 @@ ev_disconnect_cleanup(void)
     ui_disconnected();
     session_disconnect();
     roster_destroy();
+    iq_disco_items_on_disconnect();
     iq_autoping_timer_cancel();
     muc_invites_clear();
     muc_confserver_clear();

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -650,7 +650,7 @@ sv_ev_incoming_message(ProfMessage* message)
 
         if (prefs_get_boolean(PREF_MAM)) {
             win_print_loading_history(window);
-            iq_mam_request(window, g_date_time_add_seconds(message->timestamp, 0)); // copy timestamp
+            iq_mam_request(window, g_date_time_add_seconds(message->timestamp, 0), FALSE); // copy timestamp
         }
 
 #ifdef HAVE_OMEMO

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -146,7 +146,7 @@ chatwin_new(const char* const barejid)
     }
 
     if (prefs_get_boolean(PREF_MAM)) {
-        iq_mam_request(chatwin, NULL);
+        iq_mam_request(window, NULL);
         win_print_loading_history(window);
     }
 

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -146,7 +146,7 @@ chatwin_new(const char* const barejid)
     }
 
     if (prefs_get_boolean(PREF_MAM)) {
-        iq_mam_request(window, NULL);
+        iq_mam_request(window, NULL, FALSE);
         win_print_loading_history(window);
     }
 
@@ -575,7 +575,7 @@ static void
 _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 {
     if (!chatwin->history_shown) {
-        GSList* history = log_database_get_previous_chat(contact_barejid, NULL, NULL, FALSE, FALSE);
+        GSList* history = log_database_get_previous_chat(contact_barejid, NULL, NULL, FALSE, FALSE, TRUE);
         GSList* curr = history;
 
         while (curr) {
@@ -598,13 +598,13 @@ _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 // first entry's timestamp in the buffer is used. Flip true to prepend to buffer.
 // Timestamps should be in iso8601
 gboolean
-chatwin_db_history(ProfChatWin* chatwin, const char* start_time, char* end_time, gboolean flip)
+chatwin_db_history(ProfChatWin* chatwin, const char* start_time, char* end_time, gboolean flip, gboolean limit_results)
 {
     if (!end_time) {
         end_time = buffer_size(((ProfWin*)chatwin)->layout->buffer) == 0 ? NULL : g_date_time_format_iso8601(buffer_get_entry(((ProfWin*)chatwin)->layout->buffer, 0)->time);
     }
 
-    GSList* history = log_database_get_previous_chat(chatwin->barejid, start_time, end_time, !flip, flip);
+    GSList* history = log_database_get_previous_chat(chatwin->barejid, start_time, end_time, !flip, flip, limit_results);
     gboolean has_items = g_slist_length(history) != 0;
     GSList* curr = history;
 

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -33,6 +33,7 @@
  *
  */
 
+#include "xmpp/session.h"
 #define _XOPEN_SOURCE_EXTENDED
 #include "config.h"
 
@@ -913,6 +914,7 @@ _inp_rl_win_pageup_handler(int count, int key)
 static int
 _inp_rl_win_pagedown_handler(int count, int key)
 {
+    session_lost_connection();
     ProfWin* current = wins_get_current();
     win_page_down(current);
     return 0;

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -71,10 +71,10 @@ mucwin_new(const char* const barejid)
 #endif
 
     if (prefs_get_boolean(PREF_MAM)) {
-        iq_mam_request(window, NULL);
+        iq_mam_request(window, NULL, FALSE);
         win_print_loading_history(window);
     } else if ((prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY))) {
-        mucwin_db_history(mucwin, NULL, NULL, TRUE);
+        mucwin_db_history(mucwin, NULL, NULL, TRUE, TRUE);
     }
 
     // Force redraw here to show correct offline users; before this point muc_members returns a wrong list
@@ -389,13 +389,13 @@ mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message, gboolean fl
 }
 
 gboolean
-mucwin_db_history(ProfMucWin* mucwin, char* start_time, char* end_time, gboolean flip)
+mucwin_db_history(ProfMucWin* mucwin, char* start_time, char* end_time, gboolean flip, gboolean limit_results)
 {
     if (!end_time) {
         end_time = buffer_size(((ProfWin*)mucwin)->layout->buffer) == 0 ? NULL : g_date_time_format_iso8601(buffer_get_entry(((ProfWin*)mucwin)->layout->buffer, 0)->time);
     }
 
-    GSList* history = log_database_get_previous_chat(mucwin->roomjid, start_time, end_time, !flip, flip);
+    GSList* history = log_database_get_previous_chat(mucwin->roomjid, start_time, end_time, !flip, flip, limit_results);
     gboolean has_items = g_slist_length(history) != 0;
     GSList* curr = history;
 

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -73,6 +73,8 @@ mucwin_new(const char* const barejid)
     if (prefs_get_boolean(PREF_MAM)) {
         iq_mam_request(window, NULL);
         win_print_loading_history(window);
+    } else if ((prefs_get_boolean(PREF_CHLOG) && prefs_get_boolean(PREF_HISTORY))) {
+        mucwin_db_history(mucwin, NULL, NULL, TRUE);
     }
 
     // Force redraw here to show correct offline users; before this point muc_members returns a wrong list

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -397,8 +397,8 @@ void win_println_indent(ProfWin* window, int pad, const char* const message, ...
 void win_append(ProfWin* window, theme_item_t theme_item, const char* const message, ...);
 void win_appendln(ProfWin* window, theme_item_t theme_item, const char* const message, ...);
 
-void win_append_highlight(ProfWin* window, theme_item_t theme_item, const gboolean flip, const char* const message, ...);
-void win_appendln_highlight(ProfWin* window, theme_item_t theme_item, const gboolean flip, const char* const message, ...);
+void win_append_highlight(ProfWin* window, theme_item_t theme_item, GDateTime* timestamp, const gboolean flip, const char* const message, ...);
+void win_appendln_highlight(ProfWin* window, theme_item_t theme_item, GDateTime* timestamp, const gboolean flip, const char* const message, ...);
 
 char* win_get_title(ProfWin* window);
 void win_show_occupant(ProfWin* window, Occupant* occupant);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -145,7 +145,7 @@ void chatwin_set_incoming_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_incoming_char(ProfChatWin* chatwin);
 void chatwin_set_outgoing_char(ProfChatWin* chatwin, const char* const ch);
 void chatwin_unset_outgoing_char(ProfChatWin* chatwin);
-gboolean chatwin_db_history(ProfChatWin* chatwin, const char* start_time, char* end_time, gboolean flip);
+gboolean chatwin_db_history(ProfChatWin* chatwin, const char* start_time, char* end_time, gboolean flip, gboolean limit_results);
 
 // MUC window
 ProfMucWin* mucwin_new(const char* const barejid);
@@ -162,7 +162,7 @@ void mucwin_occupant_role_and_affiliation_change(ProfMucWin* mucwin, const char*
                                                  const char* const role, const char* const affiliation, const char* const actor, const char* const reason);
 void mucwin_roster(ProfMucWin* mucwin, GList* occupants, const char* const presence);
 void mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message, gboolean flip);
-gboolean mucwin_db_history(ProfMucWin* mucwin, char* start_time, char* end_time, gboolean flip);
+gboolean mucwin_db_history(ProfMucWin* mucwin, char* start_time, char* end_time, gboolean flip, gboolean limit_results);
 void mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* const id, prof_enc_t enc_mode, const char* const replace_id);
 void mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList* mentions, GList* triggers, gboolean filter_reflection, gboolean flip);
 void mucwin_subject(ProfMucWin* mucwin, const char* const nick, const char* const subject);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -161,9 +161,10 @@ void mucwin_occupant_affiliation_change(ProfMucWin* mucwin, const char* const ni
 void mucwin_occupant_role_and_affiliation_change(ProfMucWin* mucwin, const char* const nick,
                                                  const char* const role, const char* const affiliation, const char* const actor, const char* const reason);
 void mucwin_roster(ProfMucWin* mucwin, GList* occupants, const char* const presence);
-void mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message);
+void mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message, gboolean flip);
+gboolean mucwin_db_history(ProfMucWin* mucwin, char* start_time, char* end_time, gboolean flip);
 void mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* const id, prof_enc_t enc_mode, const char* const replace_id);
-void mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList* mentions, GList* triggers, gboolean filter_reflection);
+void mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList* mentions, GList* triggers, gboolean filter_reflection, gboolean flip);
 void mucwin_subject(ProfMucWin* mucwin, const char* const nick, const char* const subject);
 void mucwin_requires_config(ProfMucWin* mucwin);
 void mucwin_info(ProfMucWin* mucwin);
@@ -396,8 +397,8 @@ void win_println_indent(ProfWin* window, int pad, const char* const message, ...
 void win_append(ProfWin* window, theme_item_t theme_item, const char* const message, ...);
 void win_appendln(ProfWin* window, theme_item_t theme_item, const char* const message, ...);
 
-void win_append_highlight(ProfWin* window, theme_item_t theme_item, const char* const message, ...);
-void win_appendln_highlight(ProfWin* window, theme_item_t theme_item, const char* const message, ...);
+void win_append_highlight(ProfWin* window, theme_item_t theme_item, const gboolean flip, const char* const message, ...);
+void win_appendln_highlight(ProfWin* window, theme_item_t theme_item, const gboolean flip, const char* const message, ...);
 
 char* win_get_title(ProfWin* window);
 void win_show_occupant(ProfWin* window, Occupant* occupant);

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -662,7 +662,7 @@ win_page_up(ProfWin* window)
 
             // Don't do anything if still fetching mam messages
             if (is_not_fetching) {
-                if (!chatwin_db_history(chatwin, NULL, NULL, TRUE) && prefs_get_boolean(PREF_MAM)) {
+                if (!chatwin_db_history(chatwin, NULL, NULL, TRUE, TRUE) && prefs_get_boolean(PREF_MAM)) {
                     win_print_loading_history(window);
                     iq_mam_request_older(window);
                 }
@@ -672,7 +672,7 @@ win_page_up(ProfWin* window)
 
             // Don't do anything if still fetching mam messages
             if (is_not_fetching) {
-                if (!mucwin_db_history(mucwin, NULL, NULL, TRUE) && prefs_get_boolean(PREF_MAM)) {
+                if (!mucwin_db_history(mucwin, NULL, NULL, TRUE, TRUE) && prefs_get_boolean(PREF_MAM)) {
                     win_print_loading_history(window);
                     iq_mam_request_older(window);
                 }
@@ -710,7 +710,7 @@ win_page_down(ProfWin* window)
             char* start = g_date_time_format_iso8601(buffer_get_entry(window->layout->buffer, bf_size - 1)->time);
             GDateTime* now = g_date_time_new_now_local();
             char* end = g_date_time_format_iso8601(now);
-            chatwin_db_history((ProfChatWin*)window, start, end, FALSE);
+            chatwin_db_history((ProfChatWin*)window, start, end, FALSE, TRUE);
 
             g_free(start);
             g_date_time_unref(now);

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1462,9 +1462,9 @@ win_print_incoming(ProfWin* window, const char* const display_name_from, ProfMes
 }
 
 void
-win_print_them(ProfWin* window, theme_item_t theme_item, const char* const show_char, int flags, const char* const them, gboolean flip)
+win_print_them(ProfWin* window, theme_item_t theme_item, GDateTime* timestamp, const char* const show_char, int flags, const char* const them, gboolean flip)
 {
-    _win_printf(window, show_char, 0, NULL, flags | NO_ME | NO_EOL, theme_item, them, NULL, NULL, flip, "", NULL);
+    _win_printf(window, show_char, 0, timestamp , flags | NO_ME | NO_EOL, theme_item, them, NULL, NULL, flip, "", NULL);
 }
 
 void
@@ -1672,9 +1672,14 @@ win_appendln(ProfWin* window, theme_item_t theme_item, const char* const message
 }
 
 void
-win_append_highlight(ProfWin* window, theme_item_t theme_item, const gboolean flip, const char* const message, ...)
+win_append_highlight(ProfWin* window, theme_item_t theme_item, GDateTime* timestamp, const gboolean flip, const char* const message, ...)
 {
-    GDateTime* timestamp = g_date_time_new_now_local();
+    gboolean hadTimestamp = TRUE;
+
+    if (!timestamp) {
+        timestamp = g_date_time_new_now_local();
+        hadTimestamp = FALSE;
+    }
 
     va_list arg;
     va_start(arg, message);
@@ -1690,16 +1695,24 @@ win_append_highlight(ProfWin* window, theme_item_t theme_item, const gboolean fl
     }
 
     inp_nonblocking(TRUE);
-    g_date_time_unref(timestamp);
+
+    if (!hadTimestamp) {
+        g_date_time_unref(timestamp);
+    }
 
     g_string_free(fmt_msg, TRUE);
     va_end(arg);
 }
 
 void
-win_appendln_highlight(ProfWin* window, theme_item_t theme_item, const gboolean flip, const char* const message, ...)
+win_appendln_highlight(ProfWin* window, theme_item_t theme_item, GDateTime* timestamp, const gboolean flip, const char* const message, ...)
 {
-    GDateTime* timestamp = g_date_time_new_now_local();
+    gboolean hadTimestamp = TRUE;
+
+    if (!timestamp) {
+        timestamp = g_date_time_new_now_local();
+        hadTimestamp = FALSE;
+    }
 
     va_list arg;
     va_start(arg, message);
@@ -1716,7 +1729,10 @@ win_appendln_highlight(ProfWin* window, theme_item_t theme_item, const gboolean 
 
 
     inp_nonblocking(TRUE);
-    g_date_time_unref(timestamp);
+
+    if (!hadTimestamp) {
+        g_date_time_unref(timestamp);
+    }
 
     g_string_free(fmt_msg, TRUE);
     va_end(arg);

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -65,11 +65,11 @@ void win_show_status_string(ProfWin* window, const char* const from,
                             GDateTime* last_activity, const char* const pre,
                             const char* const default_show);
 
-void win_print_them(ProfWin* window, theme_item_t theme_item, const char* const show_char, int flags, const char* const them);
+void win_print_them(ProfWin* window, theme_item_t theme_item, const char* const show_char, int flags, const char* const them, const gboolean flip);
 void win_print_incoming(ProfWin* window, const char* const from, ProfMessage* message);
 void win_print_outgoing(ProfWin* window, const char* show_char, const char* const id, const char* const replace_id, const char* const message);
 void win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, const char* const from, const char* const message, char* id, const char* const replace_id);
-void win_println_incoming_muc_msg(ProfWin* window, char* show_char, int flags, const ProfMessage* const message);
+void win_println_incoming_muc_msg(ProfWin* window, char* show_char, int flags, const ProfMessage* const message, const gboolean flip);
 void win_print_outgoing_muc_msg(ProfWin* window, char* show_char, const char* const me, const char* const id, const char* const replace_id, const char* const message);
 void win_print_history(ProfWin* window, const ProfMessage* const message);
 void win_print_old_history(ProfWin* window, const ProfMessage* const message);

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -65,7 +65,7 @@ void win_show_status_string(ProfWin* window, const char* const from,
                             GDateTime* last_activity, const char* const pre,
                             const char* const default_show);
 
-void win_print_them(ProfWin* window, theme_item_t theme_item, const char* const show_char, int flags, const char* const them, const gboolean flip);
+void win_print_them(ProfWin* window, theme_item_t theme_item, GDateTime* timestamp, const char* const show_char, int flags, const char* const them, const gboolean flip);
 void win_print_incoming(ProfWin* window, const char* const from, ProfMessage* message);
 void win_print_outgoing(ProfWin* window, const char* show_char, const char* const id, const char* const replace_id, const char* const message);
 void win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, const char* const from, const char* const message, char* id, const char* const replace_id);

--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -47,6 +47,7 @@
 #include "config/theme.h"
 #include "plugins/plugins.h"
 #include "ui/ui.h"
+#include "ui/window.h"
 #include "ui/window_list.h"
 #include "xmpp/xmpp.h"
 #include "xmpp/roster_list.h"
@@ -885,6 +886,12 @@ wins_lost_connection(void)
         ProfWin* window = curr->data;
         if (window->type != WIN_CONSOLE) {
             win_println(window, THEME_ERROR, "-", "Lost connection.");
+            ProfBuffEntry* first_message = buffer_size(window->layout->buffer) != 0 ? buffer_get_entry(window->layout->buffer, 0) : NULL;
+            gboolean is_fetching_mam = first_message && (first_message->theme_item == THEME_ROOMINFO && g_strcmp0(first_message->message, LOADING_MESSAGE) == 0);
+
+            if (is_fetching_mam) {
+                buffer_remove_entry(window->layout->buffer, 0);
+            }
 
             // if current win, set current_win_dirty
             if (wins_is_current(window)) {

--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -932,6 +932,10 @@ wins_reestablished_connection(void)
             }
 #endif
 
+            if (prefs_get_boolean(PREF_MAM)) {
+                iq_mam_request(window, g_date_time_new_now_local(), TRUE);
+            }
+
             // if current win, set current_win_dirty
             if (wins_is_current(window)) {
                 win_update_virtual(window);

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -34,6 +34,7 @@
  */
 
 #include "config.h"
+#include "config/preferences.h"
 
 #ifdef HAVE_GIT_VERSION
 #include "gitversion.h"
@@ -561,6 +562,15 @@ stanza_create_room_join_presence(xmpp_ctx_t* const ctx,
         xmpp_stanza_add_child(x, pass);
         xmpp_stanza_release(text);
         xmpp_stanza_release(pass);
+    }
+
+    // Disable muc history
+    if (prefs_get_boolean(PREF_MAM)) {
+        xmpp_stanza_t* history = xmpp_stanza_new(ctx);
+        xmpp_stanza_set_name(history, STANZA_NAME_HISTORY);
+        xmpp_stanza_set_attribute(history, "maxchars", "0");
+        xmpp_stanza_add_child(x, history);
+        xmpp_stanza_release(history);
     }
 
     xmpp_stanza_add_child(presence, x);

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -56,6 +56,7 @@
 #define STANZA_NAME_PRESENCE  "presence"
 #define STANZA_NAME_PRIORITY  "priority"
 #define STANZA_NAME_X         "x"
+#define STANZA_NAME_HISTORY   "history"
 // XEP-0373: OpenPGP for XMPP
 #define STANZA_NAME_OPENPGP          "openpgp"
 #define STANZA_NAME_PUPKEY           "pubkey"

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -420,7 +420,7 @@ xmpp_stanza_t* stanza_create_avatar_data_publish_iq(xmpp_ctx_t* ctx, const char*
 xmpp_stanza_t* stanza_create_avatar_metadata_publish_iq(xmpp_ctx_t* ctx, const char* img_data, gsize len, int height, int width);
 xmpp_stanza_t* stanza_disable_avatar_publish_iq(xmpp_ctx_t* ctx);
 xmpp_stanza_t* stanza_create_vcard_request_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const stanza_id);
-xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const enddate, const char* const firstid, const char* const lastid);
+xmpp_stanza_t* stanza_create_mam_iq(xmpp_ctx_t* ctx, const char* const jid, const char* const startdate, const char* const enddate, const char* const firstid, const char* const lastid, const gboolean is_muc);
 xmpp_stanza_t* stanza_change_password(xmpp_ctx_t* ctx, const char* const user, const char* const password);
 xmpp_stanza_t* stanza_register_new_account(xmpp_ctx_t* ctx, const char* const user, const char* const password);
 xmpp_stanza_t* stanza_request_voice(xmpp_ctx_t* ctx, const char* const room);

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -264,8 +264,8 @@ void iq_autoping_check(void);
 void iq_http_upload_request(HTTPUpload* upload);
 void iq_command_list(const char* const target);
 void iq_command_exec(const char* const target, const char* const command);
-void iq_mam_request(ProfChatWin* win, GDateTime* enddate);
-void iq_mam_request_older(ProfChatWin* win);
+void iq_mam_request(ProfWin* win, GDateTime* enddate);
+void iq_mam_request_older(ProfWin* win);
 void iq_register_change_password(const char* const user, const char* const password);
 void iq_muc_register_nick(const char* const roomjid);
 

--- a/src/xmpp/xmpp.h
+++ b/src/xmpp/xmpp.h
@@ -259,12 +259,13 @@ void iq_room_affiliation_set(const char* const room, const char* const jid, char
 void iq_room_kick_occupant(const char* const room, const char* const nick, const char* const reason);
 void iq_room_role_set(const char* const room, const char* const nick, char* role, const char* const reason);
 void iq_room_role_list(const char* const room, char* role);
+void iq_disco_items_on_disconnect(void);
 void iq_autoping_timer_cancel(void);
 void iq_autoping_check(void);
 void iq_http_upload_request(HTTPUpload* upload);
 void iq_command_list(const char* const target);
 void iq_command_exec(const char* const target, const char* const command);
-void iq_mam_request(ProfWin* win, GDateTime* enddate);
+void iq_mam_request(ProfWin* win, GDateTime* enddate, gboolean is_reconnect);
 void iq_mam_request_older(ProfWin* win);
 void iq_register_change_password(const char* const user, const char* const password);
 void iq_muc_register_nick(const char* const roomjid);

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -363,11 +363,11 @@ mucwin_roster(ProfMucWin* mucwin, GList* occupants, const char* const presence)
 {
 }
 void
-mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message)
+mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message, gboolean flip)
 {
 }
 void
-mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList* mentions, GList* triggers, gboolean filter_reflection)
+mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList* mentions, GList* triggers, gboolean filter_reflection, gboolean flip)
 {
 }
 void

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -435,7 +435,7 @@ iq_muc_register_nick(const char* const roomjid)
 }
 
 void
-iq_mam_request(ProfChatWin* win, GDateTime* enddate)
+iq_mam_request(ProfWin* win, GDateTime* enddate)
 {
 }
 

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -404,6 +404,9 @@ void
 iq_last_activity_request(gchar* jid)
 {
 }
+iq_disco_items_on_disconnect(void)
+{
+}
 void
 iq_autoping_timer_cancel(void)
 {
@@ -435,7 +438,7 @@ iq_muc_register_nick(const char* const roomjid)
 }
 
 void
-iq_mam_request(ProfWin* win, GDateTime* enddate)
+iq_mam_request(ProfWin* win, GDateTime* enddate, gboolean is_reconnect)
 {
 }
 


### PR DESCRIPTION
MUC MAM

See #660

# How to test the functionality
* step 1: Have mam enabled
* step 2: Join random muc scroll up
* step 3: rejoining muc should fetch messages sent since last online with profanity

# I ran valgrind when using my new feature
no

----------------
# TODO
- [X] Look up older history
- [X] Look up history when creating muc window
- [X] Look up newer history
- [ ] Fetch mam on incoming message (does a new muc even get created on incoming message ?)
- [ ] Fetch mam on reconnects
- [x] Scroll history even without mam
- [ ] Why loading message sometimes lingers? (when at the end of muc mam maybe?)
- [X] Why is a chatwin opened for each member of muc?
- [ ] Last messages appear doubled (maybe this only happens for chatwins?)
- [X] wrong timestamp for messages through mam on new join of muc
- [x] mentions/triggers show printed date not original date
- [x] respect mam setting
- [X] get all rsm results even from pagination
- [ ] Autocompletion has to be correct
- [ ] how to handle read indicator with mam
- [ ] valgrind
- [ ] make loading mam for muc faster if possible
- [x] Don't request history from muc