### PR TITLE
fix(otr): prevent OTR handshake from leaking presence to strangers

### DIFF
--- a/src/otr/otr.c
+++ b/src/otr/otr.c
@@ -68,28 +68,18 @@ static int
 cb_is_logged_in(void* opdata, const char* accountname, const char* protocol, const char* recipient)
 {
     jabber_conn_status_t conn_status = connection_get_status();
-    if (conn_status != JABBER_CONNECTED) {
-        return PRESENCE_OFFLINE;
+    if (conn_status == JABBER_CONNECTED) {
+        PContact contact = roster_get_contact(recipient);
+        if (contact) {
+            if (p_contact_subscribed(contact) == TRUE) {
+                if (g_strcmp0(p_contact_presence(contact), "offline") != 0) {
+                    return PRESENCE_ONLINE;
+                }
+            }
+        }
     }
 
-    PContact contact = roster_get_contact(recipient);
-
-    // not in roster
-    if (contact == NULL) {
-        return PRESENCE_ONLINE;
-    }
-
-    // not subscribed
-    if (p_contact_subscribed(contact) == FALSE) {
-        return PRESENCE_ONLINE;
-    }
-
-    // subscribed
-    if (g_strcmp0(p_contact_presence(contact), "offline") == 0) {
-        return PRESENCE_OFFLINE;
-    } else {
-        return PRESENCE_ONLINE;
-    }
+    return PRESENCE_OFFLINE;
 }
 
 static void


### PR DESCRIPTION
`cb_is_logged_in()` incorrectly returned `PRESENCE_ONLINE` for contacts not in the roster or without a presence subscription.

According to libotr API documentation, returning 1 informs the library that it is safe to send automated background traffic (heartbeats or handshake responses).

Because of this, when spammers sent an initial OTR query (`?OTR?v23?`), we would automatically inject a handshake response, confirming the users network availability.

This violates XMPP Presence Privacy best practices defined in RFC 6121 Section 4.1, which states that presence information must not be revealed to entities without explicit authorization.

Fixes: https://github.com/profanity-im/profanity/pull/2166
