### PR TITLE
Improve history paging performance

### DIFF
--- a/src/ui/buffer.c
+++ b/src/ui/buffer.c
@@ -53,7 +53,7 @@
 #include "ui/window.h"
 #include "ui/buffer.h"
 
-#define BUFF_SIZE 1200
+#define BUFF_SIZE 200
 
 struct prof_buff_t
 {


### PR DESCRIPTION
- [x] No need for valgrind

### How to test the functionality
* Reach bottom and top of your conversations, you should see that (1) delay on page switching has been reduced and (2) that you can reach first and last message in the chat (though there already is unrelated bug, that's why, please, make sure that you can see first message without the update).
* Check whether MAM is working
* Use page up 10-20 times (to fill the buffer) and then page down until you see last messages. Then hold/click quickly page down. Lag should be much less noticeable than before changes were introduced.
