### PR TITLE
fix(omemo): silence 'no key' error for key transport messages

### DIFF
--- a/src/omemo/omemo.c
+++ b/src/omemo/omemo.c
@@ -1037,7 +1037,11 @@ omemo_on_message_recv(const char* const from_jid, uint32_t sid,
 
     if (!key) {
         log_warning("[OMEMO][RECV] received a message with no corresponding key");
-        *error = OMEMO_ERR_NO_KEY;
+        if (payload == NULL) {
+            *error = OMEMO_ERR_KEY_TRANSPORT;
+        } else {
+            *error = OMEMO_ERR_NO_KEY;
+        }
         return NULL;
     }
 


### PR DESCRIPTION
Key transport messages (OMEMO messages without a payload) are used for background synchronization and may not include a key for every device a user owns.

This change ensures that OMEMO_ERR_KEY_TRANSPORT (which is silenced by the UI) is returned if no key is found and there is no payload, identifying the message as a background sync not intended for this specific device.

Ref: a824b26008a6bbdb4f974e03e87161702abb9f05
Ref: 1458b09e27e581456b30434a68e1070a4c017eb0