### PR TITLE
Improve handling of NULL pointers fetched from DB

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -375,7 +375,7 @@ log_database_get_previous_chat(const gchar* const contact_barejid, const char* s
         ProfMessage* msg = message_init();
         msg->from_jid = jid_create(from);
         msg->to_jid = jid_create(to_jid);
-        msg->plain = _db_strdup(message);
+        msg->plain = strdup(message ?: "");
         msg->timestamp = g_date_time_new_from_iso8601(date, NULL);
         msg->type = _get_message_type_type(type);
         msg->enc = _get_message_enc_type(encryption);


### PR DESCRIPTION
#1915 unsuccessfully tried to fix strdup(message) when message is NULL, since it lead to a chain reaction that can be ungracefully fixed like this: https://github.com/profanity-im/profanity/commit/c1c2113a3a2c66db160757d7169ee18610b3c29a or instead we could use strdup("") to substitute an empty message.