### PR TITLE
Add unicode support for correction char

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9329,7 +9329,6 @@ cmd_os(ProfWin* window, const char* const command, gchar** args)
 gboolean
 cmd_correction(ProfWin* window, const char* const command, gchar** args)
 {
-    // enable/disable
     if (g_strcmp0(args[0], "on") == 0) {
         _cmd_set_boolean_preference(args[0], "Last Message Correction", PREF_CORRECTION_ALLOW);
         caps_add_feature(XMPP_FEATURE_LAST_MESSAGE_CORRECTION);
@@ -9340,15 +9339,12 @@ cmd_correction(ProfWin* window, const char* const command, gchar** args)
         return TRUE;
     }
 
-    // char
     if (g_strcmp0(args[0], "char") == 0) {
-        if (args[1] == NULL) {
-            cons_bad_cmd_usage(command);
-        } else if (strlen(args[1]) != 1) {
+        if (args[1] == NULL || g_utf8_strlen(args[1], 4) != 1) {
             cons_bad_cmd_usage(command);
         } else {
-            prefs_set_correction_char(args[1][0]);
-            cons_show("LMC char set to %c.", args[1][0]);
+            prefs_set_correction_char(args[1]);
+            cons_show("LMC char set to %s.", args[1]);
         }
     }
 

--- a/src/config/preferences.c
+++ b/src/config/preferences.c
@@ -1281,13 +1281,13 @@ prefs_get_correction_char(void)
 }
 
 void
-prefs_set_correction_char(char ch)
+prefs_set_correction_char(char* ch)
 {
-    char str[2];
-    str[0] = ch;
-    str[1] = '\0';
-
-    g_key_file_set_string(prefs, PREF_GROUP_UI, "correction.char", str);
+    if (g_utf8_strlen(ch, 4) == 1) {
+        g_key_file_set_string(prefs, PREF_GROUP_UI, "correction.char", ch);
+    } else {
+        log_error("Could not set correction char: %s", ch);
+    }
 }
 
 gboolean

--- a/src/config/preferences.h
+++ b/src/config/preferences.h
@@ -296,7 +296,7 @@ gint prefs_get_occupants_indent(void);
 void prefs_set_occupants_indent(gint value);
 
 gchar* prefs_get_correction_char(void);
-void prefs_set_correction_char(char ch);
+void prefs_set_correction_char(char* ch);
 
 void prefs_add_login(const char* jid);
 

--- a/src/config/theme.c
+++ b/src/config/theme.c
@@ -484,8 +484,8 @@ _load_preferences(void)
 
     if (g_key_file_has_key(theme, "ui", "correction.char", NULL)) {
         auto_gchar gchar* ch = g_key_file_get_string(theme, "ui", "correction.char", NULL);
-        if (ch && strlen(ch) > 0) {
-            prefs_set_correction_char(ch[0]);
+        if (ch && g_utf8_strlen(ch, 4) == 1) {
+            prefs_set_correction_char(ch);
         }
     }
 


### PR DESCRIPTION
- [x] No need to run valgrind when using my new feature

### How to test the functionality
* Set correction char to unicode character, e.g. `/correction char 🖋️`
* Use `/correct` command
