### PR TITLE
fix: Fix repeated message corrections in MUCs

### DIFF
--- a/src/ui/chatwin.c
+++ b/src/ui/chatwin.c
@@ -402,9 +402,10 @@ chatwin_outgoing_msg(ProfChatWin* chatwin, const char* const message, const char
 
     plugins_post_chat_message_display(myjid->barejid, myjid->resourcepart, display_message);
 
-    // save last id and message for LMC in case if it's not LMC message
-    if (id && !replace_id) {
-        _chatwin_set_last_message(chatwin, id, display_message);
+    // save last id and message for LMC
+    if (id) {
+        const char* const save_id = replace_id ? replace_id : id;
+        _chatwin_set_last_message(chatwin, save_id, display_message);
     }
 }
 
@@ -609,9 +610,13 @@ chatwin_db_history(ProfChatWin* chatwin, const char* start_time, const char* end
 static void
 _chatwin_set_last_message(ProfChatWin* chatwin, const char* const id, const char* const message)
 {
-    free(chatwin->last_message);
-    chatwin->last_message = strdup(message);
+    if (chatwin->last_message != message) {
+        free(chatwin->last_message);
+        chatwin->last_message = strdup(message);
+    }
 
-    free(chatwin->last_msg_id);
-    chatwin->last_msg_id = strdup(id);
+    if (chatwin->last_msg_id != id) {
+        free(chatwin->last_msg_id);
+        chatwin->last_msg_id = strdup(id);
+    }
 }

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -493,8 +493,8 @@ mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* c
 
     win_print_outgoing_muc_msg(window, ch, mynick, id, replace_id, message);
 
-    // save last id and message for LMC
-    if (id) {
+    // save last id and message for LMC in case if it's not LMC message
+    if (id && !replace_id) {
         _mucwin_set_last_message(mucwin, id, message);
     }
 

--- a/src/ui/mucwin.c
+++ b/src/ui/mucwin.c
@@ -493,9 +493,10 @@ mucwin_outgoing_msg(ProfMucWin* mucwin, const char* const message, const char* c
 
     win_print_outgoing_muc_msg(window, ch, mynick, id, replace_id, message);
 
-    // save last id and message for LMC in case if it's not LMC message
-    if (id && !replace_id) {
-        _mucwin_set_last_message(mucwin, id, message);
+    // save last id and message for LMC
+    if (id) {
+        const char* const save_id = replace_id ? replace_id : id;
+        _mucwin_set_last_message(mucwin, save_id, message);
     }
 
     wins_add_quotes_ac(window, message, FALSE);
@@ -932,11 +933,15 @@ mucwin_unset_message_char(ProfMucWin* mucwin)
 static void
 _mucwin_set_last_message(ProfMucWin* mucwin, const char* const id, const char* const message)
 {
-    free(mucwin->last_message);
-    mucwin->last_message = strdup(message);
+    if (mucwin->last_message != message) {
+        free(mucwin->last_message);
+        mucwin->last_message = strdup(message);
+    }
 
-    free(mucwin->last_msg_id);
-    mucwin->last_msg_id = strdup(id);
+    if (mucwin->last_msg_id != id) {
+        free(mucwin->last_msg_id);
+        mucwin->last_msg_id = strdup(id);
+    }
 }
 
 gchar*


### PR DESCRIPTION
Avoid overwriting the stored last message ID in MUCs when an outgoing message is a correction.

In 1:1 chats, we prevent overwriting the stored last_msg_id when sending a correction.
In MUCs, last_msg_id was unconditionally overwritten with the ID of the correction message itself.

XEP-0308:
"If a message is corrected multiple times, every subsequent correction must reference the ID of the original message, not the ID of the previous correction."