### PR TITLE
Implement substring autocompletion for /msg

### DIFF
--- a/src/command/cmd_ac.c
+++ b/src/command/cmd_ac.c
@@ -2084,7 +2084,7 @@ _cmd_ac_complete_params(ProfWin* window, const char* const input, gboolean previ
         // Remove quote character before and after names when doing autocomplete
         char* unquoted = strip_arg_quotes(input);
         for (int i = 0; i < ARRAY_SIZE(contact_choices); i++) {
-            result = autocomplete_param_with_func(unquoted, contact_choices[i], roster_contact_autocomplete, previous, NULL);
+            result = autocomplete_param_with_func(unquoted, contact_choices[i], roster_contact_autocomplete_substring, previous, NULL);
             if (result) {
                 free(unquoted);
                 return result;

--- a/src/tools/autocomplete.h
+++ b/src/tools/autocomplete.h
@@ -59,6 +59,8 @@ void autocomplete_add_unsorted(Autocomplete ac, const char* item, const gboolean
 
 // find the next item prefixed with search string
 gchar* autocomplete_complete(Autocomplete ac, const gchar* search_str, gboolean quote, gboolean previous);
+// find the next item containing search string
+gchar* autocomplete_complete_substring(Autocomplete ac, const gchar* search_str, gboolean quote, gboolean previous);
 
 GList* autocomplete_create_list(Autocomplete ac);
 gint autocomplete_length(Autocomplete ac);

--- a/src/xmpp/roster_list.c
+++ b/src/xmpp/roster_list.c
@@ -518,6 +518,14 @@ roster_contact_autocomplete(const char* const search_str, gboolean previous, voi
 }
 
 char*
+roster_contact_autocomplete_substring(const char* const search_str, gboolean previous, void* context)
+{
+    assert(roster != NULL);
+
+    return autocomplete_complete_substring(roster->name_ac, search_str, TRUE, previous);
+}
+
+char*
 roster_fulljid_autocomplete(const char* const search_str, gboolean previous, void* context)
 {
     assert(roster != NULL);

--- a/src/xmpp/roster_list.h
+++ b/src/xmpp/roster_list.h
@@ -64,6 +64,7 @@ GSList* roster_get_contacts(roster_ord_t order);
 GSList* roster_get_contacts_online(void);
 gboolean roster_has_pending_subscriptions(void);
 char* roster_contact_autocomplete(const char* const search_str, gboolean previous, void* context);
+char* roster_contact_autocomplete_substring(const char* const search_str, gboolean previous, void* context);
 char* roster_fulljid_autocomplete(const char* const search_str, gboolean previous, void* context);
 GSList* roster_get_group(const char* const group, roster_ord_t order);
 GList* roster_get_groups(void);


### PR DESCRIPTION
People with huge contact lists most likely happen to have contacts starting with popular names more often. They can use /msg Arthur to find the correct person.

But if they have 50 Arthurs it will take a while. Using the surname might be faster. So a substring search of /msg Clarke<tab> will be faster.

Fix https://github.com/profanity-im/profanity/issues/1984