### PR TITLE
omemo: ignore key contents if there is no payload

### DIFF
--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -1141,16 +1141,16 @@ omemo_on_message_recv(const char* const from_jid, uint32_t sid,
         return NULL;
     }
 
+    if (payload == NULL) {
+        signal_buffer_free(plaintext_key);
+        *error = OMEMO_ERR_KEY_TRANSPORT;
+        return NULL;
+    }
+
     if (signal_buffer_len(plaintext_key) != AES128_GCM_KEY_LENGTH + AES128_GCM_TAG_LENGTH) {
         log_error("[OMEMO][RECV] invalid key length");
         signal_buffer_free(plaintext_key);
         *error = OMEMO_ERR_DECRYPT_FAILED;
-        return NULL;
-    }
-
-    if (payload == NULL) {
-        signal_buffer_free(plaintext_key);
-        *error = OMEMO_ERR_KEY_TRANSPORT;
         return NULL;
     }
 


### PR DESCRIPTION
For key transport messages, Monal at least doesn't append the
authentication tag to the plaintext key contents as that only makes
sense if the key was used to encrypt something. This causes the key
length check to fail and show the

	OMEMO message received but decryption failed.

error to the user which is confusing because there is no user-originated
message involved.

Skip the length check for key transport messages as profanity only uses
these to advance the ratchet and makes no use of the decrypted contents.

---

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature

### How to test the functionality
I have not tested this as I know of no straightforward way to do so but it makes sense to me based on what I was able to find out. I suppose it could be tested by triggering an incoming heartbeat message by sending enough outgoing messages but it should also become apparent if it works over time based on whether the error still appears (right now with 0.17.0 I am seeing on average one every one or two days).
