### PR TITLE
fix(ox): filter keys listed by `/ox keys` to those matching xmpp prefix

### DIFF
--- a/src/command/cmd_funcs.c
+++ b/src/command/cmd_funcs.c
@@ -7508,7 +7508,7 @@ cmd_ox(ProfWin* window, const char* const command, gchar** args)
     // Should we move this to a common command
     // e.g. '/openpgp keys'?.
     else if (g_strcmp0(args[0], "keys") == 0) {
-        GHashTable* keys = p_gpg_list_keys();
+        GHashTable* keys = ox_gpg_list_keys();
         if (!keys || g_hash_table_size(keys) == 0) {
             cons_show("No keys found");
             return TRUE;

--- a/src/pgp/ox.c
+++ b/src/pgp/ox.c
@@ -28,18 +28,10 @@
 
 static gpgme_key_t _ox_key_lookup(const char* const barejid, gboolean secret_only);
 static gboolean _ox_key_is_usable(gpgme_key_t key, const char* const barejid, gboolean secret);
+static GHashTable* _ox_gpg_get_keys(gboolean check_secret);
 
-/*!
- * \brief Public keys with XMPP-URI.
- *
- * This function will look for all public key with a XMPP-URI as UID.
- *
- * @returns GHashTable* with GString* xmpp-uri and ProfPGPKey* value. Empty
- * hash, if there is no key. NULL in case of error.
- *
- */
-GHashTable*
-ox_gpg_public_keys(void)
+static GHashTable*
+_ox_gpg_get_keys(gboolean check_secret)
 {
     gpgme_error_t error;
     GHashTable* result = g_hash_table_new_full(g_str_hash, g_str_equal, free, (GDestroyNotify)p_gpg_free_key);
@@ -112,9 +104,73 @@ ox_gpg_public_keys(void)
             error = gpgme_op_keylist_next(ctx, &key);
         }
     }
+
+    if (check_secret) {
+        // Pass 2: Check if any of these public keys also has a corresponding secret key
+        error = gpgme_op_keylist_start(ctx, NULL, 1); // 1 = secret/private keys
+        if (error == GPG_ERR_NO_ERROR) {
+            gpgme_key_t key;
+            error = gpgme_op_keylist_next(ctx, &key);
+            while (!error) {
+                gpgme_subkey_t sub = key->subkeys;
+                while (sub) {
+                    if (sub->secret) {
+                        // Match by fingerprint
+                        GList* values = g_hash_table_get_values(result);
+                        GList* curr = values;
+                        while (curr) {
+                            ProfPGPKey* pkey = curr->data;
+                            if (g_strcmp0(pkey->fp, sub->fpr) == 0) {
+                                pkey->secret = TRUE;
+                                break;
+                            }
+                            curr = curr->next;
+                        }
+                        g_list_free(values);
+                    }
+                    sub = sub->next;
+                }
+
+                gpgme_key_unref(key);
+                error = gpgme_op_keylist_next(ctx, &key);
+            }
+        }
+    }
+
     gpgme_release(ctx);
 
     return result;
+}
+
+/*!
+ * \brief Public keys with XMPP-URI.
+ *
+ * This function will look for all public key with a XMPP-URI as UID.
+ *
+ * @returns GHashTable* with GString* xmpp-uri and ProfPGPKey* value. Empty
+ * hash, if there is no key. NULL in case of error.
+ *
+ */
+GHashTable*
+ox_gpg_public_keys(void)
+{
+    return _ox_gpg_get_keys(FALSE);
+}
+
+/*!
+ * \brief List all keys with XMPP-URI and check their secret status.
+ *
+ * This function will look for all keys with a XMPP-URI as UID and determine if
+ * they have private counterparts.
+ *
+ * @returns GHashTable* with GString* xmpp-uri and ProfPGPKey* value. Empty
+ * hash, if there is no key. NULL in case of error.
+ *
+ */
+GHashTable*
+ox_gpg_list_keys(void)
+{
+    return _ox_gpg_get_keys(TRUE);
 }
 
 char*

--- a/src/pgp/ox.h
+++ b/src/pgp/ox.h
@@ -19,6 +19,7 @@ void p_ox_gpg_readkey(const char* const filename, char** key, char** fp);
 gboolean p_ox_gpg_import(char* base64_public_key);
 
 GHashTable* ox_gpg_public_keys(void);
+GHashTable* ox_gpg_list_keys(void);
 
 gboolean ox_is_private_key_available(const char* const barejid);
 gboolean ox_is_public_key_available(const char* const barejid);

--- a/tests/unittests/pgp/stub_ox.c
+++ b/tests/unittests/pgp/stub_ox.c
@@ -19,3 +19,9 @@ ox_gpg_public_keys(void)
 {
     return NULL;
 }
+
+GHashTable*
+ox_gpg_list_keys(void)
+{
+    return NULL;
+}


### PR DESCRIPTION
The `/ox keys` command previously listed all PGP keys known to the system, displaying a massive number of keys of which the vast majority cannot be used for OX.

According to XEP-0373: OpenPGP for XMPP, the User ID of the key must correspond to the JID of the user as an 'xmpp' URI ("xmpp:juliet@example.org"). General PGP keys in the user's keyring that lack this prefix are invalid for OX.

* Introduce internal helper `_ox_gpg_get_keys()` to retrieve keys containing an 'xmpp:' UID prefix.
* Create new `ox_gpg_list_keys()` that runs a second-pass query specifically looking for corresponding private keys in the secret keyring.
* Update `/ox keys` to call `ox_gpg_list_keys()` instead of the generic `p_gpg_list_keys()`.

Fixes: https://github.com/profanity-im/profanity/issues/2177
