### PR TITLE
Allow redirects for  `/plugins install` and add emptiness check for downloaded files

### DIFF
--- a/src/tools/http_download.c
+++ b/src/tools/http_download.c
@@ -176,6 +176,10 @@ http_file_get(void* userdata)
         err = strdup(curl_easy_strerror(res));
     }
 
+    if (ftell(outfh) == 0) {
+        err = strdup("Output file is empty.");
+    }
+
     curl_easy_cleanup(curl);
     curl_global_cleanup();
 

--- a/src/tools/http_download.c
+++ b/src/tools/http_download.c
@@ -159,6 +159,8 @@ http_file_get(void* userdata)
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "profanity");
 
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
     if (cafile) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, cafile);
     }


### PR DESCRIPTION
### How to test the functionality
Use `/plugins install <redirect_link>`, e.g. `/plugins install https://github.com/profanity-im/profanity-plugins/raw/master/stable/syscmd.py`

To test emptiness check, I would suggest finding some empty file that ends up with `.c` or `.py` for the purpose of testing.

Fix #1901