### PR TITLE
Add PEP nicknames from XEP-0172

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ core_sources = \
 	src/xmpp/avatar.c src/xmpp/avatar.h \
 	src/xmpp/ox.c src/xmpp/ox.h \
 	src/xmpp/vcard.c src/xmpp/vcard.h src/xmpp/vcard_funcs.h \
+	src/xmpp/nickname.c src/xmpp/nickname.h \
 	src/event/common.c src/event/common.h \
 	src/event/server_events.c src/event/server_events.h \
 	src/event/client_events.c src/event/client_events.h \
@@ -129,6 +130,7 @@ unittest_sources = \
 	tests/unittests/xmpp/stub_ox.c \
 	tests/unittests/xmpp/stub_xmpp.c \
 	tests/unittests/xmpp/stub_message.c \
+	tests/unittests/xmpp/stub_nickname.c \
 	tests/unittests/ui/stub_ui.c tests/unittests/ui/stub_ui.h \
 	tests/unittests/ui/stub_vcardwin.c \
 	tests/unittests/log/stub_log.c \

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -63,6 +63,7 @@
 #include "xmpp/roster_list.h"
 #include "xmpp/avatar.h"
 #include "xmpp/vcard_funcs.h"
+#include "xmpp/nickname.h"
 
 #ifdef HAVE_LIBOTR
 #include "otr/otr.h"
@@ -105,6 +106,7 @@ sv_ev_login_account_success(char* account_name, gboolean secured)
     log_database_init(account);
     vcard_user_refresh();
     avatar_pep_subscribe();
+    nickname_pep_subscribe();
 
     ui_handle_login_account_success(account, secured);
 

