### PR TITLE
fix(ui): guard terminal writes while suspended

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -348,7 +348,7 @@ sv_ev_room_message(ProfMessage* message)
         status_bar_active(num, WIN_MUC, mucwin->roomjid);
 
         if ((g_strcmp0(mynick, message->from_jid->resourcepart) != 0) && (prefs_get_boolean(PREF_BEEP))) {
-            beep();
+            ui_beep();
         }
 
         // not currently on groupchat window
@@ -356,7 +356,7 @@ sv_ev_room_message(ProfMessage* message)
         status_bar_new(num, WIN_MUC, mucwin->roomjid);
 
         if ((g_strcmp0(mynick, message->from_jid->resourcepart) != 0) && (prefs_get_boolean(PREF_FLASH))) {
-            flash();
+            ui_flash();
         }
 
         cons_show_incoming_room_message(message->from_jid->resourcepart, mucwin->roomjid, num, mention, triggers, mucwin->unread, window);

--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -326,7 +326,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
             cons_show_incoming_message(display_name, num, chatwin->unread, window);
 
             if (prefs_get_boolean(PREF_FLASH)) {
-                flash();
+                ui_flash();
             }
 
             chatwin->unread++;
@@ -363,7 +363,7 @@ chatwin_incoming_msg(ProfChatWin* chatwin, ProfMessage* message, gboolean win_cr
         wins_add_quotes_ac(window, message->plain, FALSE);
 
         if (prefs_get_boolean(PREF_BEEP)) {
-            beep();
+            ui_beep();
         }
     }
 

--- a/src/ui/core.c
+++ b/src/ui/core.c
@@ -180,6 +180,7 @@ void
 ui_suspend(void)
 {
     inp_suspend();
+    doupdate();
     endwin();
 }
 
@@ -188,6 +189,22 @@ ui_resume(void)
 {
     refresh();
     inp_resume();
+}
+
+void
+ui_beep(void)
+{
+    if (!isendwin()) {
+        beep();
+    }
+}
+
+void
+ui_flash(void)
+{
+    if (!isendwin()) {
+        flash();
+    }
 }
 
 void

--- a/src/ui/inputwin.c
+++ b/src/ui/inputwin.c
@@ -422,7 +422,9 @@ _inp_write(char* line, int offset)
     _inp_win_handle_scroll();
 
     _inp_win_update_virtual();
-    doupdate();
+    if (!isendwin()) {
+        doupdate();
+    }
 }
 
 static int

--- a/src/ui/privwin.c
+++ b/src/ui/privwin.c
@@ -57,7 +57,7 @@ privwin_incoming_msg(ProfPrivateWin* privatewin, ProfMessage* message)
         privatewin->unread++;
 
         if (prefs_get_boolean(PREF_FLASH)) {
-            flash();
+            ui_flash();
         }
     }
 
@@ -65,7 +65,7 @@ privwin_incoming_msg(ProfPrivateWin* privatewin, ProfMessage* message)
     wins_add_quotes_ac(window, message->plain, TRUE);
 
     if (prefs_get_boolean(PREF_BEEP)) {
-        beep();
+        ui_beep();
     }
 
     if (notify) {

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -83,6 +83,8 @@ void ui_handle_recipient_error(const char* const recipient, const char* const er
 void ui_handle_error(const char* const err_msg);
 void ui_clear_win_title(void);
 void ui_goodbye_title(void);
+void ui_beep(void);
+void ui_flash(void);
 void ui_handle_room_configuration_form_error(const char* const roomjid, const char* const message);
 void ui_handle_room_config_submit_result(const char* const roomjid);
 void ui_handle_room_config_submit_result_error(const char* const roomjid, const char* const message);

--- a/tests/unittests/ui/stub_ui.c
+++ b/tests/unittests/ui/stub_ui.c
@@ -1465,3 +1465,13 @@ ui_is_suspended(void)
 {
     return FALSE;
 }
+
+void
+ui_beep(void)
+{
+}
+
+void
+ui_flash(void)
+{
+}


### PR DESCRIPTION
We forgot to guard `beep()` and `flush()`.

Ref: 36ec2b0ae1fa7afcdfe6f166323955b8bd121b0f
Ref: dd76f9087fe93db5ced608ee3c744f299b933cbe

Fixes: https://github.com/profanity-im/profanity/issues/2162
