### PR TITLE
Remove subscription when reporting spam/abuse

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -3077,6 +3077,12 @@ cmd_blocked(ProfWin* window, const char* const command, gchar** args)
         if (!res) {
             cons_show("User %s already blocked.", args[1]);
         }
+
+        // remove the subscription as well
+        if (presence_sub_request_exists(jid)) {
+            presence_subscription(jid, PRESENCE_UNSUBSCRIBED);
+        }
+
         return TRUE;
     }
 


### PR DESCRIPTION
When users receive a message and a subscription request from a new contact, and they use `/blocked report-abse JID` or `/blocked report-spam JID` they most likely want the subscription request to vanish as well.

According to mdosch Conversations is behaving like this too.

Fix: https://github.com/profanity-im/profanity/issues/1970