### PR TITLE
Fix keyfile warning messages for non-critical files

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -131,6 +131,8 @@ load_config_keyfile(prof_keyfile_t* keyfile, const char* filename);
 gboolean
 load_custom_keyfile(prof_keyfile_t* keyfile, gchar* filename);
 gboolean
+load_custom_keyfile_quiet(prof_keyfile_t* keyfile, gchar* filename, gboolean suppress_missing_warnings);
+gboolean
 save_keyfile(prof_keyfile_t* keyfile);
 void
 free_keyfile(prof_keyfile_t* keyfile);

--- a/src/config/tlscerts.c
+++ b/src/config/tlscerts.c
@@ -75,7 +75,8 @@ tlscerts_init(void)
 
     prof_add_shutdown_routine(_tlscerts_close);
 
-    load_data_keyfile(&tlscerts_prof_keyfile, FILE_TLSCERTS);
+    auto_gchar gchar* loc = files_get_data_path(FILE_TLSCERTS);
+    load_custom_keyfile_quiet(&tlscerts_prof_keyfile, loc, TRUE);
     tlscerts = tlscerts_prof_keyfile.keyfile;
 
     certs_ac = autocomplete_new();

--- a/src/tools/bookmark_ignore.c
+++ b/src/tools/bookmark_ignore.c
@@ -53,7 +53,8 @@ static gchar* account_jid = NULL;
 static void
 _bookmark_ignore_load()
 {
-    load_data_keyfile(&bookmark_ignore_prof_keyfile, FILE_BOOKMARK_AUTOJOIN_IGNORE);
+    auto_gchar gchar* loc = files_get_data_path(FILE_BOOKMARK_AUTOJOIN_IGNORE);
+    load_custom_keyfile_quiet(&bookmark_ignore_prof_keyfile, loc, TRUE);
     bookmark_ignore_keyfile = bookmark_ignore_prof_keyfile.keyfile;
 }
 


### PR DESCRIPTION
Resolves issue #1911 by suppressing unimportant warning messages for missing keyfiles that are normal to not exist during initial runs.

Changes:
- Added load_custom_keyfile_quiet() function to src/common.h/c
- Modified _load_keyfile() to accept suppress_missing_warnings parameter
- Updated bookmark_ignore.c to use quiet loading for bookmark_ignore file
- Updated tlscerts.c to use quiet loading for tlscerts file

Missing files now log as debug messages instead of warnings for:
- ~/.local/share/profanity/bookmark_ignore
- ~/.local/share/profanity/tlscerts

Important keyfiles still show warnings when missing to maintain proper error visibility for critical configuration files.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

<!-- For completed items, change [ ] to [x]. -->
- [ x] I ran valgrind when using my new feature

### How to test the functionality
* step 1
compile with make / configure first
* step 2
use the command "./profanity