### PR TITLE
Fix unable to download item twice

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -9447,6 +9447,7 @@ _url_http_method(ProfWin* window, const char* cmd_template, gchar* url, gchar* p
     download->filename = strdup(filename);
     download->id = strdup(id);
     download->cmd_template = cmd_template ? strdup(cmd_template) : NULL;
+    download->silent = FALSE;
 
     pthread_create(&(download->worker), NULL, &http_file_get, download);
     http_download_add_download(download);

--- a/src/tools/aesgcm_download.c
+++ b/src/tools/aesgcm_download.c
@@ -110,6 +110,7 @@ aesgcm_file_get(void* userdata)
     http_dl->url = strdup(https_url);
     http_dl->filename = strdup(tmpname);
     http_dl->cmd_template = NULL;
+    http_dl->silent = FALSE;
     aesgcm_dl->http_dl = http_dl;
 
     http_file_get(http_dl); // TODO(wstrm): Verify result.


### PR DESCRIPTION
## Summary

Partial fix for https://github.com/profanity-im/profanity/issues/1939  

> When doing the same in an unencrypted (no e2ee) chat there is no Downloading… message at all but the file is downloaded.  

Download a file twice with `/url save`, the second download will not print download progress to the window.  

The cause is `HTTPDownload`'s `silent` variable is not initialized; so, `silent` points to a second-hand stack memory address with old data. `silent` references data, so the `if` statement will fail in **src/tools/http_download.c:206** and download progress will not print to the window.  

The fix is to initialize `silent` in both encrypted and unencrypted file download scenarios.  

## Testing

Valgrind: Yes  

- `/url save` without OMEMO  
  **SUCCESS**: Try three times with the same URL and download status will display every time.  

- `/url save` with OMEMO  
  **SUCCESS**: Try three times with the same URL and download status will display every time.  

- `/plugins install [https://raw.githubusercontent.com/profanity-im/profanity-plugins/master/stable/sounds.py`](https://raw.githubusercontent.com/profanity-im/profanity-plugins/master/stable/sounds.py%60)  
  **SUCCESS**: Try once and download progress is hidden.  