### PR TITLE
fix(database): resolve migration failure and improve init safety

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -159,10 +159,12 @@ log_database_init(ProfAccount* account)
     }
 
     if (db_version == -1) {
-        query = "INSERT INTO `DbVersion` (`version`) VALUES ('2') ON CONFLICT(`version`) DO NOTHING";
+        query = sqlite3_mprintf("INSERT INTO `DbVersion` (`version`) VALUES (%d) ON CONFLICT(`version`) DO NOTHING", latest_version);
         if (SQLITE_OK != sqlite3_exec(g_chatlog_database, query, NULL, 0, &err_msg)) {
+            sqlite3_free(query);
             goto out;
         }
+        sqlite3_free(query);
         db_version = _get_db_version();
     }
 
@@ -195,6 +197,7 @@ out:
     } else {
         log_error("Unknown SQLite error in log_database_init().");
     }
+    log_database_close();
     return FALSE;
 }
 
@@ -598,7 +601,8 @@ _migrate_to_v2(void)
         "replace_id = COALESCE(NULLIF(replace_id, ''), NULL), "
         "type = COALESCE(NULLIF(type, ''), NULL), "
         "encryption = COALESCE(NULLIF(encryption, ''), NULL);",
-        "UPDATE `DbVersion` SET `version` = 2;",
+        "DELETE FROM `DbVersion`;",
+        "INSERT INTO `DbVersion` (`version`) VALUES (2);",
         "END TRANSACTION"
     };
 
@@ -692,7 +696,8 @@ _migrate_to_v3(void)
         "WHERE id = NEW.replaces_db_id; "
         "END;",
 
-        "UPDATE `DbVersion` SET `version` = 3;",
+        "DELETE FROM `DbVersion`;",
+        "INSERT INTO `DbVersion` (`version`) VALUES (3);",
         "END TRANSACTION"
     };
 

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -81,7 +81,9 @@ sv_ev_login_account_success(char* account_name, gboolean secured)
     omemo_on_connect(account);
 #endif
 
-    log_database_init(account);
+    if (!log_database_init(account)) {
+        log_error("Failed to initialize database for account: %s", account->jid);
+    }
     vcard_user_refresh();
     avatar_pep_subscribe();
 


### PR DESCRIPTION
Ensure the DbVersion table contains exactly one row during migrations by using DELETE and INSERT instead of UPDATE. This fixes issues where multiple version rows caused unique constraint failures and rolled back schema migrations.

Properly close the database on initialization failure to prevent subsequent operations on a broken state.

Initialize new databases with the latest schema version to avoid redundant migration attempts.

Fixes https://github.com/profanity-im/profanity/issues/2105