### PR TITLE
Fix loading of encryption type

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -290,7 +290,7 @@ log_database_get_previous_chat(const gchar* const contact_barejid, const char* s
         char* date = (char*)sqlite3_column_text(stmt, 1);
         char* from = (char*)sqlite3_column_text(stmt, 2);
         char* type = (char*)sqlite3_column_text(stmt, 3);
-        char* encryption = (char*)sqlite3_column_text(stmt, 3);
+        char* encryption = (char*)sqlite3_column_text(stmt, 4);
 
         ProfMessage* msg = message_init();
         msg->from_jid = jid_create(from);


### PR DESCRIPTION
The column of the encryption type in the result is 4, not 3.

Fixup of 6375b2719fd16cbedf531ff197f6d82ffbcc873a
