### PR TITLE
Fix tests with gcc15 (uintptr_t)

### DIFF
--- a/tests/unittests/config/stub_accounts.c
+++ b/tests/unittests/config/stub_accounts.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 

--- a/tests/unittests/log/stub_log.c
+++ b/tests/unittests/log/stub_log.c
@@ -20,6 +20,7 @@
  *
  */
 
+#include <stdint.h>
 #include <glib.h>
 #include <setjmp.h>
 #include <cmocka.h>

--- a/tests/unittests/test_autocomplete.c
+++ b/tests/unittests/test_autocomplete.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>

--- a/tests/unittests/test_chat_session.c
+++ b/tests/unittests/test_chat_session.c
@@ -4,6 +4,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "xmpp/chat_session.h"
 

--- a/tests/unittests/test_common.c
+++ b/tests/unittests/test_common.c
@@ -5,6 +5,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 void
 replace_one_substr(void** state)

--- a/tests/unittests/test_jid.c
+++ b/tests/unittests/test_jid.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>

--- a/tests/unittests/test_parser.c
+++ b/tests/unittests/test_parser.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>

--- a/tests/unittests/test_preferences.c
+++ b/tests/unittests/test_preferences.c
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>

--- a/tests/unittests/test_roster_list.c
+++ b/tests/unittests/test_roster_list.c
@@ -5,6 +5,7 @@
 #include <setjmp.h>
 #include <cmocka.h>
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "xmpp/contact.h"
 #include "xmpp/roster_list.h"


### PR DESCRIPTION
on openSUSE Tumbleweed, when running tests and using gcc15:

````
[   13s] In file included from tests/unittests/test_preferences.c:4:
[   13s] tests/unittests/test_preferences.c: In function ‘statuses_console_defaults_to_all’:
[   13s] tests/unittests/test_preferences.c:16:5: error: ‘uintptr_t’ undeclared (first use in this function)
[   13s]    16 |     assert_non_null(setting);
[   13s]       |     ^~~~~~~~~~~~~~~
[   13s] tests/unittests/test_preferences.c:10:1: note: ‘uintptr_t’ is defined in header ‘<stdint.h>’; this is probably fixable by adding ‘#include <stdint.h>’
[   13s]     9 | #include "config/preferences.h"
[   13s]   +++ |+#include <stdint.h>
[   13s]    10 |
````

Investigation shows that this is exclusive to gcc15, and `tests/`. This PR fixes `error: ‘uintptr_t’ undeclared` by including the header ‘<stdint.h>` that defines this symbol.

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature

Sorry, not set up here.

### How to test the functionality

* `make check` on openSUSE Tumbleweed

