### PR TITLE
More mam fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -56,3 +56,6 @@ assignees: ''
 * libstrophe version
 * omemo backend
 * Some bugs might be due to specific implementation in the server. `/serversoftware example.domain` can be helpful
+
+## Reporter (optional)
+<!--- If this issue is being submitted on behalf of someone else (from the MUC), please mention their nickname or JID here if they wish to share it. -->

--- a/README.md
+++ b/README.md
@@ -33,8 +33,14 @@ For more technical details check out our [CONTRIBUTING.md](CONTRIBUTING.md) file
 
 ## Getting help
 To get help, first read our [User Guide](https://profanity-im.github.io/userguide.html) then check out the [FAQ](https://profanity-im.github.io/faq.html).
-If you have are having a problem then first search the [issue tracker](https://github.com/profanity-im/profanity/issues).
-If you don't find anything there either come to our [MUC](xmpp:profanity@rooms.dismail.de?join) or create a new issue depending on what your problem is.
+If you are having a problem, first search the [issue tracker](https://github.com/profanity-im/profanity/issues).
+
+If you don't find any existing issue, you can report it:
+- **With a GitHub account:** Create a new issue directly on our [issue tracker](https://github.com/profanity-im/profanity/issues). This is what you **should** do. If you don't have an account, create one! It makes our life much easier.
+- **Without a GitHub account:**
+  1. Copy our [Bug Report Template](.github/ISSUE_TEMPLATE/bug_report.md) (ignoring the header block between `---`), and fill it out.
+  2. Include your preferred name, MUC nickname, or JID in the **Reporter** field.
+  3. Send the filled out template to our mailing list at `profanity@lists.posteo.de`, or join our MUC and ask someone to submit it on your behalf.
 
 ## Links
 

--- a/src/ui/window.c
+++ b/src/ui/window.c
@@ -748,14 +748,22 @@ win_page_down(ProfWin* window, int scroll_size)
     *page_start += scroll_size;
 
     // Scrolled down after reaching the bottom of the page
-    if ((*page_start > total_rows - page_space || (*page_start == page_space && *page_start >= total_rows)) && window->type == WIN_CHAT) {
+    if ((*page_start > total_rows - page_space || (*page_start == page_space && *page_start >= total_rows)) && (window->type == WIN_CHAT || window->type == WIN_MUC)) {
         unsigned int bf_size = buffer_size(window->layout->buffer);
         if (bf_size != 0) {
             ProfBuffEntry* last_entry = buffer_get_entry(window->layout->buffer, bf_size - 1);
             auto_gchar gchar* start = g_date_time_format_iso8601(last_entry->time);
             auto_gchar gchar* end_date = prof_date_time_format_iso8601(NULL);
-            if (*scroll_state != WIN_SCROLL_REACHED_BOTTOM && !chatwin_db_history((ProfChatWin*)window, start, end_date, FALSE)) {
-                *scroll_state = WIN_SCROLL_REACHED_BOTTOM;
+            if (*scroll_state != WIN_SCROLL_REACHED_BOTTOM) {
+                gboolean has_items;
+                if (window->type == WIN_MUC) {
+                    has_items = mucwin_db_history((ProfMucWin*)window, start, end_date, FALSE);
+                } else {
+                    has_items = chatwin_db_history((ProfChatWin*)window, start, end_date, FALSE);
+                }
+                if (!has_items) {
+                    *scroll_state = WIN_SCROLL_REACHED_BOTTOM;
+                }
             }
 
             int offset = last_entry->y_end_pos - 1;

--- a/src/xmpp/iq.c
+++ b/src/xmpp/iq.c
@@ -3070,10 +3070,10 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
             if (set) {
                 win_print_loading_history(window);
 
-                auto_char char* firstid = NULL;
-                xmpp_stanza_t* first = xmpp_stanza_get_child_by_name(set, STANZA_NAME_FIRST);
-                if (first) {
-                    firstid = xmpp_stanza_get_text(first);
+                auto_char char* lastid = NULL;
+                xmpp_stanza_t* last = xmpp_stanza_get_child_by_name(set, STANZA_NAME_LAST);
+                if (last) {
+                    lastid = xmpp_stanza_get_text(last);
 
                     // 4.3.2. send same stanza with set,max stanza
                     xmpp_ctx_t* const ctx = connection_get_ctx();
@@ -3084,9 +3084,9 @@ _mam_rsm_id_handler(xmpp_stanza_t* const stanza, void* const userdata)
                     }
                     xmpp_stanza_t* iq;
                     if (window->type == WIN_MUC) {
-                        iq = stanza_create_muc_mam_iq(ctx, data->barejid, data->start_datestr, NULL, firstid, NULL);
+                        iq = stanza_create_muc_mam_iq(ctx, data->barejid, data->start_datestr, NULL, NULL, lastid);
                     } else {
-                        iq = stanza_create_mam_iq(ctx, data->barejid, data->start_datestr, NULL, firstid, NULL);
+                        iq = stanza_create_mam_iq(ctx, data->barejid, data->start_datestr, NULL, NULL, lastid);
                     }
 
                     MamRsmUserdata* ndata = g_new0(MamRsmUserdata, 1);

--- a/src/xmpp/message.c
+++ b/src/xmpp/message.c
@@ -76,6 +76,10 @@ gchar*
 get_display_name(const ProfMessage* const message, int* flags)
 {
     if (message->type == PROF_MSG_TYPE_MUC) {
+        if (equals_our_barejid(message->from_jid->barejid)) {
+            return prefs_get_string(PREF_OUTGOING_STAMP);
+        }
+
         const char* const mynick = muc_nick(message->from_jid->barejid);
         gboolean is_me = (g_strcmp0(mynick, message->from_jid->resourcepart) == 0);
         if (is_me) {


### PR DESCRIPTION
`maniac` mentioned `when I scroll like, 2 months _backwards in time_ in the chat history, I can only scroll _forwards in time_ a month.
So we found a bug in rsm pagination.
Also add a note how to report bugs if you don't have an GH account.
And last but not least a fix for the wrong display name.