### PR TITLE
ci: disable macOS for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,19 +22,6 @@ jobs:
           docker build -f Dockerfile.${{ matrix.flavor }} -t profanity .
           docker run profanity ./ci-build.sh
 
-  macos:
-    runs-on: macos-latest
-    name: macOS
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run brew bundle
-        run: brew bundle
-      - name: Run tests
-        env:
-          # Ensure that "keg-only" Homebrew versions are used.
-          PKG_CONFIG_PATH: "/usr/local/opt/ncurses/lib/pkgconfig:/usr/local/opt/expat/lib/pkgconfig:/usr/local/opt/curl/lib/pkgconfig:/usr/local/opt/openssl/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig:/usr/local/opt/sqlite/lib/pkgconfig:$PKG_CONFIG_PATH"
-        run: ./ci-build.sh
-
   code-style:
     runs-on: ubuntu-22.04
     name: Check coding style


### PR DESCRIPTION
We get some build fails there and I don't see what's the problem on a first glance. Noone else stepped up neither.