### PR TITLE
Fix when feature discovery is finished

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -58,6 +58,7 @@
 #include "ui/window.h"
 #include "tools/bookmark_ignore.h"
 #include "xmpp/xmpp.h"
+#include "xmpp/iq.h"
 #include "xmpp/muc.h"
 #include "xmpp/chat_session.h"
 #include "xmpp/roster_list.h"
@@ -196,6 +197,7 @@ sv_ev_roster_received(void)
 void
 sv_ev_connection_features_received(void)
 {
+    iq_feature_retrieval_complete_handler();
 #ifdef HAVE_OMEMO
     omemo_publish_crypto_materials();
 #endif

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2539,7 +2539,6 @@ _disco_items_result_handler(xmpp_stanza_t* const stanza)
     if (g_strcmp0(id, "discoitemsreq") == 0) {
         cons_show_disco_items(items, from);
     } else if (g_strcmp0(id, "discoitemsreq_onconnect") == 0) {
-        received_disco_items = TRUE;
         connection_set_disco_items(items);
 
         while (late_delivery_windows) {
@@ -2552,6 +2551,12 @@ _disco_items_result_handler(xmpp_stanza_t* const stanza)
     }
 
     g_slist_free_full(items, (GDestroyNotify)_item_destroy);
+}
+
+void
+iq_feature_retrieval_complete_handler(void)
+{
+    received_disco_items = TRUE;
 }
 
 void

--- a/src/xmpp/iq.h
+++ b/src/xmpp/iq.h
@@ -40,6 +40,7 @@ typedef int (*ProfIqCallback)(xmpp_stanza_t* const stanza, void* const userdata)
 typedef void (*ProfIqFreeCallback)(void* userdata);
 
 void iq_handlers_init(void);
+void iq_feature_retrieval_complete_handler(void);
 void iq_send_stanza(xmpp_stanza_t* const stanza);
 void iq_id_handler_add(const char* const id, ProfIqCallback func, ProfIqFreeCallback free_func, void* userdata);
 void iq_disco_info_request_onconnect(const char* jid);

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -451,6 +451,11 @@ iq_mam_request(ProfChatWin* win, GDateTime* enddate)
 }
 
 void
+iq_feature_retrieval_complete_handler(void)
+{
+}
+
+void
 publish_user_mood(const char* const mood, const char* const text)
 {
 }


### PR DESCRIPTION
Feature discovery was marked as finished once we received a reply to the initial request. The discovery mechanism allows to delegate the real feature discovery to another service running on different domain and those requests are created dynamically.

This was another instance causing the warning message described in #1940

Fixes #1940 (once more)

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature

### How to test the functionality
* have an account on a server that delegates feature discovery like hot-chilli
* send a 1-on-1 message to that account while being offline
* connect to that account

Before the patch you would receive the warning when connecting to the server and the server delivers the 1-on-1 message before feature discovery was finished.