### PR TITLE
fix: query bare JID for PEP features during discovery

### DIFF
--- a/src/xmpp/connection.c
+++ b/src/xmpp/connection.c
@@ -660,6 +660,13 @@ connection_request_features(void)
     /* We don't record it as a requested feature to avoid triggering th
      * sv_ev_connection_features_received too soon */
     iq_disco_info_request_onconnect(conn.domain);
+
+    const char* barejid = connection_get_barejid();
+    if (barejid && !g_hash_table_contains(conn.features_by_jid, barejid)) {
+        g_hash_table_insert(conn.features_by_jid, strdup(barejid),
+                            g_hash_table_new_full(g_str_hash, g_str_equal, free, NULL));
+        iq_disco_info_request_onconnect(barejid);
+    }
 }
 
 void


### PR DESCRIPTION
XEP-0163 (Personal Eventing Protocol) states that service discovery information queries regarding PEP capabilities must be sent to the users bare JID in order to determine support.

Profanity only queried the server domain JID and its generic disco#items on connect, but never queried the users own bare JID.

Because ejabberd advertises PEP and PubSub features on both the server JID and the bare JID this bug was kind of invisible. However, Prosody strictly advertises PEP capabilities only on the users bare JID.

This discovery failure became a hard blocker for OMEMO on Prosody servers following commit 01c781fcf ("Don't publish keys if the server doesn't support pubsub."), which turned the check for publish-options into an early-return condition.

We now query our own bare JID during feature discovery on connect and insert it into conn.features_by_jid.

See-also: https://xmpp.org/extensions/xep-0163.html
Ref: 01c781fcf690e8473501e3804e057571abb166a8