### PR TITLE
build: Fix running functional tests by meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -750,7 +750,7 @@ if get_option('tests')
         build_by_default: false,
       )
 
-      test('functional tests', functionaltests, timeout: 1800)
+      test('functional tests', functionaltests, workdir: meson.project_source_root(), timeout: 1800)
     endif
   else
     warning('cmocka not found, tests will not be built')


### PR DESCRIPTION
In some environments `./build_run/functionaltests` was working
but `meson test -C build_run` failed for functional tests.
This commit should fix this by setting the working directory
to the meson project source.

<!--- Make sure to read CONTRIBUTING.md -->
<!--- It mentions the rules to follow and helpful tools -->

<!-- For completed items, change [ ] to [x]. -->
- [ ] I ran valgrind when using my new feature

### How to test the functionality
* `meson test -C build_run` should now work.
