### PR TITLE
fix(presence): align autoaway state on reconnect

### DIFF
--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -32,6 +32,7 @@
 #include "ui/window.h"
 #include "tools/bookmark_ignore.h"
 #include "xmpp/xmpp.h"
+#include "xmpp/session.h"
 #include "xmpp/iq.h"
 #include "xmpp/muc.h"
 #include "xmpp/chat_session.h"
@@ -152,6 +153,7 @@ sv_ev_roster_received(void)
 
     // send initial presence
     resource_presence_t conn_presence = accounts_get_login_presence(account_name);
+    session_set_activity_state_for_presence(conn_presence);
     auto_gchar gchar* last_activity_str = accounts_get_last_activity(account_name);
     auto_gchar gchar* status_message = accounts_get_login_status(account_name);
     int diff_secs = 0;

--- a/src/xmpp/session.c
+++ b/src/xmpp/session.c
@@ -422,6 +422,18 @@ session_init_activity(void)
 }
 
 void
+session_set_activity_state_for_presence(resource_presence_t presence)
+{
+    if (presence == RESOURCE_AWAY) {
+        activity_state = ACTIVITY_ST_AWAY;
+    } else if (presence == RESOURCE_XA) {
+        activity_state = ACTIVITY_ST_XA;
+    } else {
+        activity_state = ACTIVITY_ST_ACTIVE;
+    }
+}
+
+void
 session_check_autoaway(void)
 {
     jabber_conn_status_t conn_status = connection_get_status();

--- a/src/xmpp/session.h
+++ b/src/xmpp/session.h
@@ -12,6 +12,8 @@
 
 #include <glib.h>
 
+#include "common.h"
+
 void session_login_success(gboolean secured);
 void session_login_failed(void);
 void session_lost_connection(void);
@@ -19,6 +21,7 @@ void session_autoping_fail(void);
 
 void session_init_activity(void);
 void session_check_autoaway(void);
+void session_set_activity_state_for_presence(resource_presence_t presence);
 
 void session_reconnect(gchar* altdomain, unsigned short altport);
 

--- a/tests/unittests/xmpp/stub_xmpp.c
+++ b/tests/unittests/xmpp/stub_xmpp.c
@@ -23,6 +23,10 @@ void
 session_check_autoaway(void)
 {
 }
+void
+session_set_activity_state_for_presence(resource_presence_t presence)
+{
+}
 
 jabber_conn_status_t
 session_connect_with_details(const char* const jid,


### PR DESCRIPTION
Align the internal autoaway activity state with the actual initial login presence sent on successful reconnection.

When reconnection succeeds we establish the initial presence (Online or Last status), but the internal `activity_state` remained in `ACTIVITY_ST_AWAY` or `ACTIVITY_ST_XA` because the state was never updated upon disconnect or reconnect.

This led to two issues:
1. If the user reconnected as Online while remaining idle, the state was stuck in `ACTIVITY_ST_AWAY` and the client never went away again.
2. If the user returned and pressed a key, the client could not trigger a transition back to Online since it already thought they were active, causing the clients presence to get stuck in Away.

Fixes: https://github.com/profanity-im/profanity/issues/2073