### PR TITLE
Remove plenking

### DIFF
--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -2608,7 +2608,7 @@ static int
 _mam_buffer_commit_handler(xmpp_stanza_t* const stanza, void* const userdata)
 {
     ProfChatWin* chatwin = (ProfChatWin*)userdata;
-    // Remove the "Loading messages …" message
+    // Remove the "Loading messages…" message
     buffer_remove_entry(((ProfWin*)chatwin)->layout->buffer, 0);
     chatwin_db_history(chatwin, NULL, NULL, TRUE);
     return 0;

--- a/src/xmpp/ox.c
+++ b/src/xmpp/ox.c
@@ -91,7 +91,7 @@ ox_announce_public_key(const char* const filename)
 {
     assert(filename);
 
-    cons_show("Announce OpenPGP Key for OX %s …", filename);
+    cons_show("Announce OpenPGP Key for OX %s…", filename);
     log_info("[OX] Announce OpenPGP Key of OX: %s", filename);
 
     // key the key and the fingerprint via GnuPG from file


### PR DESCRIPTION
There were two cases of plenking (a space between a word and the punctuation
marks) in front of `…`.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature
Should not be necessary as only two strings were changed (space removed).

### How to test the functionality
* If it builds it should be fine.
