### PR TITLE
fix: Ignore self-presence for untracked MUC rooms

### DIFF
--- a/src/xmpp/presence.c
+++ b/src/xmpp/presence.c
@@ -813,7 +813,12 @@ _muc_user_self_handler(xmpp_stanza_t* stanza)
                 affiliation = xmpp_stanza_get_attribute(item, "affiliation");
             }
         }
-        sv_ev_muc_self_online(room, nick, config_required, role, affiliation, actor, reason, jid, show_str, status_str);
+
+        if (muc_active(room)) {
+            sv_ev_muc_self_online(room, nick, config_required, role, affiliation, actor, reason, jid, show_str, status_str);
+        } else {
+            log_debug("presence: self-presence received for untracked room: %s", room);
+        }
     }
 }
 


### PR DESCRIPTION
Only handle self-presence for rooms we are actively managing.

Earlier we blindly react to any self-presence
stanza by calling 'ui_room_join'.

The join could have been initiated by another client or an external Gateway. In the case of #731 this was Slack.
I remember that more people reported this kind of bug in our MUC.

We then would open a window and the nick would be (null) because we don't have any nickname for that room set.

So only react on self-presence if we manage the MUC. Other XMPP clients do the same.

Fix https://github.com/profanity-im/profanity/issues/731