### PR TITLE
Reset autoconnect account when the account gets removed

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -569,6 +569,12 @@ cmd_account_remove(ProfWin* window, const char* const command, gchar** args)
     }
     cons_show("");
 
+    auto_gchar gchar* autocon_account = prefs_get_string(PREF_CONNECT_ACCOUNT);
+    if (g_strcmp0(account_name, autocon_account) == 0) {
+        prefs_set_string(PREF_CONNECT_ACCOUNT, NULL);
+        cons_show("Autoconnect account reset because the corresponding account was removed.");
+    }
+
     return TRUE;
 }
 


### PR DESCRIPTION
When a user added an account, set it as autoconnect and then removed that account. It still was set as the autoconnect account.

```
    /account add test
    /autoconnect set test
    /account remove test
    /save
    /quit
    Start profanity
```

Fix https://github.com/profanity-im/profanity/issues/1976