### PR TITLE
Bug Fix #1938

### DIFF
--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -1143,22 +1143,10 @@ _handle_groupchat(xmpp_stanza_t* const stanza)
         message->timestamp = oldest_delay;
     }
 
-    //1390 Bug fix explained
-    /*
-    Previously the code from 1136 to 1145 looked like this
-    bool is_muc_history = FALSE;
-    if (message->timestamp != NULL) {
-        is_muc_history = TRUE;
-        g_date_time_unref(message->timestamp);
-        message->timestamp = NULL;
-    }
+    //1938 Bug fix explained
+    //Instead of discarding the timestamp associated with the message without checking it
+    //First we check if we have an older delay, at which point we replace the time stamp with that.
 
-    // we want to display the oldest delay
-    message->timestamp = stanza_get_oldest_delay(stanza);
-
-    However, this is discarding a possibly correct timestamp instead of checking
-    it against the oldest delay. This could be a server quirk in that it doesn't work.
-    */
 
     // now this has nothing to do with MUC history
     // it's just setting the time to the received time so upon displaying we can use this time


### PR DESCRIPTION
For the bug reported in #1938 there seems to be an issue of not grabbing the right time stamp. This is similar to the bug in #1190 of not grabbing the proper delay for MAM messages. To fix this, instead of discarding the original timestamp and trying to find the oldest delay, which may have been lost to a server quirk, we preserve the timestamp until an older delay is found. Then, and only then, will the timestamp update. Of course if it still can't find a delay and there is no timestamp, the fall back of grabbing the current time is still available. This should fix the bug experienced in #1938 and #1190 , given they look like they stem from a similar issue. 

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature

### How to test the functionality
* Step 1 - Profanity is not connected.
* Step 2 - Receive messages in a MUC
*Step 3 - Connect Profanity
Now the timestamps should be correct for the MUC.

Previous to this there were issues of inaccurate time stamps, but now that should be mitigated. 
