### PR TITLE
Fix scrolling

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -333,7 +333,7 @@ log_database_get_previous_chat(const gchar* const contact_barejid, const char* s
     auto_gchar gchar* end_date_fmt = end_time ? end_time : g_date_time_format_iso8601(now);
     auto_sqlite gchar* query = sqlite3_mprintf("SELECT * FROM ("
                                                "SELECT COALESCE(B.`message`, A.`message`) AS message, "
-                                               "A.`timestamp`, A.`from_jid`, A.`to_jid`, A.`type`, A.`encryption` FROM `ChatLogs` AS A "
+                                               "A.`timestamp`, A.`from_jid`, A.`to_jid`, A.`type`, A.`encryption`, A.`stanza_id` FROM `ChatLogs` AS A "
                                                "LEFT JOIN `ChatLogs` AS B ON (A.`replaced_by_db_id` = B.`id` AND A.`from_jid` = B.`from_jid`) "
                                                "WHERE (A.`replaces_db_id` IS NULL) "
                                                "AND ((A.`from_jid` = %Q AND A.`to_jid` = %Q) OR (A.`from_jid` = %Q AND A.`to_jid` = %Q)) "
@@ -365,8 +365,10 @@ log_database_get_previous_chat(const gchar* const contact_barejid, const char* s
         char* to_jid = (char*)sqlite3_column_text(stmt, 3);
         char* type = (char*)sqlite3_column_text(stmt, 4);
         char* encryption = (char*)sqlite3_column_text(stmt, 5);
+        char* id = (char*)sqlite3_column_text(stmt, 6);
 
         ProfMessage* msg = message_init();
+        msg->id = id ? strdup(id) : NULL;
         msg->from_jid = jid_create(from);
         msg->to_jid = jid_create(to_jid);
         msg->plain = strdup(message ?: "");

--- a/src/ui/buffer.h
+++ b/src/ui/buffer.h
@@ -52,6 +52,9 @@ typedef struct prof_buff_entry_t
     // pointer because it could be a unicode symbol as well
     gchar* show_char;
     int pad_indent;
+    int y_start_pos;
+    int y_end_pos;
+    int _lines;
     GDateTime* time;
     int flags;
     theme_item_t theme_item;
@@ -69,8 +72,8 @@ typedef struct prof_buff_t* ProfBuff;
 
 ProfBuff buffer_create();
 void buffer_free(ProfBuff buffer);
-void buffer_append(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id);
-void buffer_prepend(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id);
+void buffer_append(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id, int y_start_pos, int y_end_pos);
+void buffer_prepend(ProfBuff buffer, const char* show_char, int pad_indent, GDateTime* time, int flags, theme_item_t theme_item, const char* const display_from, const char* const barejid, const char* const message, DeliveryReceipt* receipt, const char* const id, int y_start_pos, int y_end_pos);
 void buffer_remove_entry_by_id(ProfBuff buffer, const char* const id);
 void buffer_remove_entry(ProfBuff buffer, int entry);
 int buffer_size(ProfBuff buffer);


### PR DESCRIPTION
Current state:
 - Fixes "overscrolling"
 - Lag reduction (only necessary lines are being drawn)

Currently it's full of debugging lines with some issues which are to be fixed before release:
- [x] Fix "underscrolling"
- [x] Fix "overscrolling" (profanity jumps over big messages received from DB)
- [x] Change line calculation (made based on curses' position)
- [x] Cleanup debug lines
- [x] Merge
- [x] Fix a problem: extremely big message (e.g. 3k lines) causes profanity to jump back once scrolled on top

#### This line is for github CI/CD system to link the issue
Fix https://github.com/profanity-im/profanity/issues/1934