### PR TITLE
Cut URLs before adding to automcomp at `>`

### DIFF
--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -1310,7 +1310,8 @@ wins_add_urls_ac(const ProfWin* const win, const ProfMessage* const message, con
     GRegex* regex;
     GMatchInfo* match_info;
 
-    regex = g_regex_new("(https?|aesgcm)://\\S+", 0, 0, NULL);
+    // https://stackoverflow.com/questions/43588699/regex-for-matching-any-url-character
+    regex = g_regex_new("(https?|aesgcm)://[\\w\\-.~:/?#\\[\\]@!$&'()*+,;=%]+", 0, 0, NULL);
     g_regex_match(regex, message->plain, 0, &match_info);
 
     while (g_match_info_matches(match_info)) {


### PR DESCRIPTION
First I tried with g_uri_parse() and g_uri_to_string() but then I learned that GUri validation API is only for things that are part of a proper URL.

Let's cut the string at `>` since they are sometimes enclosed in `<>`.

Fix https://github.com/profanity-im/profanity/issues/1877