### PR TITLE
Fix message receipts

### DIFF
--- a/src/event/client_events.c
+++ b/src/event/client_events.c
@@ -111,7 +111,12 @@ cl_ev_send_msg_correct(ProfChatWin* chatwin, const char* const msg, const char* 
     gboolean request_receipt = prefs_get_boolean(PREF_RECEIPTS_REQUEST);
     if (request_receipt) {
         auto_char char* jid = chat_session_get_jid(chatwin->barejid);
-        request_receipt = caps_jid_has_feature(jid, XMPP_FEATURE_RECEIPTS);
+        EntityCapabilities* caps = caps_lookup(jid);
+        if (caps != NULL) {
+            GSList* found = g_slist_find_custom(caps->features, XMPP_FEATURE_RECEIPTS, (GCompareFunc)g_strcmp0);
+            request_receipt = (found != NULL);
+            caps_destroy(caps);
+        }
     }
 
     auto_char char* plugin_msg = plugins_pre_chat_message_send(chatwin->barejid, msg);


### PR DESCRIPTION
When we wanted to adhere better to the XEPs we actually did a mistake.

In commit 421bb2e (so the mistake is there since 0.17.0), a check was added to only request receipts if
support was confirmed via entity capabilities. This was too restrictive as it defaulted to 'not supported' when capabilities were not yet cached (new sessions or bare JIDs).

Following XEP-0184 recommendations, we now only omit the receipt request if we have positive knowledge that the contact does not support it. If capabilities are unknown, we follow the users preference.

Ref: 421bb2e2616af0f20500536d9842174b0943d0b2
