### PR TITLE
fix: Dont OMEMO trust check so often

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -598,6 +598,8 @@ _sv_ev_incoming_omemo(ProfChatWin* chatwin, gboolean new_win, ProfMessage* messa
         chat_log_omemo_msg_in(message);
     }
     chatwin->pgp_recv = FALSE;
+
+    wins_omemo_trust_changed(chatwin->barejid);
 #endif
 }
 

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -144,6 +144,8 @@ omemo_init(void)
     pthread_mutex_init(&omemo_static_data.lock, &omemo_static_data.attr);
 
     omemo_static_data.fingerprint_ac = g_hash_table_new_full(g_str_hash, g_str_equal, free, (GDestroyNotify)autocomplete_free);
+
+    wins_omemo_trust_changed(NULL);
 }
 
 static gboolean
@@ -274,6 +276,8 @@ omemo_on_connect(ProfAccount* account)
     }
 
     _omemo_finalize_identity_load(account);
+
+    wins_omemo_trust_changed(NULL);
 }
 
 void
@@ -298,6 +302,8 @@ omemo_on_disconnect(void)
     signal_protocol_store_context_destroy(omemo_ctx.store);
     signal_context_destroy(omemo_ctx.signal);
     memset(&omemo_ctx, 0, sizeof(omemo_ctx));
+
+    wins_omemo_trust_changed(NULL);
 }
 
 void
@@ -598,6 +604,8 @@ omemo_set_device_list(const char* const from, GList* device_list)
             }
         }
     }
+
+    wins_omemo_trust_changed(jid->barejid);
 }
 
 GKeyFile*
@@ -1505,6 +1513,8 @@ omemo_trust(const char* const jid, const char* const fingerprint_formatted)
     signal_buffer_free(buffer);
 
     omemo_bundle_request(jid, device_id, omemo_start_device_session_handle_bundle, free, strdup(jid));
+
+    wins_omemo_trust_changed(jid);
 }
 
 void
@@ -1567,6 +1577,8 @@ omemo_untrust(const char* const jid, const char* const fingerprint_formatted)
     auto_gchar gchar* device_id_str = g_strdup_printf("%d", device_id);
     g_key_file_remove_key(omemo_ctx.trust.keyfile, jid, device_id_str, NULL);
     omemo_trust_keyfile_save();
+
+    wins_omemo_trust_changed(jid);
 }
 
 static void
@@ -1968,6 +1980,8 @@ _cache_device_identity(const char* const jid, uint32_t device_id, ec_public_key*
         free(formatted_fingerprint);
     }
     free(fingerprint);
+
+    wins_omemo_trust_changed(jid);
 }
 
 static void

--- a/src/ui/titlebar.c
+++ b/src/ui/titlebar.c
@@ -431,7 +431,7 @@ _show_muc_privacy(ProfMucWin* mucwin)
         wattroff(win, bracket_attrs);
 
 #ifdef HAVE_OMEMO
-        if (omemo_is_jid_trusted(mucwin->roomjid)) {
+        if (mucwin->omemo_trusted) {
             wprintw(win, " ");
             wattron(win, bracket_attrs);
             wprintw(win, "[");
@@ -586,7 +586,7 @@ _show_privacy(ProfChatWin* chatwin)
         wattroff(win, bracket_attrs);
 
 #ifdef HAVE_OMEMO
-        if (omemo_is_jid_trusted(chatwin->barejid)) {
+        if (chatwin->omemo_trusted) {
             wprintw(win, " ");
             wattron(win, bracket_attrs);
             wprintw(win, "[");

--- a/src/ui/win_types.h
+++ b/src/ui/win_types.h
@@ -177,6 +177,7 @@ typedef struct prof_chat_win_t
     gboolean pgp_send;
     gboolean pgp_recv;
     gboolean is_omemo;
+    gboolean omemo_trusted;
     gboolean is_ox; // XEP-0373: OpenPGP for XMPP
     char* resource_override;
     gboolean history_shown;
@@ -201,6 +202,7 @@ typedef struct prof_muc_win_t
     gboolean showjid;
     gboolean showoffline;
     gboolean is_omemo;
+    gboolean omemo_trusted;
     unsigned long memcheck;
     char* enctext;
     char* message_char;

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -36,6 +36,9 @@
 
 #include "config.h"
 #include "ui/window_list.h"
+#ifdef HAVE_OMEMO
+#include "omemo/omemo.h"
+#endif
 
 #include <stdlib.h>
 #include <string.h>
@@ -154,6 +157,9 @@ win_create_chat(const char* const barejid)
     new_win->pgp_recv = FALSE;
     new_win->pgp_send = FALSE;
     new_win->is_omemo = FALSE;
+#ifdef HAVE_OMEMO
+    new_win->omemo_trusted = omemo_is_jid_trusted(barejid);
+#endif
     new_win->is_ox = FALSE;
     new_win->history_shown = FALSE;
     new_win->unread = 0;
@@ -217,6 +223,9 @@ win_create_muc(const char* const roomjid)
     new_win->enctext = NULL;
     new_win->message_char = NULL;
     new_win->is_omemo = FALSE;
+#ifdef HAVE_OMEMO
+    new_win->omemo_trusted = omemo_is_jid_trusted(roomjid);
+#endif
     new_win->last_message = NULL;
     new_win->last_msg_id = NULL;
     new_win->has_attention = FALSE;

--- a/src/ui/window_list.c
+++ b/src/ui/window_list.c
@@ -994,6 +994,31 @@ _wins_get_next_available_num(GList* used)
     }
 }
 
+void
+wins_omemo_trust_changed(const char* const jid)
+{
+    GList* curr = values;
+    while (curr) {
+        ProfWin* window = curr->data;
+        if (window->type == WIN_CHAT) {
+            ProfChatWin* chatwin = (ProfChatWin*)window;
+            if (jid == NULL || strcmp(chatwin->barejid, jid) == 0) {
+#ifdef HAVE_OMEMO
+                chatwin->omemo_trusted = omemo_is_jid_trusted(chatwin->barejid);
+#endif
+            }
+        } else if (window->type == WIN_MUC) {
+            ProfMucWin* mucwin = (ProfMucWin*)window;
+            if (jid == NULL || strcmp(mucwin->roomjid, jid) == 0) {
+#ifdef HAVE_OMEMO
+                mucwin->omemo_trusted = omemo_is_jid_trusted(mucwin->roomjid);
+#endif
+            }
+        }
+        curr = g_list_next(curr);
+    }
+}
+
 gboolean
 wins_tidy(void)
 {

--- a/src/ui/window_list.h
+++ b/src/ui/window_list.h
@@ -88,6 +88,7 @@ GSList* wins_get_chat_recipients(void);
 GSList* wins_get_prune_wins(void);
 void wins_lost_connection(void);
 void wins_reestablished_connection(void);
+void wins_omemo_trust_changed(const char* const jid);
 gboolean wins_tidy(void);
 GSList* wins_create_summary(gboolean unread);
 GSList* wins_create_summary_attention();


### PR DESCRIPTION
a26cdf386bfec381563294342f2152a5c0eb677e / #2104 added OMEMO trust status to the title bar, but it was being re-calculated on UI refresh.

Update only on certain operations (like `/omemo trust`, new device discoveries and even incoming OMEMO messages for example).