### PR TITLE
Change default download location

### DIFF
--- a/src/command/cmd_defs.c
+++ b/src/command/cmd_defs.c
@@ -2572,7 +2572,7 @@ static const struct cmd_t command_defs[] = {
               "Open or save URLs. This works with OMEMO encrypted files as well.")
       CMD_ARGS(
               { "open", "Open URL with predefined executable." },
-              { "save", "Save URL to optional path, default path is current directory." })
+              { "save", "Save URL to optional path. The location is displayed after successful download." })
       CMD_EXAMPLES(
               "/url open https://profanity-im.github.io",
               "/url save https://profanity-im.github.io/guide/latest/userguide.html /home/user/Download/")

--- a/src/config/files.c
+++ b/src/config/files.c
@@ -165,6 +165,22 @@ files_get_data_path(const char* const location)
 }
 
 gchar*
+files_get_download_path(const char* const jid)
+{
+    auto_gchar gchar* xdg_data = _files_get_xdg_data_home();
+
+    if (jid) {
+        auto_char char* account_dir = str_replace(jid, "@", "_at_");
+        GDateTime* now = g_date_time_new_now_local();
+        auto_gchar gchar* date = g_date_time_format(now, "%Y_%m_%d");
+        g_date_time_unref(now);
+        return g_strdup_printf("%s/profanity/%s/%s/%s", xdg_data, DIR_DOWNLOADS, account_dir, date);
+    } else {
+        return g_strdup_printf("%s/profanity/%s", xdg_data, DIR_DOWNLOADS);
+    }
+}
+
+gchar*
 files_get_account_data_path(const char* const specific_dir, const char* const jid)
 {
     auto_gchar gchar* data_dir = files_get_data_path(specific_dir);

--- a/src/config/files.h
+++ b/src/config/files.h
@@ -66,6 +66,7 @@ void files_create_directories(void);
 
 gchar* files_get_config_path(const char* const config_base);
 gchar* files_get_data_path(const char* const location);
+gchar* files_get_download_path(const char* const jid);
 gchar* files_get_account_data_path(const char* const specific_dir, const char* const jid);
 
 gchar* files_get_log_file(const char* const log_file);


### PR DESCRIPTION
`/url save $someurl` will now download to
`~/.local/share/profanity/downloads/from_jid/date/filename` instead of `~/.local/share/profanity/downloads`.

Like this the downloaded files should be better ordered.

This will only happen for MUC and 1:1 chat windows. Private windows might have only a nick or jid. Lets not distinguish between those two ways. And since the nick option is unreliable to be the same person lets just put them in the general downloads folder. As is done with downloads from all other windows as well.

I also had the idea to make this configurable but this suits my needs and time limits right now.