### PR TITLE
fix: Fix not saving first created account

### DIFF
--- a/src/config/accounts.c
+++ b/src/config/accounts.c
@@ -100,23 +100,14 @@ _accounts_save(const char* account_name)
 
     auto_gchar gchar* sanitized = _sanitize_account_name(account_name);
 
-    gsize written = 0;
     if (_accounts_has_group(sanitized)) {
-        gsize naccounts;
-        auto_gcharv gchar** account_names = g_key_file_get_groups(current.keyfile, &naccounts);
-        for (gsize i = 0; i < naccounts; i++) {
-            /* EITHER current already contains the account, OR we're at the end of
-             * the list of accounts and we should add this new one.
-             */
-            if (g_strcmp0(sanitized, account_names[i]) && (i != naccounts - 1))
-                continue;
-            gsize nkeys;
-            auto_gcharv gchar** keys = g_key_file_get_keys(accounts_prof_keyfile.keyfile, sanitized, &nkeys, NULL);
+        gsize nkeys;
+        auto_gcharv gchar** keys = g_key_file_get_keys(accounts_prof_keyfile.keyfile, sanitized, &nkeys, NULL);
+        if (keys) {
             for (gsize j = 0; j < nkeys; ++j) {
                 auto_gchar gchar* new_value = g_key_file_get_value(accounts_prof_keyfile.keyfile, sanitized, keys[j], NULL);
                 g_key_file_set_value(current.keyfile, sanitized, keys[j], new_value);
             }
-            written++;
         }
     } else {
         g_key_file_remove_group(current.keyfile, sanitized, NULL);


### PR DESCRIPTION
Commit 81f92f1fe introduced a selective update mechanism to _accounts_save() to prevent overwrites when running multiple instances by only modifying the specific account being saved.

There was one mistake: the logic for adding a new
account was tied to the final iteration of a loop over existing accounts.

When starting with an empty accounts file, the
loop never executes though.

We can call g_key_file_set_value() directly and don't need the loop because this function will only modify one entry or add it if it doesn't exist.

I didn't test this PR.