### PR TITLE
ci: reenable Arch and Tumbleweed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        flavor: [debian, fedora, ubuntu]
+        flavor: [debian, fedora, tumbleweed, ubuntu]
 
     name: Linux
     steps:


### PR DESCRIPTION
This reverts commit 58d130a0a930fe94eca241d6885d838ce73fbaa4.
This reverts commit 47860731716a443edac245958c1e74fa1bc97e8e.
