### PR TITLE
ox: correctly recognize ox encrypted carbons

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -471,6 +471,8 @@ sv_ev_outgoing_carbon(ProfMessage* message)
 
     if (message->enc == PROF_MSG_ENC_OMEMO) {
         chatwin_outgoing_carbon(chatwin, message);
+    } else if (message->enc == PROF_MSG_ENC_OX) {
+        chatwin_outgoing_carbon(chatwin, message);
     } else if (message->encrypted) {
 #ifdef HAVE_LIBGPGME
         message->plain = p_gpg_decrypt(message->encrypted);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -467,6 +467,8 @@ chatwin_outgoing_carbon(ProfChatWin* chatwin, ProfMessage* message)
         enc_char = prefs_get_pgp_char();
     } else if (message->enc == PROF_MSG_ENC_OMEMO) {
         enc_char = prefs_get_omemo_char();
+    } else if (message->enc == PROF_MSG_ENC_OX) {
+        enc_char = prefs_get_ox_char();
     } else {
         enc_char = strdup("-");
     }


### PR DESCRIPTION
and dont display them as legacy pgp encrypted messages. This was forgotten in 2c94ee5a8.

Fix https://github.com/profanity-im/profanity/issues/1875

# I ran valgrind when using my new feature
no
