### PR TITLE
Stop OTR from leaking network availability

### DIFF
--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -96,6 +96,16 @@ static void
 cb_inject_message(void* opdata, const char* accountname,
                   const char* protocol, const char* recipient, const char* message)
 {
+    PContact contact = roster_get_contact(recipient);
+
+    if (contact == NULL) {
+        return;
+    }
+
+    if (p_contact_subscribed(contact) == FALSE) {
+        return;
+    }
+
     free(message_send_chat_otr(recipient, message, FALSE, NULL));
 }
 


### PR DESCRIPTION
In Profanity, OTR can be abused to leak the user's network availability, without a subscription request and with just their bare JID. This may have been exploited in the wild by malicious users and spammers.

This PR will stop `libotr` from injecting messages if the recipient doesn't have a subscription