### PR TITLE
Fix Dockerfile.arch base image error: Update archlinux/latest to archlinux

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,4 +1,4 @@
-FROM archlinux/latest
+FROM archlinux
 
 RUN pacman -Syu --noconfirm && pacman -S --needed --noconfirm \
   autoconf \


### PR DESCRIPTION
This pull request addresses an error in the Dockerfile.arch file caused by using an incorrect base image reference (archlinux/latest). The Docker Hub archlinux repository does not support a latest tag, which leads to a "failed to resolve source metadata" error during the Docker build process. This PR updates the base image reference to archlinux, resolving the error and allowing for a successful build.

**Problem**

The current Dockerfile uses archlinux/latest as the base image:


`FROM archlinux/latest`

Since archlinux/latest does not exist on Docker Hub, attempting to build this Dockerfile results in the following error:


`ERROR: failed to solve: archlinux/latest: failed to resolve source metadata for docker.io/archlinux/latest:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
`
**Steps to Reproduce**

    Clone the repository.

    _Run the following Docker build command:_

   ` sudo docker build -t profanity -f Dockerfile.arch .`

    Observe the error indicating that archlinux/latest could not be found or accessed.

**Fix**

This PR modifies the Dockerfile.arch to use the correct base image, archlinux, without the non-existent latest tag:


`FROM archlinux`

**Validation**

After applying this fix, you can verify that the Docker image builds successfully:

    _Run the updated build command:_

`    sudo docker build -t profanity -f Dockerfile.arch .`

    The build should complete without errors, and the profanity image will be created as expected.

**Impact**

This change ensures that the Docker build can complete successfully without requiring additional permissions or custom image sources. It aligns the Dockerfile with the official Arch Linux image structure on Docker Hub, improving compatibility and reliability for users.