### PR TITLE
Show encryption for historical messages

### DIFF
--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -433,16 +433,8 @@ chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, 
     auto_char char* enc_char;
     if (chatwin->outgoing_char) {
         enc_char = chatwin->outgoing_char;
-    } else if (enc_mode == PROF_MSG_ENC_OTR) {
-        enc_char = prefs_get_otr_char();
-    } else if (enc_mode == PROF_MSG_ENC_PGP) {
-        enc_char = prefs_get_pgp_char();
-    } else if (enc_mode == PROF_MSG_ENC_OMEMO) {
-        enc_char = prefs_get_omemo_char();
-    } else if (enc_mode == PROF_MSG_ENC_OX) {
-        enc_char = prefs_get_ox_char();
     } else {
-        enc_char = strdup("-");
+        enc_char = get_show_char(enc_mode);
     }
 
     if (request_receipt && id) {

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -518,16 +518,8 @@ mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* c
     auto_char char* ch;
     if (mucwin->message_char) {
         ch = strdup(mucwin->message_char);
-    } else if (enc_mode == PROF_MSG_ENC_OTR) {
-        ch = prefs_get_otr_char();
-    } else if (enc_mode == PROF_MSG_ENC_PGP) {
-        ch = prefs_get_pgp_char();
-    } else if (enc_mode == PROF_MSG_ENC_OMEMO) {
-        ch = prefs_get_omemo_char();
-    } else if (enc_mode == PROF_MSG_ENC_OX) {
-        ch = prefs_get_omemo_char();
     } else {
-        ch = strdup("-");
+        ch = get_show_char(enc_mode);
     }
 
     win_print_outgoing_muc_msg(window, ch, mynick, id, replace_id, message);
@@ -566,14 +558,8 @@ mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList
     auto_char char* ch;
     if (mucwin->message_char) {
         ch = strdup(mucwin->message_char);
-    } else if (message->enc == PROF_MSG_ENC_OTR) {
-        ch = prefs_get_otr_char();
-    } else if (message->enc == PROF_MSG_ENC_PGP) {
-        ch = prefs_get_pgp_char();
-    } else if (message->enc == PROF_MSG_ENC_OMEMO) {
-        ch = prefs_get_omemo_char();
     } else {
-        ch = strdup("-");
+        ch = get_show_char(message->enc);
     }
 
     win_insert_last_read_position_marker((ProfWin*)mucwin, mucwin->roomjid);

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -98,4 +98,6 @@ void win_remove_entry_message(ProfWin* window, const char* const id);
 
 char* win_quote_autocomplete(ProfWin* window, const char* const input, gboolean previous);
 
+char* get_show_char(prof_enc_t encryption_mode);
+
 #endif


### PR DESCRIPTION
See commit message.

<!-- For completed items, change [ ] to [x]. -->
- [x] No need to run valgrind when using my new feature

### How to test the functionality
* Use page up in the chat window until you see historical message. Encryption used should be displayed accordingly.