### PR TITLE
Make `muc_nick` return a `const char* const`

### DIFF
--- a/src/chatlog.c
+++ b/src/chatlog.c
@@ -307,7 +307,7 @@ void
 groupchat_log_msg_out(const gchar* const room, const gchar* const msg)
 {
     if (prefs_get_boolean(PREF_GRLOG)) {
-        char* mynick = muc_nick(room);
+        const char* const mynick = muc_nick(room);
         _groupchat_log_chat(connection_get_barejid(), room, mynick, msg);
     }
 }
@@ -326,7 +326,7 @@ groupchat_log_omemo_msg_out(const gchar* const room, const gchar* const msg)
     if (prefs_get_boolean(PREF_CHLOG)) {
         const char* mybarejid = connection_get_barejid();
         auto_gchar gchar* pref_omemo_log = prefs_get_string(PREF_OMEMO_LOG);
-        char* mynick = muc_nick(room);
+        const char* const mynick = muc_nick(room);
 
         if (strcmp(pref_omemo_log, "on") == 0) {
             _groupchat_log_chat(mybarejid, room, mynick, msg);

--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -4633,7 +4633,7 @@ cmd_bookmark(ProfWin* window, const char* const command, gchar** args)
         // default to current nickname, password, and autojoin "on"
         ProfMucWin* mucwin = (ProfMucWin*)window;
         assert(mucwin->memcheck == PROFMUCWIN_MEMCHECK);
-        char* nick = muc_nick(mucwin->roomjid);
+        const char* const nick = muc_nick(mucwin->roomjid);
         char* password = muc_password(mucwin->roomjid);
         gboolean added = bookmark_add(mucwin->roomjid, nick, password, "on", NULL);
         if (added) {

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -114,7 +114,7 @@ sv_ev_login_account_success(char* account_name, gboolean secured)
     GList* curr = rooms;
     while (curr) {
         char* password = muc_password(curr->data);
-        char* nick = muc_nick(curr->data);
+        const char* const nick = muc_nick(curr->data);
         presence_join_room(curr->data, nick, password);
         curr = g_list_next(curr);
     }
@@ -336,7 +336,7 @@ sv_ev_room_message(ProfMessage* message)
         return;
     }
 
-    char* mynick = muc_nick(mucwin->roomjid);
+    const char* const mynick = muc_nick(mucwin->roomjid);
 
     // only log message not coming from this client (but maybe same account, different client)
     // our messages are logged when outgoing

--- a/src/plugins/api.c
+++ b/src/plugins/api.c
@@ -231,7 +231,8 @@ api_get_current_nick(void)
     if (current->type == WIN_MUC) {
         ProfMucWin* mucwin = (ProfMucWin*)current;
         assert(mucwin->memcheck == PROFMUCWIN_MEMCHECK);
-        return muc_nick(mucwin->roomjid);
+        const char* const nick = muc_nick(mucwin->roomjid);
+        return nick ? strdup(nick) : NULL;
     } else {
         return NULL;
     }
@@ -286,7 +287,9 @@ api_current_win_is_console(void)
 char*
 api_get_room_nick(const char* barejid)
 {
-    return muc_nick(barejid);
+    const char* const nick = muc_nick(barejid);
+
+    return nick ? strdup(nick) : NULL;
 }
 
 void

--- a/src/plugins/python_api.c
+++ b/src/plugins/python_api.c
@@ -435,7 +435,9 @@ python_api_get_current_nick(PyObject* self, PyObject* args)
     char* nick = api_get_current_nick();
     disable_python_threads();
     if (nick) {
-        return Py_BuildValue("s", nick);
+        PyObject* obj = Py_BuildValue("s", nick);
+        free(nick);
+        return obj;
     } else {
         Py_RETURN_NONE;
     }

--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -778,7 +778,7 @@ ui_room_join(const char* const roomjid, gboolean focus)
     }
     ProfWin* window = (ProfWin*)mucwin;
 
-    char* nick = muc_nick(roomjid);
+    const char* const nick = muc_nick(roomjid);
     win_print(window, THEME_ROOMINFO, "!", "-> You have joined the room as %s", nick);
     if (prefs_get_boolean(PREF_MUC_PRIVILEGES)) {
         char* role = muc_role_str(roomjid);

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -368,7 +368,7 @@ mucwin_history(ProfMucWin* mucwin, const ProfMessage* const message)
     assert(mucwin != NULL);
 
     char* nick = message->from_jid->resourcepart;
-    char* mynick = muc_nick(mucwin->roomjid);
+    const char* const mynick = muc_nick(mucwin->roomjid);
     GSList* mentions = get_mentions(prefs_get_boolean(PREF_NOTIFY_MENTION_WHOLE_WORD), prefs_get_boolean(PREF_NOTIFY_MENTION_CASE_SENSITIVE), message->plain, mynick);
     GList* triggers = prefs_message_get_triggers(message->plain);
 
@@ -512,7 +512,7 @@ mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* c
     assert(mucwin != NULL);
 
     ProfWin* window = (ProfWin*)mucwin;
-    char* mynick = muc_nick(mucwin->roomjid);
+    const char* const mynick = muc_nick(mucwin->roomjid);
 
     // displayed message char
     auto_char char* ch = get_enc_char(enc_mode, mucwin->message_char);
@@ -548,7 +548,7 @@ mucwin_incoming_msg(ProfMucWin* mucwin, const ProfMessage* const message, GSList
     }
 
     ProfWin* window = (ProfWin*)mucwin;
-    char* mynick = muc_nick(mucwin->roomjid);
+    const char* const mynick = muc_nick(mucwin->roomjid);
 
     auto_char char* ch = get_enc_char(message->enc, mucwin->message_char);
 

--- a/src/xmpp/muc.c
+++ b/src/xmpp/muc.c
@@ -426,7 +426,7 @@ muc_rooms(void)
  * Return current users nickname for the specified room
  * The nickname is owned by the chat room and should not be modified or freed
  */
-char*
+const char* const
 muc_nick(const char* const room)
 {
     ChatRoom* chat_room = g_hash_table_lookup(rooms, room);

--- a/src/xmpp/muc.h
+++ b/src/xmpp/muc.h
@@ -94,7 +94,7 @@ GList* muc_rooms(void);
 
 void muc_set_features(const char* const room, GSList* features);
 
-char* muc_nick(const char* const room);
+const char* const muc_nick(const char* const room);
 char* muc_password(const char* const room);
 
 void muc_nick_change_start(const char* const room, const char* const new_nick);

--- a/src/xmpp/presence.c
+++ b/src/xmpp/presence.c
@@ -259,7 +259,7 @@ _send_room_presence(xmpp_stanza_t* presence)
     GList* curr = rooms;
     while (curr) {
         const char* room = curr->data;
-        const char* nick = muc_nick(room);
+        const char* const nick = muc_nick(room);
 
         if (nick) {
             auto_char char* full_room_jid = create_fulljid(room, nick);
@@ -327,7 +327,7 @@ presence_leave_chat_room(const char* const room_jid)
 {
     assert(room_jid != NULL);
 
-    char* nick = muc_nick(room_jid);
+    const char* const nick = muc_nick(room_jid);
     if (!nick) {
         log_error("Could not get nickname for room: %s", room_jid);
         return;

--- a/src/xmpp/stanza.c
+++ b/src/xmpp/stanza.c
@@ -1384,7 +1384,7 @@ stanza_is_muc_self_presence(xmpp_stanza_t* const stanza,
     if (from) {
         auto_jid Jid* from_jid = jid_create(from);
         if (muc_active(from_jid->barejid)) {
-            char* nick = muc_nick(from_jid->barejid);
+            const char* const nick = muc_nick(from_jid->barejid);
             if (g_strcmp0(from_jid->resourcepart, nick) == 0) {
                 return TRUE;
             }
@@ -1394,7 +1394,7 @@ stanza_is_muc_self_presence(xmpp_stanza_t* const stanza,
         if (muc_nick_change_pending(from_jid->barejid)) {
             char* new_nick = from_jid->resourcepart;
             if (new_nick) {
-                char* nick = muc_nick(from_jid->barejid);
+                const char* const nick = muc_nick(from_jid->barejid);
                 char* old_nick = muc_old_nick(from_jid->barejid, new_nick);
                 if (g_strcmp0(old_nick, nick) == 0) {
                     return TRUE;


### PR DESCRIPTION
In the documentation of the `muc_nick` function we can read:

> The nickname is owned by the chat room and should not be modified or freed

We should reflect that in the return type and `strdup` the value for the plugin API.

Fixes: https://github.com/profanity-im/profanity/issues/2013