### PR TITLE
Revert plugins api breakage

### DIFF
--- a/src/plugins/plugins.c
+++ b/src/plugins/plugins.c
@@ -515,15 +515,15 @@ plugins_on_disconnect(const char* const account_name, const char* const fulljid)
 }
 
 char*
-plugins_pre_chat_message_display(const char* const barejid, const char* const resource, char* message)
+plugins_pre_chat_message_display(const char* const barejid, const char* const resource, const char* message)
 {
     GList* values = g_hash_table_get_values(plugins);
     if (!values) {
-        return message;
+        return NULL;
     }
 
     char* new_message = NULL;
-    char* curr_message = message;
+    char* curr_message = strdup(message);
 
     GList* curr = values;
     while (curr) {

--- a/src/plugins/plugins.c
+++ b/src/plugins/plugins.c
@@ -571,8 +571,7 @@ plugins_pre_chat_message_send(const char* const barejid, const char* message)
             new_message = plugin->pre_chat_message_send(plugin, barejid, curr_message);
             if (new_message) {
                 free(curr_message);
-                curr_message = strdup(new_message);
-                free(new_message);
+                curr_message = new_message;
             } else {
                 free(curr_message);
                 g_list_free(values);
@@ -617,8 +616,7 @@ plugins_pre_room_message_display(const char* const barejid, const char* const ni
         new_message = plugin->pre_room_message_display(plugin, barejid, nick, curr_message);
         if (new_message) {
             free(curr_message);
-            curr_message = strdup(new_message);
-            free(new_message);
+            curr_message = new_message;
         }
         curr = g_list_next(curr);
     }
@@ -658,8 +656,7 @@ plugins_pre_room_message_send(const char* const barejid, const char* message)
             new_message = plugin->pre_room_message_send(plugin, barejid, curr_message);
             if (new_message) {
                 free(curr_message);
-                curr_message = strdup(new_message);
-                free(new_message);
+                curr_message = new_message;
             } else {
                 free(curr_message);
                 g_list_free(values);
@@ -728,8 +725,7 @@ plugins_pre_priv_message_display(const char* const fulljid, const char* message)
         new_message = plugin->pre_priv_message_display(plugin, jidp->barejid, jidp->resourcepart, curr_message);
         if (new_message) {
             free(curr_message);
-            curr_message = strdup(new_message);
-            free(new_message);
+            curr_message = new_message;
         }
         curr = g_list_next(curr);
     }
@@ -771,8 +767,7 @@ plugins_pre_priv_message_send(const char* const fulljid, const char* const messa
             new_message = plugin->pre_priv_message_send(plugin, jidp->barejid, jidp->resourcepart, curr_message);
             if (new_message) {
                 free(curr_message);
-                curr_message = strdup(new_message);
-                free(new_message);
+                curr_message = new_message;
             } else {
                 free(curr_message);
                 g_list_free(values);
@@ -820,8 +815,7 @@ plugins_on_message_stanza_send(const char* const text)
         new_stanza = plugin->on_message_stanza_send(plugin, curr_stanza);
         if (new_stanza) {
             free(curr_stanza);
-            curr_stanza = strdup(new_stanza);
-            free(new_stanza);
+            curr_stanza = new_stanza;
         }
         curr = g_list_next(curr);
     }
@@ -867,8 +861,7 @@ plugins_on_presence_stanza_send(const char* const text)
         new_stanza = plugin->on_presence_stanza_send(plugin, curr_stanza);
         if (new_stanza) {
             free(curr_stanza);
-            curr_stanza = strdup(new_stanza);
-            free(new_stanza);
+            curr_stanza = new_stanza;
         }
         curr = g_list_next(curr);
     }
@@ -914,8 +907,7 @@ plugins_on_iq_stanza_send(const char* const text)
         new_stanza = plugin->on_iq_stanza_send(plugin, curr_stanza);
         if (new_stanza) {
             free(curr_stanza);
-            curr_stanza = strdup(new_stanza);
-            free(new_stanza);
+            curr_stanza = new_stanza;
         }
         curr = g_list_next(curr);
     }

--- a/src/plugins/plugins.c
+++ b/src/plugins/plugins.c
@@ -569,11 +569,10 @@ plugins_pre_chat_message_send(const char* const barejid, const char* message)
         ProfPlugin* plugin = curr->data;
         if (plugin->contains_hook(plugin, "prof_pre_chat_message_send")) {
             new_message = plugin->pre_chat_message_send(plugin, barejid, curr_message);
+            free(curr_message);
             if (new_message) {
-                free(curr_message);
                 curr_message = new_message;
             } else {
-                free(curr_message);
                 g_list_free(values);
 
                 return NULL;
@@ -654,11 +653,10 @@ plugins_pre_room_message_send(const char* const barejid, const char* message)
         ProfPlugin* plugin = curr->data;
         if (plugin->contains_hook(plugin, "prof_pre_room_message_send")) {
             new_message = plugin->pre_room_message_send(plugin, barejid, curr_message);
+            free(curr_message);
             if (new_message) {
-                free(curr_message);
                 curr_message = new_message;
             } else {
-                free(curr_message);
                 g_list_free(values);
 
                 return NULL;
@@ -765,11 +763,10 @@ plugins_pre_priv_message_send(const char* const fulljid, const char* const messa
         ProfPlugin* plugin = curr->data;
         if (plugin->contains_hook(plugin, "prof_pre_priv_message_send")) {
             new_message = plugin->pre_priv_message_send(plugin, jidp->barejid, jidp->resourcepart, curr_message);
+            free(curr_message);
             if (new_message) {
-                free(curr_message);
                 curr_message = new_message;
             } else {
-                free(curr_message);
                 g_list_free(values);
 
                 return NULL;

--- a/src/plugins/plugins.h
+++ b/src/plugins/plugins.h
@@ -132,7 +132,7 @@ void plugins_on_start(void);
 void plugins_on_connect(const char* const account_name, const char* const fulljid);
 void plugins_on_disconnect(const char* const account_name, const char* const fulljid);
 
-char* plugins_pre_chat_message_display(const char* const barejid, const char* const resource, char* message);
+char* plugins_pre_chat_message_display(const char* const barejid, const char* const resource, const char* message);
 void plugins_post_chat_message_display(const char* const barejid, const char* const resource, const char* message);
 char* plugins_pre_chat_message_send(const char* const barejid, const char* message);
 void plugins_post_chat_message_send(const char* const barejid, const char* message);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -403,7 +403,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
 }
 
 void
-chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, prof_enc_t enc_mode,
+chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, const char* id, prof_enc_t enc_mode,
                      gboolean request_receipt, const char* const replace_id)
 {
     assert(chatwin != NULL);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -307,9 +307,9 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
     }
 
     char* old_plain = message->plain;
-
-    auto_char char* new_plain = plugins_pre_chat_message_display(message->from_jid->barejid, message->from_jid->resourcepart, strdup(message->plain));
-    message->plain = new_plain;
+    auto_char char* new_plain = plugins_pre_chat_message_display(message->from_jid->barejid, message->from_jid->resourcepart, message->plain);
+    if (new_plain)
+        message->plain = new_plain;
 
     gboolean show_message = true;
 
@@ -414,7 +414,8 @@ chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, 
     auto_char char* enc_char = get_enc_char(enc_mode, chatwin->outgoing_char);
 
     const Jid* myjid = connection_get_jid();
-    auto_char char* display_message = plugins_pre_chat_message_display(myjid->barejid, myjid->resourcepart, strdup(message));
+    auto_char char* plugin_message = plugins_pre_chat_message_display(myjid->barejid, myjid->resourcepart, message);
+    const char* display_message = plugin_message ?: message;
 
     if (request_receipt && id) {
         win_print_outgoing_with_receipt((ProfWin*)chatwin, enc_char, "me", display_message, id, replace_id);
@@ -565,8 +566,12 @@ _chatwin_history(ProfChatWin* chatwin, const char* const contact_barejid)
 
         while (curr) {
             ProfMessage* msg = curr->data;
-            msg->plain = plugins_pre_chat_message_display(msg->from_jid->barejid, msg->from_jid->resourcepart, msg->plain);
+            char* old_plain = msg->plain;
+            auto_char char* plugin_msg = plugins_pre_chat_message_display(msg->from_jid->barejid, msg->from_jid->resourcepart, msg->plain);
+            if (plugin_msg)
+                msg->plain = plugin_msg;
             win_print_history((ProfWin*)chatwin, msg);
+            msg->plain = old_plain;
             curr = g_slist_next(curr);
         }
         chatwin->history_shown = TRUE;
@@ -591,12 +596,16 @@ chatwin_db_history(ProfChatWin* chatwin, const char* start_time, char* end_time,
 
     while (curr) {
         ProfMessage* msg = curr->data;
-        msg->plain = plugins_pre_chat_message_display(msg->from_jid->barejid, msg->from_jid->resourcepart, msg->plain);
+        char* old_plain = msg->plain;
+        auto_char char* plugin_msg = plugins_pre_chat_message_display(msg->from_jid->barejid, msg->from_jid->resourcepart, msg->plain);
+        if (plugin_msg)
+            msg->plain = plugin_msg;
         if (flip) {
             win_print_old_history((ProfWin*)chatwin, msg);
         } else {
             win_print_history((ProfWin*)chatwin, msg);
         }
+        msg->plain = old_plain;
         curr = g_slist_next(curr);
     }
 

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -127,7 +127,7 @@ ProfChatWin* chatwin_new(const char* const barejid);
 void chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_created);
 void chatwin_receipt_received(ProfChatWin* chatwin, const char* const id);
 void chatwin_recipient_gone(ProfChatWin* chatwin);
-void chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, prof_enc_t enc_mode, gboolean request_receipt, const char* const replace_id);
+void chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, const char* id, prof_enc_t enc_mode, gboolean request_receipt, const char* const replace_id);
 void chatwin_outgoing_carbon(ProfChatWin* chatwin, ProfMessage* message);
 void chatwin_contact_online(ProfChatWin* chatwin, Resource* resource, GDateTime* last_activity);
 void chatwin_contact_offline(ProfChatWin* chatwin, char* resource, char* status);

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -1617,7 +1617,7 @@ win_print_http_transfer(ProfWin* window, const char* const message, char* id)
 }
 
 void
-win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, const char* const from, const char* const message, char* id, const char* const replace_id)
+win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, const char* const from, const char* const message, const char* id, const char* const replace_id)
 {
     GDateTime* time = g_date_time_new_now_local();
 

--- a/src/ui/window.h
+++ b/src/ui/window.h
@@ -65,7 +65,7 @@ void win_show_status_string(ProfWin* window, const char* const from,
 void win_print_them(ProfWin* window, theme_item_t theme_item, const char* const show_char, int flags, const char* const them);
 void win_print_incoming(ProfWin* window, const char* const from, ProfMessage* message);
 void win_print_outgoing(ProfWin* window, const char* show_char, const char* const id, const char* const replace_id, const char* const message);
-void win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, const char* const from, const char* const message, char* id, const char* const replace_id);
+void win_print_outgoing_with_receipt(ProfWin* window, const char* show_char, const char* const from, const char* const message, const char* id, const char* const replace_id);
 void win_println_incoming_muc_msg(ProfWin* window, char* show_char, int flags, const ProfMessage* const message);
 void win_print_outgoing_muc_msg(ProfWin* window, char* show_char, const char* const me, const char* const id, const char* const replace_id, const char* const message);
 void win_print_history(ProfWin* window, const ProfMessage* const message);

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -277,7 +277,7 @@ chatwin_recipient_gone(ProfChatWin* chatwin)
 }
 
 void
-chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, char* id, prof_enc_t enc_mode, gboolean request_receipt, const char* const replace_id)
+chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, const char* id, prof_enc_t enc_mode, gboolean request_receipt, const char* const replace_id)
 {
 }
 void


### PR DESCRIPTION
Check commit messages for details.

In order to keep the plugins API stable, we have to partially revert 16ed7cc18720820e22fba881fc50df7ead42ffb2.