### PR TITLE
chore: support building libstrophe as a subproject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@
 ### Build Options
 Meson requires features to be **explicitly enabled**. Nothing is auto-enabled; if you want a feature, you must pass the corresponding `-Doption=enabled` flag.
 
+The system libstrophe is used by default; if you instead want to automatically download and link against libstrophe HEAD from upstream Git, provide `-Dforce_fallback_for=libstrophe` flag.
+
 | Feature | Description | Meson option |
 | :--- | :--- | :--- |
 | **Notifications** | Desktop notifications support | `-Dnotifications=enabled` |

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('profanity', 'c',
   default_options: [
     'c_std=gnu99',
     'warning_level=2',
+    'wrap_mode=nofallback',
   ]
 )
 
@@ -98,13 +99,17 @@ math_dep = cc.find_library('m')
 libstrophe_dep = dependency('libstrophe', version: '>= 0.12.3')
 
 # Check for XMPP_CERT_PUBKEY_FINGERPRINT_SHA256 support
-if cc.links('''
-  #include <strophe.h>
-  int main() {
-    xmpp_tlscert_get_string(NULL, XMPP_CERT_PUBKEY_FINGERPRINT_SHA256);
-    return 1;
-  }
-  ''', dependencies: libstrophe_dep)
+if libstrophe_dep.type_name() != 'internal'
+  if cc.links('''
+    #include <strophe.h>
+    int main() {
+      xmpp_tlscert_get_string(NULL, XMPP_CERT_PUBKEY_FINGERPRINT_SHA256);
+      return 1;
+    }
+    ''', dependencies: libstrophe_dep)
+    conf_data.set('HAVE_XMPP_CERT_PUBKEY_FINGERPRINT_SHA256', 1)
+  endif
+else
   conf_data.set('HAVE_XMPP_CERT_PUBKEY_FINGERPRINT_SHA256', 1)
 endif
 

--- a/subprojects/libstrophe.wrap
+++ b/subprojects/libstrophe.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/strophe/libstrophe.git
+revision = HEAD
+patch_directory = libstrophe

--- a/subprojects/packagefiles/libstrophe/meson.build
+++ b/subprojects/packagefiles/libstrophe/meson.build
@@ -1,0 +1,19 @@
+project('libstrophe', 'c',
+  meson_version : '>=0.60.3',
+  version : run_command('git', 'describe',  '--tags', check : true).stdout().strip(),
+)
+
+mod = import('unstable-external_project')
+
+run_command('bootstrap.sh', check : true)
+
+p = mod.add_project('configure',
+  configure_options : ['--prefix=@PREFIX@',
+                       '--libdir=@PREFIX@/@LIBDIR@',
+                       '--includedir=@PREFIX@/@INCLUDEDIR@',
+                      ],
+  verbose : true
+)
+
+libstrophe_dep = p.dependency('strophe')
+meson.override_dependency('libstrophe', libstrophe_dep)


### PR DESCRIPTION
When pkg-config doesn't find usable libstrophe this will download and build it automatically.
