### PR TITLE
Update compiler flags for homebrew packages on Apple silicon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,9 +336,9 @@ AM_CONDITIONAL([BUILD_OMEMO], [false])
 if test "x$enable_omemo" != xno; then
     OMEMO_LIBS=""
     PKG_CHECK_MODULES([libsignal], [libsignal-protocol-c >= 2.3.2],
-        [OMEMO_LIBS="-lsignal-protocol-c"
-         AC_CHECK_LIB([gcrypt], [gcry_md_extract],
-             [OMEMO_LIBS="-lgcrypt $OMEMO_LIBS"
+        [OMEMO_LIBS="$libsignal_LIBS"
+         PKG_CHECK_MODULES([gcrypt], [libgcrypt >= 1.7.0],
+             [OMEMO_LIBS="$gcrypt_LIBS $OMEMO_LIBS"
               AM_CONDITIONAL([BUILD_OMEMO], [true])],
              [AC_MSG_NOTICE([gcrypt >= 1.7.0 not found, OMEMO support not enabled])])],
         [AC_MSG_NOTICE([libsignal-protocol-c >= 2.3.2 not found, OMEMO support not enabled])])


### PR DESCRIPTION
Add /opt/homebrew/{include,lib} flags for apple silicon Macs.

Homebrew moved from /usr/local to /opt/homebrew for Apple silicon Macs, but /opt/homebrew/{include,lib} are not included as default search paths by Clang/GCC.

As a result, without adding these paths, running 'make' fails with errors complaining that <gcrypt.h>, <signal/key_helper.h> etc cannot be found.
<br/>
**UPDATE:**

Use PKG_CHECK_MODULES to check for libgcrypt: previously `./configure --enable-omemo` resulted in

> configure: gcrypt >= 1.7.0 not found, OMEMO support not enabled
> configure: error: OMEMO support requires a library which is missed

despite libgcrypt being installed.
