### PR TITLE
build(meson): add configurable docdir option for documentation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -582,10 +582,15 @@ if man_pages.length() > 0 and man_pages[0] != ''
 endif
 
 # Install example config and theme template
+doc_dir = get_option('docdir')
+if doc_dir == ''
+  doc_dir = get_option('datadir') / 'doc' / meson.project_name()
+endif
+
 install_data(
   'profrc.example',
   'theme_template',
-  install_dir: get_option('datadir') / 'doc' / meson.project_name(),
+  install_dir: doc_dir,
 )
 
 # Tests

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -96,3 +96,9 @@ option('themes_path',
   value: '',
   description: 'Custom path for themes installation (empty for default)'
 )
+
+option('docdir',
+  type: 'string',
+  value: '',
+  description: 'Custom path for documentation installation (empty for default)'
+)


### PR DESCRIPTION
Introduce a custom 'docdir' string option to allow packagers to override the default documentation installation directory.

Fix: https://github.com/profanity-im/profanity/issues/2173