### PR TITLE
Add types to function prototypes

### DIFF
--- a/src/tools/bookmark_ignore.h
+++ b/src/tools/bookmark_ignore.h
@@ -36,7 +36,7 @@
 #ifndef BOOKMARK_IGNORE_H
 #define BOOKMARK_IGNORE_H
 
-void bookmark_ignore_on_connect();
+void bookmark_ignore_on_connect(const char* const barejid);
 void bookmark_ignore_on_disconnect();
 gboolean bookmark_ignored(Bookmark* bookmark);
 gchar** bookmark_ignore_list(gsize* len);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -288,7 +288,7 @@ void cons_show_disco_info(const char* from, GSList* identities, GSList* features
 
 void cons_show_disco_contact_information(GHashTable* addresses);
 
-void cons_show_qrcode();
+void cons_show_qrcode(const char* const text);
 
 void cons_show_room_invite(const char* const invitor, const char* const room, const char* const reason);
 void cons_check_version(gboolean not_available_msg);


### PR DESCRIPTION
Running make (macOS, Clang 16.0.0) results in errors complaining about passing arguments without function prototypes.

Specifically:
- bookmark_ignore_on_connect()
- cons_show_qrcode()

Adding parameters to prototypes results in successful build.