### PR TITLE
Add support for libomemo-c as OMEMO backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,23 @@ Both build systems support several features that can be enabled or disabled.
 | **OTR** | Off-the-Record encryption | `--enable-otr` | `-Dotr=enabled` |
 | **PGP** | PGP encryption support | `--enable-pgp` | `-Dpgp=enabled` |
 | **OMEMO** | OMEMO encryption support | `--enable-omemo` | `-Domemo=enabled` |
+| **OMEMO Backend** | Select OMEMO backend library | *N/A* | `-Domemo-backend=libsignal\|libomemo-c` |
 | **QR Code** | OMEMO QR code display | `--enable-omemo-qrcode` | `-Domemo-qrcode=enabled` |
 | **Icons/Clipboard** | GTK tray icons & clipboard | `--enable-icons-and-clipboard` | `-Dicons-and-clipboard=enabled` |
 | **GDK Pixbuf** | Avatar scaling support | `--enable-gdk-pixbuf` | `-Dgdk-pixbuf=enabled` |
 | **XScreenSaver** | Idle time detection | `--with-xscreensaver` | `-Dxscreensaver=enabled` |
 | **Tests** | Build unit tests | *Built by default* | `-Dtests=true` |
 | **Sanitizers** | Run-time error detection | *Via CFLAGS* | `-Db_sanitize=address,undefined` |
+
+### Selecting OMEMO Backend
+When building with OMEMO support enabled in Meson, you can choose between two backend libraries:
+- `libsignal`: The default backend using `libsignal-protocol-c`.
+- `libomemo-c`: An alternative backend using `libomemo-c`.
+
+Example of choosing the `libomemo-c` backend:
+```bash
+meson setup build_run -Domemo=enabled -Domemo-backend=libomemo-c
+```
 
 ### Using Autotools
 1. Generate configuration files: `./bootstrap.sh`

--- a/meson.build
+++ b/meson.build
@@ -157,7 +157,7 @@ dl_dep = disabler()
 gpgme_dep = disabler()
 libotr_dep = disabler()
 gdk_pixbuf_dep = disabler()
-libsignal_dep = disabler()
+omemo_dep = disabler()
 gcrypt_dep = disabler()
 qrencode_dep = disabler()
 
@@ -251,7 +251,13 @@ endif
 
 # OMEMO support
 if get_option('omemo').enabled()
-  libsignal_dep = dependency('libsignal-protocol-c', version: '>= 2.3.2', required: true)
+  omemo_backend = get_option('omemo-backend')
+  if omemo_backend == 'libsignal'
+    omemo_dep = dependency('libsignal-protocol-c', version: '>= 2.3.2', required: true)
+  elif omemo_backend == 'libomemo-c'
+    omemo_dep = dependency('libomemo-c', version: '>= 0.5.1', required: true)
+    conf_data.set('HAVE_LIBOMEMO_C', 1)
+  endif
   gcrypt_dep = dependency('libgcrypt', version: '>= 1.7.0', required: true)
   build_omemo = true
   conf_data.set('HAVE_OMEMO', 1)
@@ -337,8 +343,8 @@ if gdk_pixbuf_dep.found()
   profanity_deps += gdk_pixbuf_dep
 endif
 
-if libsignal_dep.found()
-  profanity_deps += libsignal_dep
+if omemo_dep.found()
+  profanity_deps += omemo_dep
 endif
 
 if gcrypt_dep.found()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,6 +35,13 @@ option('omemo',
   description: 'Enable OMEMO encryption'
 )
 
+option('omemo-backend',
+  type: 'combo',
+  choices: ['libsignal', 'libomemo-c'],
+  value: 'libsignal',
+  description: 'Select OMEMO backend library'
+)
+
 option('xscreensaver',
   type: 'feature',
   value: 'disabled',

--- a/src/omemo/crypto.c
+++ b/src/omemo/crypto.c
@@ -9,8 +9,13 @@
 #include "config.h"
 
 #include <assert.h>
+#ifdef HAVE_LIBOMEMO_C
+#include <omemo/signal_protocol.h>
+#include <omemo/signal_protocol_types.h>
+#else
 #include <signal/signal_protocol.h>
 #include <signal/signal_protocol_types.h>
+#endif
 
 #include "log.h"
 #include "omemo/omemo.h"

--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -16,11 +16,20 @@
 #include <errno.h>
 #include <glib.h>
 #include <pthread.h>
+
+#ifdef HAVE_LIBOMEMO_C
+#include <omemo/key_helper.h>
+#include <omemo/protocol.h>
+#include <omemo/signal_protocol.h>
+#include <omemo/session_builder.h>
+#include <omemo/session_cipher.h>
+#else
 #include <signal/key_helper.h>
 #include <signal/protocol.h>
 #include <signal/signal_protocol.h>
 #include <signal/session_builder.h>
 #include <signal/session_cipher.h>
+#endif
 
 #include "config/account.h"
 #include "config/files.h"

--- a/src/omemo/store.c
+++ b/src/omemo/store.c
@@ -7,7 +7,12 @@
  * SPDX-License-Identifier: GPL-3.0-or-later WITH OpenSSL-exception
  */
 #include <glib.h>
+
+#ifdef HAVE_LIBOMEMO_C
+#include <omemo/signal_protocol.h>
+#else
 #include <signal/signal_protocol.h>
+#endif
 
 #include "config.h"
 #include "log.h"


### PR DESCRIPTION
Add the ability to choose between libsignal-protocol-c (default) and libomemo-c when building with OMEMO support enabled in Meson.

This PR is in favour of https://github.com/profanity-im/profanity/pull/2020.
