### PR TITLE
docs: XEP list does not need to be updated manually on a release

### DIFF
--- a/RELEASE_GUIDE.md
+++ b/RELEASE_GUIDE.md
@@ -54,4 +54,3 @@ https://github.com/profanity-im/profanity-im.github.io
 * Copy `guide/latest` to `guide/newversion`
 * Tarball location, name, checksum in index.html will be updated automatically during `make` / GH Action
 * Update profanity_version.txt
-* Take results from profanity.doap and put them into xeps.html


### PR DESCRIPTION
Updated tooling builds supported XEP list from profanity.doap file

Fixes: #2154
