### PR TITLE
Handle alt+enter as newline char

### DIFF
--- a/docs/profanity.1
+++ b/docs/profanity.1
@@ -80,6 +80,9 @@ Mark current window for later reading with an attention flag.
 .BI ALT+m
 Switch between windows marked with the attention flag.
 .TP
+.BI ALT+ENTER
+Add newline character without sending a message/command.
+.TP
 .BI ALT+c
 Run external editor (see
 .BR profanity-editor (1))

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -137,6 +137,7 @@ static int _inp_rl_subwin_pagedown_handler(int count, int key);
 static int _inp_rl_startup_hook(void);
 static int _inp_rl_down_arrow_handler(int count, int key);
 static int _inp_rl_send_to_editor(int count, int key);
+static int _inp_rl_print_newline_symbol(int count, int key);
 
 void
 create_input_window(void)
@@ -482,6 +483,7 @@ _inp_rl_addfuncs(void)
     rl_add_funmap_entry("prof_win_close", _inp_rl_win_close_handler);
     rl_add_funmap_entry("prof_send_to_editor", _inp_rl_send_to_editor);
     rl_add_funmap_entry("prof_cut_to_history", _inp_rl_down_arrow_handler);
+    rl_add_funmap_entry("prof_print_newline_symbol", _inp_rl_print_newline_symbol);
 }
 
 // Readline callbacks
@@ -554,6 +556,8 @@ _inp_rl_startup_hook(void)
 
     rl_bind_keyseq("\\e[1;5B", _inp_rl_down_arrow_handler); // ctrl+arrow down
     rl_bind_keyseq("\\eOb", _inp_rl_down_arrow_handler);
+
+    rl_bind_keyseq("\\e\\C-\r", _inp_rl_print_newline_symbol); // alt+enter
 
     // unbind unwanted mappings
     rl_bind_keyseq("\\e=", NULL);
@@ -958,5 +962,12 @@ _inp_rl_send_to_editor(int count, int key)
     rl_point = rl_end;
     rl_forced_update_display();
 
+    return 0;
+}
+
+static int
+_inp_rl_print_newline_symbol(int count, int key)
+{
+    rl_insert_text("\n");
     return 0;
 }


### PR DESCRIPTION
See commit message.

### How to test functionality
Write a message and use alt+enter during writing to put a new character symbol there. Plain "Enter" for sending message/command should work as well as before.

### Why alt+enter?
Well, you see, shift+enter and ctrl+enter aren't that bindable, as you can see by using `showkey --ascii` command. Though shift/ctrl variants might be more preferable since they are used in some popular applications, we just can't bind on them using GNU Readline, while alt+enter does the work as well. 

I will be glad if someone can improve the solution to take keybinding from preference and allow custom settings for ctrl+enter, shift+enter etc. Though even current solution will suffice in terms of functionality and you can get used to it quite quickly.