### PR TITLE
fix(xmpp): prevent crash when login into a server with disabled certificates

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -1139,6 +1139,14 @@ sv_ev_muc_occupant_online(const char* const room, const char* const nick, const 
 int
 sv_ev_certfail(const char* const errormsg, const TLSCertificate* cert)
 {
+    if (cert == NULL) {
+        cons_show("");
+        cons_show_error("TLS certificate verification failed: %s", (errormsg != NULL) ? errormsg : "Unknown error");
+        cons_show_error("No certificate information was provided by the server.");
+        cons_show("");
+        return 0;
+    }
+
     // check profanity trusted certs
     if (tlscerts_exists(cert)) {
         cafile_add(cert);

--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -1060,12 +1060,16 @@ _connection_certfail_cb(const xmpp_tlscert_t* xmpptlscert, const char* errormsg)
 TLSCertificate*
 _xmppcert_to_profcert(const xmpp_tlscert_t* xmpptlscert)
 {
+    if (xmpptlscert == NULL) {
+        return NULL;
+    }
+
     const char* pubkey_fp = NULL;
 #ifdef HAVE_XMPP_CERT_PUBKEY_FINGERPRINT_SHA256
     pubkey_fp = xmpp_tlscert_get_string(xmpptlscert, XMPP_CERT_PUBKEY_FINGERPRINT_SHA256);
 #endif
-    int version = (int)strtol(
-        xmpp_tlscert_get_string(xmpptlscert, XMPP_CERT_VERSION), NULL, 10);
+    const char* version_str = xmpp_tlscert_get_string(xmpptlscert, XMPP_CERT_VERSION);
+    int version = (version_str != NULL) ? (int)strtol(version_str, NULL, 10) : 0;
     return tlscerts_new(
         xmpp_tlscert_get_string(xmpptlscert, XMPP_CERT_FINGERPRINT_SHA1),
         version,


### PR DESCRIPTION
If a server does not provide a certificate we need to print an error message if we want to connect with tls.

This change does not effect `/tls disable`. So it's only for `/tls force`, `/tls trust` and `/tls legacy`.

Fixes https://github.com/profanity-im/profanity/issues/2114