### PR TITLE
fix(omemo): add missing includes for libomemo-c builds

### DIFF
--- a/src/omemo/crypto.h
+++ b/src/omemo/crypto.h
@@ -8,7 +8,14 @@
  */
 #include <stdio.h>
 #include <stdbool.h>
+#include "config.h"
+
+#ifdef HAVE_LIBOMEMO_C
+#include <omemo/signal_protocol_types.h>
+#else
 #include <signal/signal_protocol_types.h>
+#endif
+
 #include <gcrypt.h>
 
 #define AES128_GCM_KEY_LENGTH 16

--- a/src/omemo/store.c
+++ b/src/omemo/store.c
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later WITH OpenSSL-exception
  */
 #include <glib.h>
+#include "config.h"
 
 #ifdef HAVE_LIBOMEMO_C
 #include <omemo/signal_protocol.h>
@@ -14,7 +15,6 @@
 #include <signal/signal_protocol.h>
 #endif
 
-#include "config.h"
 #include "log.h"
 #include "omemo/omemo.h"
 #include "omemo/store.h"

--- a/src/omemo/store.h
+++ b/src/omemo/store.h
@@ -6,9 +6,13 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later WITH OpenSSL-exception
  */
-#include <signal/signal_protocol.h>
-
 #include "config.h"
+
+#ifdef HAVE_LIBOMEMO_C
+#include <omemo/signal_protocol.h>
+#else
+#include <signal/signal_protocol.h>
+#endif
 
 #define OMEMO_STORE_GROUP_IDENTITY           "identity"
 #define OMEMO_STORE_GROUP_PREKEYS            "prekeys"


### PR DESCRIPTION
<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

<!-- For completed items, change [ ] to [x]. -->
- [x] I ran valgrind when using my new feature

This pr fixes some missing `libomemo-c` imports and usages of `HAVE_LIBOMEMO_C` before import `config.h`. 

The reason for this pr is the failing homebrew build: https://github.com/Homebrew/homebrew-core/pull/274439

## Changes by file

- `src/omemo/crypto.h`: add missing `libomemo-c` imports (selection via `HAVE_LIBOMEMO_C`) and import `config.h` (for `HAVE_LIBOMEMO_C`)
- `src/omemo/store.h`: add missing `libomemo-c` imports (selection via `HAVE_LIBOMEMO_C`)
- `src/omemo/store.c`: move `config.h` before the conditional include so the compile-time flag is defined before header selection.