### PR TITLE
Set PAD_SIZE back to 1000

### DIFF
--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -62,7 +62,7 @@
 #include "xmpp/xmpp.h"
 #include "xmpp/roster_list.h"
 
-static const int PAD_SIZE = 100;
+static const int PAD_SIZE = 1000;
 static const char* LOADING_MESSAGE = "Loading older messages…";
 static const char* CONS_WIN_TITLE = "Profanity. Type /help for help information.";
 static const char* XML_WIN_TITLE = "XML Console";


### PR DESCRIPTION
PAD_SIZE was set to 100 in f27fa98
Set PAD_SIZE back to 1000 to fix the `Ncurses Overflow! ... pos: 99, ...` problem.

Fixes: #2045
Fixes: f27fa98