--- a/src/xmpp/nickname.c
+++ b/src/xmpp/nickname.c
@@ -1,0 +1,74 @@
+/*
+ * nickname.c
+ * vim: expandtab:ts=4:sts=4:sw=4
+ *
+ * Copyright (C) 2023 Bohdan Horbesko <bodqhrohro@gmail.com>
+ *
+ * This file is part of Profanity.
+ *
+ * Profanity is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Profanity is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Profanity.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link the code of portions of this program with the OpenSSL library under
+ * certain conditions as described in each individual source file, and
+ * distribute linked combinations including the two.
+ *
+ * You must obey the GNU General Public License in all respects for all of the
+ * code used other than OpenSSL. If you modify file(s) with this exception, you
+ * may extend this exception to your version of the file(s), but you are not
+ * obligated to do so. If you do not wish to do so, delete this exception
+ * statement from your version. If you delete this exception statement from all
+ * source files in the program, then also delete it here.
+ *
+ */
+
+#include "xmpp/message.h"
+#include "xmpp/roster_list.h"
+#include "xmpp/stanza.h"
+#include "ui/ui.h"
+
+static int _pep_nick_handler(xmpp_stanza_t* const stanza, void* const userdata);
+
+void
+nickname_pep_subscribe(void)
+{
+    message_pubsub_event_handler_add(STANZA_NS_NICK, _pep_nick_handler, NULL, NULL);
+}
+
+static int
+_pep_nick_handler(xmpp_stanza_t* const stanza, void* const userdata)
+{
+    const char* from = xmpp_stanza_get_attribute(stanza, STANZA_ATTR_FROM);
+    if (from) {
+        xmpp_stanza_t* event = xmpp_stanza_get_child_by_name_and_ns(stanza, STANZA_NAME_EVENT, STANZA_NS_PUBSUB_EVENT);
+        if (event) {
+            xmpp_stanza_t* items = xmpp_stanza_get_child_by_name(event, STANZA_NAME_ITEMS);
+            if (items) {
+                xmpp_stanza_t* item = xmpp_stanza_get_child_by_name(items, STANZA_NAME_ITEM);
+                if (item) {
+                    xmpp_stanza_t* nick = xmpp_stanza_get_child_by_name_and_ns(item, STANZA_NAME_NICK, STANZA_NS_NICK);
+                    if (nick) {
+                        auto_char char* text = xmpp_stanza_get_text(nick);
+
+                        PContact contact = roster_get_contact(from);
+                        if (contact) {
+                            roster_change_name(contact, text);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return 1;
+}

--- a/src/xmpp/nickname.h
+++ b/src/xmpp/nickname.h
@@ -1,0 +1,41 @@
+/*
+ * nickname.h
+ * vim: expandtab:ts=4:sts=4:sw=4
+ *
+ * Copyright (C) 2023 Bohdan Horbesko <bodqhrohro@gmail.com>
+ *
+ * This file is part of Profanity.
+ *
+ * Profanity is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Profanity is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Profanity.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * In addition, as a special exception, the copyright holders give permission to
+ * link the code of portions of this program with the OpenSSL library under
+ * certain conditions as described in each individual source file, and
+ * distribute linked combinations including the two.
+ *
+ * You must obey the GNU General Public License in all respects for all of the
+ * code used other than OpenSSL. If you modify file(s) with this exception, you
+ * may extend this exception to your version of the file(s), but you are not
+ * obligated to do so. If you do not wish to do so, delete this exception
+ * statement from your version. If you delete this exception statement from all
+ * source files in the program, then also delete it here.
+ *
+ */
+
+#ifndef XMPP_NICKNAME_H
+#define XMPP_NICKNAME_H
+
+void nickname_pep_subscribe(void);
+
+#endif

--- a/src/xmpp/stanza.h
+++ b/src/xmpp/stanza.h
@@ -254,6 +254,7 @@
 #define STANZA_NS_STREAMS                 "http://etherx.jabber.org/streams"
 #define STANZA_NS_XMPP_STREAMS            "urn:ietf:params:xml:ns:xmpp-streams"
 #define STANZA_NS_VCARD                   "vcard-temp"
+#define STANZA_NS_NICK                    "http://jabber.org/protocol/nick"
 
 #define STANZA_DATAFORM_SOFTWARE "urn:xmpp:dataforms:softwareinfo"
 

--- a/tests/unittests/test_cmd_otr.c
+++ b/tests/unittests/test_cmd_otr.c
@@ -164,7 +164,7 @@ test_with_command_and_connection_status(char* command, void* cmd_func, jabber_co
 
     expect_cons_show("You must be connected with an account to load OTR information.");
 
-    gboolean (*func)(ProfWin * window, const char* const command, gchar** args) = cmd_func;
+    gboolean (*func)(ProfWin* window, const char* const command, gchar** args) = cmd_func;
     gboolean result = func(NULL, CMD_OTR, args);
     assert_true(result);
 }

--- a/tests/unittests/xmpp/stub_nickname.c
+++ b/tests/unittests/xmpp/stub_nickname.c
@@ -1,0 +1,1 @@
+void nickname_pep_subscribe(void){};


### PR DESCRIPTION
<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

# How to test the functionality
* Setup telegabber
* Switch to the roster window
* Change some chat name at the Telegram side
* Look if it's changed in the roster

# I ran valgrind when using my new feature
```
==4147910== Memcheck, a memory error detector
==4147910== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==4147910== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==4147910== Command: profanity
==4147910== 
==4147910== 
==4147910== HEAP SUMMARY:
==4147910==     in use at exit: 1,849,573 bytes in 1,554 blocks
==4147910==   total heap usage: 1,551,248 allocs, 1,549,694 frees, 87,668,537 bytes allocated
==4147910== 
==4147910== LEAK SUMMARY:
==4147910==    definitely lost: 1,080 bytes in 15 blocks
==4147910==    indirectly lost: 2,125 bytes in 41 blocks
==4147910==      possibly lost: 832 bytes in 14 blocks
==4147910==    still reachable: 1,842,968 bytes in 1,457 blocks
==4147910==         suppressed: 0 bytes in 0 blocks
==4147910== Rerun with --leak-check=full to see details of leaked memory
==4147910== 
==4147910== For lists of detected and suppressed errors, rerun with: -s
==4147910== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```