### PR TITLE
fix(mam): do not discard self sent messages received via MAM if sent …

### DIFF
--- a/src/database.c
+++ b/src/database.c
@@ -926,7 +926,7 @@ log_database_update_archive_id(const prof_msg_type_t type, const char* const roo
     if (query) {
         if (SQLITE_OK == sqlite3_prepare_v2(g_chatlog_database, query, -1, &stmt, NULL)) {
             if (sqlite3_step(stmt) == SQLITE_DONE) {
-                success = TRUE;
+                success = (sqlite3_changes(g_chatlog_database) > 0);
             }
             sqlite3_finalize(stmt);
         }

--- a/src/event/server_events.c
+++ b/src/event/server_events.c
@@ -660,11 +660,14 @@ sv_ev_incoming_message(ProfMessage* message)
     gboolean is_self_reflection = (message->is_mam && equals_our_barejid(message->from_jid->barejid));
 
     if (is_self_reflection) {
+        gboolean updated = FALSE;
         if (message->id && message->stanzaid && message->to_jid) {
-            log_database_update_archive_id(PROF_MSG_TYPE_CHAT, message->to_jid->barejid, message->id, message->stanzaid);
+            updated = log_database_update_archive_id(PROF_MSG_TYPE_CHAT, message->to_jid->barejid, message->id, message->stanzaid);
         }
-        rosterwin_roster();
-        return;
+        if (updated) {
+            rosterwin_roster();
+            return;
+        }
     }
 
     gboolean new_win = FALSE;


### PR DESCRIPTION
…offline

Profanity is offline and the user is sending messages from another client,

When Profanity comes online and requests MAM history, these self sent messages are received.
Before sv_ev_incoming_message classified all MAM messages from our own bare JID as a self reflection, attempted to update their archive ID in the database, and then immediately discarded them by returning early. Since the database update failed because the message was sent while offline, the message was permanently lost and never logged or displayed.