### PR TITLE
Update Dockerfile to include missing Python dependency and ensure file copying

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,3 @@
-# Build the latest Debian testing image
 FROM debian:testing
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -25,6 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libxss-dev \
   make \
   pkg-config \
+  python3 \
   python3-dev \
   python-dev-is-python3 \
   libsqlite3-dev \
@@ -34,14 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir -p /usr/src/{stabber,libstrophe,profanity}
 WORKDIR /usr/src
 
-#RUN git clone https://github.com/boothj5/stabber
 RUN git clone -c http.sslverify=false https://github.com/strophe/libstrophe
-
-#WORKDIR /usr/src/stabber
-#RUN ./bootstrap.sh
-#RUN ./configure --prefix=/usr --disable-dependency-tracking
-#RUN make
-#RUN make install
 
 WORKDIR /usr/src/libstrophe
 RUN ./bootstrap.sh
@@ -50,4 +43,9 @@ RUN make
 RUN make install
 
 WORKDIR /usr/src/profanity
-COPY . /usr/src/profanity
+COPY . .
+
+RUN ./bootstrap.sh
+RUN ./configure --prefix=/usr  
+RUN make
+RUN make install

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -45,6 +45,12 @@ RUN make install
 WORKDIR /usr/src/profanity
 COPY . .
 
+#WORKDIR /usr/src/stabber
+#RUN ./bootstrap.sh
+#RUN ./configure --prefix=/usr --disable-dependency-tracking
+#RUN make
+#RUN make install
+
 RUN ./bootstrap.sh
 RUN ./configure --prefix=/usr  
 RUN make


### PR DESCRIPTION
This pull request updates the Dockerfile to resolve a missing dependency issue that prevented Profanity from starting in the Docker container. Specifically:

    Added Python 3 and necessary development libraries to the Dockerfile dependencies.
    Ensured all source files are correctly copied into the container during the build process.

These changes enable Profanity to build and run successfully within the Debian-based Docker container.
### How to Test the Functionality

    **Build the Docker Image:**


docker build -t profanity_test .

**Run the Container:**

`docker run -it profanity_test /bin/bash`

**Navigate to the Profanity Directory:**

`cd /usr/src/profanity`

**Start Profanity:**

`./profanity`

**Verify:**

    Confirm that Profanity starts without any errors related to missing libraries.
    Test basic commands within Profanity to ensure functionality.