### PR TITLE
Fix OTR whitespace tag detection to prevent false positives

### DIFF
--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -296,7 +296,8 @@ otr_on_message_recv(const char* const barejid, const char* const resource, const
     // check for OTR whitespace (opportunistic or always)
     if (policy == PROF_OTRPOLICY_OPPORTUNISTIC || policy == PROF_OTRPOLICY_ALWAYS) {
         if (whitespace_base) {
-            if (strstr(message, OTRL_MESSAGE_TAG_V2) || strstr(message, OTRL_MESSAGE_TAG_V1)) {
+            char* tag_position = whitespace_base + strlen(OTRL_MESSAGE_TAG_BASE);
+            if (strncmp(tag_position, OTRL_MESSAGE_TAG_V2, strlen(OTRL_MESSAGE_TAG_V2)) == 0 || strncmp(tag_position, OTRL_MESSAGE_TAG_V1, strlen(OTRL_MESSAGE_TAG_V1)) == 0) {
                 // Remove whitespace pattern for proper display in UI
                 // Handle both BASE+TAGV1/2(16+8) and BASE+TAGV1+TAGV2(16+8+8)
                 int tag_length = 24;


### PR DESCRIPTION
## Description
   Fixes OTR whitespace tag false positive detection.
   
   ## Problem
   The current implementation uses `strstr()` to detect OTR whitespace tags, which matches the pattern anywhere in the message. This causes normal user messages containing these patterns to incorrectly trigger OTR session initialization.
   
   ## Solution
   Changed to use `strncmp()` to verify that V1/V2 tags immediately follow the base tag, ensuring only legitimate OTR whitespace tags trigger session establishment.
   
   ## Testing
   Built and tested on macOS with libotr 4.1.1.