### PR TITLE
profanity: exit gracefully on SIGTERM and SIGHUP

### DIFF
--- a/src/profanity.c
+++ b/src/profanity.c
@@ -196,6 +196,13 @@ _connect_default(const char* const account)
 }
 
 static void
+sigterm_handler(int sig)
+{
+    log_info("Received signal %d, exiting", sig);
+    force_quit = TRUE;
+}
+
+static void
 _init(char* log_level, char* config_file, char* log_file, char* theme_name)
 {
     setlocale(LC_ALL, "");
@@ -204,6 +211,8 @@ _init(char* log_level, char* config_file, char* log_file, char* theme_name)
     signal(SIGINT, SIG_IGN);
     signal(SIGTSTP, SIG_IGN);
     signal(SIGWINCH, ui_sigwinch_handler);
+    signal(SIGTERM, sigterm_handler);
+    signal(SIGHUP, sigterm_handler);
     if (pthread_mutex_init(&lock, NULL) != 0) {
         log_error("Mutex init failed");
         exit(1);


### PR DESCRIPTION
<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature

### How to test the functionality
* step 1

Launch profanity and connect to server. Verify it can be seen as connected by other clients.

* step 2

Send SIGTERM to it or close the terminal it's running in. Verify in the other clients that it immediately comes offline, rather than only after a while when the connection times out.
